### PR TITLE
refactor(observability): implement unified structured logging strategy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,9 @@
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   postgres:
     build:
@@ -9,6 +15,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
 
@@ -20,6 +27,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
     restart: unless-stopped
+    logging: *default-logging
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: ${GF_USERS_ALLOW_SIGN_UP}
@@ -34,6 +42,7 @@ services:
       - loki_data:/loki
     command: -config.file=/etc/loki/local-config.yaml
     restart: unless-stopped
+    logging: *default-logging
 
   promtail:
     image: grafana/promtail:latest
@@ -47,6 +56,7 @@ services:
     depends_on:
       - loki
     restart: unless-stopped
+    logging: *default-logging
 
 volumes:
   postgres_data:

--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -13,6 +13,18 @@ scrape_configs:
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
         refresh_interval: 5s
+    
+    # Pipeline stages parse the content of the log line
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            service: service
+            msg: msg
+      - labels:
+          level:
+          service:
+
     relabel_configs:
       # 1. Clean container name: remove leading slash
       - source_labels: ['__meta_docker_container_name']

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -4,18 +4,24 @@ RUN apk --no-cache add ca-certificates
 
 WORKDIR /app
 
-# Copy the root .env file to the current directory (which is /app)
+# Copy the shared package first
+COPY pkg/ ./pkg/
+
+# Copy the proxy service
+COPY proxy/ ./proxy/
+
+# Copy the root .env if needed (though usually handled by docker-compose)
 COPY .env .
 
-# Copy go.mod and go.sum from the proxy directory
-COPY proxy/go.mod proxy/go.sum ./
+WORKDIR /app/proxy
+
+# Download dependencies (now it can find ../pkg/logger)
 RUN go mod download
 
-# Copy the rest of the proxy source code
-COPY proxy/ .
+# Build the binary
+RUN go build -o /app/proxy_server .
 
-RUN go build -o proxy_server .
-
+WORKDIR /app
 EXPOSE 8085
 
 CMD ["./proxy_server"]

--- a/pkg/logger/go.mod
+++ b/pkg/logger/go.mod
@@ -1,0 +1,3 @@
+module logger
+
+go 1.25.2

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,22 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Setup initializes the global slog logger to output JSON to stdout.
+// It adds a permanent "service" field to all log entries.
+func Setup(serviceName string) {
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}
+
+	handler := slog.NewJSONHandler(os.Stdout, opts).
+		WithAttrs([]slog.Attr{
+			slog.String("service", serviceName),
+		})
+
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+}

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -7,7 +7,10 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 	go.mongodb.org/mongo-driver v1.17.6
+	logger v0.0.0
 )
+
+replace logger => ../pkg/logger
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -1,17 +1,22 @@
 package main
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 
 	"proxy/utils"
+
+	"logger"
 
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 )
 
 func main() {
+	// Initialize structured logging first
+	logger.Setup("proxy")
+
 	godotenv.Load(".env")
 	godotenv.Load("../.env")
 
@@ -35,6 +40,9 @@ func main() {
 	http.HandleFunc("/api/reading", utils.WithLogging(readingService.ReadingHandler))
 	http.HandleFunc("/api/sync/reading", utils.WithLogging(readingService.SyncReadingHandler))
 
-	log.Printf("🚀 The GO proxy listening on :%s", port)
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	slog.Info("🚀 The GO proxy listening on port", "port", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		slog.Error("Server failed to start", "error", err)
+		os.Exit(1)
+	}
 }

--- a/proxy/utils/logging.go
+++ b/proxy/utils/logging.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 )
@@ -12,6 +12,12 @@ func WithLogging(next http.HandlerFunc) http.HandlerFunc {
 		start := time.Now()
 		// We could wrap ResponseWriter to capture status code, but for now we keep it simple
 		next(w, r)
-		log.Printf("METHOD=%s PATH=%s REMOTE=%s DURATION=%v", r.Method, r.URL.Path, r.RemoteAddr, time.Since(start))
+
+		slog.Info("request_processed",
+			"http_method", r.Method,
+			"path", r.URL.Path,
+			"remote_ip", r.RemoteAddr,
+			"duration", time.Since(start).String(),
+		)
 	}
 }

--- a/proxy/utils/logging_test.go
+++ b/proxy/utils/logging_test.go
@@ -59,16 +59,16 @@ func TestWithLogging(t *testing.T) {
 
 			// Verify log output
 			logOutput := buf.String()
-			if !strings.Contains(logOutput, "METHOD="+tt.method) {
+			if !strings.Contains(logOutput, "http_method="+tt.method) {
 				t.Errorf("log missing method: expected %s, got %s", tt.method, logOutput)
 			}
-			if !strings.Contains(logOutput, "PATH="+tt.path) {
+			if !strings.Contains(logOutput, "path="+tt.path) {
 				t.Errorf("log missing path: expected %s, got %s", tt.path, logOutput)
 			}
-			if !strings.Contains(logOutput, "REMOTE="+tt.remoteAddr) {
+			if !strings.Contains(logOutput, "remote_ip="+tt.remoteAddr) {
 				t.Errorf("log missing remote addr: expected %s, got %s", tt.remoteAddr, logOutput)
 			}
-			if !strings.Contains(logOutput, "DURATION=") {
+			if !strings.Contains(logOutput, "duration=") {
 				t.Errorf("log missing duration: %s", logOutput)
 			}
 		})

--- a/system-metrics/go.mod
+++ b/system-metrics/go.mod
@@ -6,7 +6,10 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/joho/godotenv v1.5.1
 	github.com/shirou/gopsutil/v4 v4.25.11
+	logger v0.0.0
 )
+
+replace logger => ../pkg/logger
 
 require (
 	github.com/ebitengine/purego v0.9.1 // indirect


### PR DESCRIPTION
### Summary

This PR migrates the observability stack from unstructured text logs to a centralized, structured JSON logging architecture. By adopting `log/slog` and a shared internal library, we enable sub-millisecond filtering and powerful aggregation in Grafana/Loki. This change also introduces operational guardrails through Docker log rotation and updates the build pipeline to support shared internal modules.

### List of Changes

#### 1. Core Platform (pkg/logger)

- Created a shared `pkg/logger` Go module to standardize `slog` initialization.
- Enforced a common schema including `time`, `level`, `msg`, and `service` fields.

#### 2. Proxy Service

- Integrated `logger` shared package and replaced `log` with `slog`.
- Refactored HTTP middleware to emit `request_processed` events with structured metadata.
- Updated database connection logic to emit `db_connection_failed` and `db_connected` events.
- **Fix:** Updated `go.mod` to correctly `require` the local `logger` module.

#### 3. System Metrics Service

- Integrated `logger` shared package.
- Refactored collection loop to emit `metrics_collected` (INFO) and `db_insert_failed` (ERROR) events.
- Modernized startup error handling to ensure crashes are logged as structured data.

#### 4. Infrastructure (Docker & Promtail)

- **Build Fix:** Updated `docker/proxy/Dockerfile` to copy the `pkg/` directory into the build context, resolving module dependency errors.
- **Promtail:** Configured `pipeline_stages` in `promtail-config.yaml` to parse incoming JSON logs and promote `service` and `level` fields to Loki labels.
- **Guardrails:** Implemented YAML anchors (`x-logging`) in `docker-compose.yml` to define a global log rotation policy (10MB max, 3 files).

### Verification

- [x] Local build verification of `proxy` and `system-metrics`.
- [x] Validated JSON log output format manually via `curl` and `jq`.
- [x] Verified Promtail correctly extracts `service` label from JSON logs.
- [x] Verified `docker-compose.yml` syntax.