### PR TITLE
docs: standardize architectural decision process and overhaul readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 help:
 	@echo "Available commands:"
+	@echo "  make rfc               - Create a new RFC (Architecture Decision Record)"
 	@echo "  make create            - Create necessary docker volumes"
 	@echo "  make backup            - Backup docker volumes"
 	@echo "  make restore           - Restore docker volumes from backup"
@@ -11,9 +12,10 @@ help:
 	@echo "  make proxy-up          - Start the go proxy server"
 	@echo "  make proxy-down        - Stop the go proxy server"
 	@echo "  make proxy-update      - Rebuild and restart the go proxy server"
-	@echo "  make promtail-up       - Start the promtail log collector"
-	@echo "  make promtail-down     - Stop the promtail log collector"
-	@echo "  make promtail-update   - Restart the promtail log collector"
+
+# Architecture Decision Record Creation
+rfc:
+	@./scripts/create_rfc.sh
 
 # Docker Volume Management
 create:
@@ -71,24 +73,3 @@ proxy-down:
 
 proxy-update: proxy-down proxy-up
 	@echo "Proxy server updated."
-
-# Promtail Management
-promtail-up:
-	@echo "Starting promtail..."
-	@docker run -d \
-		--name promtail_server \
-		--restart unless-stopped \
-		--network host \
-		-v $(PWD)/docker/promtail/promtail-config.yaml:/etc/promtail/config.yaml \
-		-v /var/lib/docker/containers:/var/lib/docker/containers:ro \
-		-v /var/run/docker.sock:/var/run/docker.sock:ro \
-		grafana/promtail:latest \
-		-config.file=/etc/promtail/config.yaml
-
-promtail-down:
-	@echo "Stopping promtail..."
-	@docker stop promtail_server || true
-	@docker rm promtail_server || true
-
-promtail-update: promtail-down promtail-up
-	@echo "Promtail updated."

--- a/README.md
+++ b/README.md
@@ -4,6 +4,47 @@ A personal telemetry system that collects **system metrics** and **application e
 
 ---
 
+## 🌐 Live Site
+
+[Explore Live Telemetry & System Evolution](https://victoriacheng15.github.io/observability-hub/)
+
+---
+
+## 🎨 Design Philosophy
+
+- **Continuous Contextual Telemetry:** Built to understand system behavior over time through continuous telemetry rather than one-off checks.
+- **Systemic Health Monitoring:** Tracks host health, debugs pipeline failures, and connects infrastructure metrics to application events.
+- **Data Ownership:** Prioritizes 100% self-hosted infrastructure and long-term data retention without cloud dependencies.
+- **Simplicity & Reliability:** Employs scheduled, stateless, and idempotent Go services over complex, heavy-weight agents.
+- **Scale-Ready Storage:** Leverages TimescaleDB (PostgreSQL) for efficient time-series analysis and historical tracking.
+
+---
+
+## 📚 Architectural Approach & Documentation
+
+| Component | Approach |
+| :--- | :--- |
+| **Collectors** | Custom Go services—cron-driven, stateless, and idempotent. |
+| **Storage** | **TimescaleDB** with JSONB for unified metric/event storage. |
+| **Visualization** | **Grafana** dashboards separated by concern (infra vs. app). |
+| **Observability** | **Loki** (logs) and a **Go proxy** (ETL) for full telemetry coverage. |
+
+For deep dives into the system's inner workings:
+
+- **[Architecture](./docs/architecture/README.md)**: System context, component diagrams, and data flows.
+- **[Decisions](./docs/decisions/README.md)**: Architectural Decision Records (ADRs) explaining the "Why."
+
+---
+
+## 🛠️ Tech Stack
+
+![Go](https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white)
+![Postgres](https://img.shields.io/badge/postgres-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white)
+![Grafana](https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white)
+![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
+
+---
+
 ## 🔍 What It Does
 
 | Capability | Details |
@@ -16,25 +57,6 @@ A personal telemetry system that collects **system metrics** and **application e
 
 ---
 
-## 🏗 Architecture Overview
+## 🚀 Explore the Live Site
 
-The system is designed for simplicity and reliability:
-
-| Component | Approach |
-| :--- | :--- |
-| **Collectors** | Custom Go services—cron-driven, stateless, and idempotent. |
-| **Storage** | **TimescaleDB** with JSONB for unified metric/event storage. |
-| **Visualization** | **Grafana** dashboards separated by concern (infra vs. app). |
-| **Observability** | **Loki** (logs) and a **Go proxy** (ETL) for full telemetry coverage. |
-
-For full architecture details, data model, and Mermaid diagrams:  
-→ [docs/architecture/README.md](./docs/architecture/README.md)
-
----
-
-## 💡 Why I Built This
-
-I built this to understand how observability can reveal system behavior over time—not just through logs or one-off checks, but through continuous, contextual telemetry.
-
-It started as a personal experiment.  
-Now, it’s how I monitor host health, debug pipeline failures, and connect infrastructure metrics to application events—all without cloud dependencies.
+[Explore Live Telemetry & System Evolution](https://victoriacheng15.github.io/observability-hub/)

--- a/docs/decisions/001-postgres-vs-influxdb.md
+++ b/docs/decisions/001-postgres-vs-influxdb.md
@@ -1,16 +1,16 @@
 # RFC 001: PostgreSQL vs. InfluxDB for Metrics Storage
 
-**Status:** Implemented  
-**Date:** Nov 2025  
+**Status:** Accepted
+**Date:** 2025-11-01
 **Author:** Victoria Cheng
 
-## 1. The Problem
+## The Problem
 
 The observability system requires a storage engine to hold system metrics (CPU, Memory, Disk, Network) collected from the homelab.
 
 Initially, **InfluxDB** was considered due to its specialized nature as a Time-Series Database (TSDB). However, this introduced architectural questions regarding long-term maintenance and data flexibility.
 
-## 2. Proposed Solution (PostgreSQL + JSONB)
+## Proposed Solution (PostgreSQL + JSONB)
 
 Switch to **PostgreSQL** using the `JSONB` data type for metrics storage, with the option to use **TimescaleDB** if performance limits are reached.
 
@@ -21,7 +21,7 @@ Switch to **PostgreSQL** using the `JSONB` data type for metrics storage, with t
 - **Flexibility:** JSONB allows storing unstructured telemetry data without strict schema migrations, which is ideal for an evolving observability project.
 - **Operational Simplicity:** One backup strategy, one container to monitor, and one set of security patches to manage.
 
-## 3. Comparison
+## Comparison
 
 | Feature | InfluxDB | PostgreSQL (JSONB) |
 | :--- | :--- | :--- |
@@ -30,6 +30,6 @@ Switch to **PostgreSQL** using the `JSONB` data type for metrics storage, with t
 | **Ecosystem** | Strong within TIG stack. | Massive; works with every tool on earth. |
 | **Maintenance** | High (Another DB to manage). | Low (Consolidated into existing DB). |
 
-## 4. Conclusion
+## Conclusion
 
 While InfluxDB is a powerful tool for massive scale, the operational overhead and niche query language make it less ideal for a self-hosted homelab environment compared to the flexibility and ubiquity of PostgreSQL.

--- a/docs/decisions/002-cloud-to-local-bridge.md
+++ b/docs/decisions/002-cloud-to-local-bridge.md
@@ -1,22 +1,22 @@
 # RFC 002: Cloud-to-Homelab Telemetry Bridge
 
-**Status:** Implemented  
-**Date:** Dec 2025  
+**Status:** Accepted
+**Date:** 2025-12-01
 **Author:** Victoria Cheng
 
-## 1. The Problem
+## The Problem
 
 Telemetry generated in Azure Functions (Cover Craft / Reading App) needs to be visualized in the local Grafana instance.
 
 **Constraint:** The local environment is behind a residential firewall (NAT). Inbound HTTP connections from Azure are restricted for security reasons. The goal is to avoid the complexity of maintaining a VPN for a single-purpose logging use case.
 
-## 2. Proposed Solution (The "Pull Model")
+## Proposed Solution (The "Pull Model")
 
 Use a shared **MongoDB** instance (Atlas) as an intermediate "Buffer" or Store-and-Forward node.
 
-1. **Producer (Azure):** The Azure Function writes event logs to MongoDB with `status: "ingested"`.
-2. **Consumer (Local Go Proxy):** A local service polls MongoDB once per day.
-3. **Processing:** The Go service downloads new logs, saves them to the local PostgreSQL (the Single Source of Truth), and updates the MongoDB document to `status: "processed"`.
+- **Producer (Azure):** The Azure Function writes event logs to MongoDB with `status: "ingested"`.
+- **Consumer (Local Go Proxy):** A local service polls MongoDB once per day.
+- **Processing:** The Go service downloads new logs, saves them to the local PostgreSQL (the Single Source of Truth), and updates the MongoDB document to `status: "processed"`.
 
 ### Diagram
 
@@ -37,7 +37,7 @@ sequenceDiagram
     end
 ```
 
-## 3. Alternatives Considered
+## Alternatives Considered
 
 | Alternative | Pros | Cons | Decision |
 | :--- | :--- | :--- | :--- |
@@ -45,6 +45,6 @@ sequenceDiagram
 | **Port Forwarding** | Free, easy to setup. | **Security Risk.** Exposes home network to the public internet. | Rejected |
 | **MongoDB Bridge** | Secure (Outbound only), Free tier, simple implementation. | Polling introduces slight latency (not real-time). | **Accepted** |
 
-## 4. Implementation Details
+## Implementation Details
 
 The synchronization logic is handled by the `proxy/utils/reading.go` service. It follows a **Fetch -> Insert -> Acknowledge** transaction pattern to ensure data consistency.

--- a/docs/decisions/003-shared-logging-library.md
+++ b/docs/decisions/003-shared-logging-library.md
@@ -1,0 +1,66 @@
+# RFC 003: Shared Structured Logging Library
+
+**Status:** Accepted
+**Date:** 2026-01-03
+**Author:** Victoria Cheng
+
+## The Problem
+
+As the project matures into a multi-service architecture (Proxy, System Metrics), logging has become fragmented.
+
+- **Unstructured:** Plain text logs (`log.Printf`) are difficult to parse in Loki without fragile Regular Expressions.
+- **Inconsistent:** Different services use different logging formats and field names.
+- **Low Signal:** Metadata critical for debugging (e.g., service names, request duration, error levels) is often buried in unstructured strings.
+
+## Proposed Solution (Shared `pkg/logger`)
+
+Implement a centralized logging strategy using a **Shared Go Package** pattern, leveraging the standard library's `log/slog` (Go 1.21+).
+
+### The "Paved Road" Approach
+
+A root-level module `pkg/logger` was created for all services to import. This module enforces a strict schema and configuration, removing the need for individual service developers to configure loggers manually.
+
+### Standard Schema
+
+All logs are output as JSON to `stdout`.
+
+**Example:**
+
+```json
+{
+  "time": "2026-01-01T12:00:00Z",
+  "level": "INFO",
+  "msg": "request_processed",
+  "service": "proxy",
+  "http_method": "GET"
+}
+```
+
+**Core Fields:**
+
+- `time`: RFC3339 Timestamp (automatic).
+- `level`: Severity (INFO, WARN, ERROR, DEBUG).
+- `msg`: The event description (snake_case).
+- `service`: The name of the originating service (e.g., `proxy`).
+
+## Implementation Details
+
+The **Local Module Replacement** pattern was used to share code without publishing to a public repository.
+
+- **Shared Module:** Created `pkg/logger` at the repository root.
+- **Service Linkage:** Each service (`proxy`, `system-metrics`) uses a `replace` directive in its `go.mod` pointing to `../pkg/logger`.
+- **Operational Excellence:** Implemented Docker-level log rotation via YAML anchors (`x-logging`) in `docker-compose.yml` to prevent disk exhaustion (10MB max, 3 files).
+- **Ingestion:** Configured Promtail `pipeline_stages` to parse JSON logs and promote `service` and `level` to Loki labels.
+
+## Comparison
+
+| Feature | Ad-Hoc Logging (Old) | Shared `slog` Library (Implemented) |
+| :--- | :--- | :--- |
+| **Format** | Text / Unstructured | JSON / Structured |
+| **Parsing** | Complex Regex in Loki | Automatic JSON Parsing |
+| **Consistency** | Varies by developer | Enforced by library |
+| **Maintenance** | Code duplicated in every service | Centralized in `pkg/logger` |
+
+## Conclusion
+
+Adopting a shared, structured logging library is a critical step towards **Platform Maturity**. It enables "Observability as Code" by ensuring that all telemetry entering our system is high-quality, queryable, and uniform by default.

--- a/docs/decisions/004-spatial-telemetry-rfc.md
+++ b/docs/decisions/004-spatial-telemetry-rfc.md
@@ -1,0 +1,46 @@
+# RFC 004: Spatial Keyboard Telemetry Pipeline
+
+**Status:** Proposed
+**Date:** Jan 2026
+**Author:** Victoria Cheng
+
+## The Problem
+
+Standard input monitoring (keyloggers or counters) lacks the physical context of *where* interactions happen. For ergonomic analysis, heatmapping, and advanced hardware telemetry, we need a way to map raw Linux input events to physical coordinates on a 2D plane.
+
+Existing solutions are either platform-specific (Windows-only), high-latency (Python-based), or closed-source. We need a low-level, high-performance bridge that can ship this data from an "Edge" device (Desktop) to a "Control Plane" (Laptop) without impacting system performance.
+
+## Proposed Solution
+
+A distributed IoT pipeline consisting of three tiers:
+
+- **C++ Edge Agent:** Reads `/dev/input/event*` directly using `ioctl`. Maps scancodes to `(x, y)` coordinates in millimeters.
+- **Go Proxy (Gateway):** A centralized ingress point that validates telemetry payloads and batches them for database insertion.
+- **PostGIS (Storage):** A relational database with spatial indexing to store keypresses as `GEOMETRY(POINT)`.
+
+### Rationale
+
+- **C++ for Performance:** Direct kernel access and zero Garbage Collection (GC) ensures that even high-speed typing (150+ WPM) doesn't cause telemetry lag or CPU spikes.
+- **Distributed Architecture:** Decouples the data collection (Desktop) from the visualization (Laptop), allowing the observability hub to remain centralized.
+- **Spatial Focus:** By using PostGIS, we can perform advanced spatial queries (e.g., "distance traveled between keypresses") that are impossible in standard time-series databases.
+
+## Comparison
+
+| Feature | Python / Node Script | C++ Agent (Proposed) |
+| :--- | :--- | :--- |
+| **Resource Usage** | Moderate CPU / High RAM | Near-zero CPU / < 5MB RAM |
+| **Kernel Interface** | Wrapper libraries (Heavy) | Direct `ioctl` (Native) |
+| **Latentcy** | GC Pauses possible | Deterministic |
+| **Portability** | Requires Runtime (interpreter) | Static Binary |
+
+## Operational Excellence (Failure Modes)
+
+| Scenario | Impact | Mitigation |
+| :--- | :--- | :--- |
+| **Network Loss** | Data cannot be shipped. | Agent implements an in-memory ring buffer (10k events) using FIFO. |
+| **High Load** | DB pressure. | Go Proxy uses worker pools and batch inserts. |
+| **Device Swap** | Scancodes change. | Configuration-driven mapping via `layout.json`. |
+
+## Conclusion
+
+This architecture provides a high-signal portfolio piece that demonstrates full-stack systems engineering—from hardware-level C++ to cloud-native Go and advanced SQL.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,56 @@
+# Architectural Decision Records (ADR)
+
+This directory serves as the **Institutional Memory** for the Observability Hub. It documents the "Why" behind major technical choices, ensuring the project remains maintainable and its evolution is transparent.
+
+---
+
+## Decision Lifecycle
+
+| Status | Meaning |
+| :--- | :--- |
+| **🟢 Proposed** | Planning phase. The design is being discussed or researched. |
+| **🔵 Accepted** | Implementation phase or completed. This is the current project standard. |
+| **🟡 Superseded** | Historical record. This decision has been replaced by a newer ADR. |
+
+---
+
+## Conventions
+
+- **File Naming:** `00X-descriptive-title.md`
+- **Dates:** Use ISO 8601 format (`YYYY-MM-DD`).
+- **Formatting:** Use hyphens (`-`) for all lists; no numbered lists.
+- **Automation:** Run `make rfc` to interactively generate a new file that follows these standards.
+
+---
+
+## 📝 RFC Template
+
+To create a new proposal, copy the block below into a new `.md` file.
+
+```markdown
+# RFC [00X]: [Descriptive Title]
+
+**Status:** Proposed | Accepted | Superseded  
+**Date:** YYYY-MM-DD  
+**Author:** Victoria Cheng
+
+## The Problem
+
+Identify the issue or opportunity. Why does this need to change?
+
+## Proposed Solution
+
+Technical details of the implementation. Use code snippets or diagrams.
+
+## Comparison / Alternatives Considered
+
+What else could we have done? Why is this path better?
+
+## Failure Modes (Operational Excellence)
+
+How does this break? How will we know when it's failing in production?
+
+## Conclusion
+
+Final summary and next steps.
+```

--- a/scripts/create_rfc.sh
+++ b/scripts/create_rfc.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+DOCS_DIR="docs/decisions"
+
+# - Determine Default ID
+# List files, filter for those starting with digits, extract the number, sort numerically descending, take the top one.
+LAST_ID=$(ls "$DOCS_DIR" | grep -E '^[0-9]+-' | cut -d'-' -f1 | sort -rn | head -n1)
+
+if [ -z "$LAST_ID" ]; then
+    NEXT_ID_NUM=1
+else
+    # Force base 10 arithmetic to avoid octal confusion with leading zeros
+    NEXT_ID_NUM=$((10#$LAST_ID + 1))
+fi
+
+DEFAULT_ID=$(printf "%03d" "$NEXT_ID_NUM")
+
+# - Prompt for inputs
+# usage of /dev/tty allows interaction even if run via 'make' which might redirect stdin
+exec < /dev/tty
+
+echo "-------------------------------------------------"
+echo "  Create New RFC (Architecture Decision Record)"
+echo "-------------------------------------------------"
+
+read -p "RFC ID [$DEFAULT_ID]: " USER_ID
+ID="${USER_ID:-$DEFAULT_ID}"
+
+DEFAULT_TITLE="New Feature"
+read -p "Title [$DEFAULT_TITLE]: " USER_TITLE
+TITLE="${USER_TITLE:-$DEFAULT_TITLE}"
+
+# - Slugify Title for Filename
+# Convert to lowercase, replace non-alphanumeric chars with dashes, remove leading/trailing dashes
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/^-|-$//g')
+FILENAME="${DOCS_DIR}/${ID}-${SLUG}.md"
+
+if [ -f "$FILENAME" ]; then
+    echo "Error: File $FILENAME already exists."
+    exit 1
+fi
+
+DATE=$(date +%Y-%m-%d)
+
+# - Generate File Content
+cat <<EOF > "$FILENAME"
+# RFC ${ID}: ${TITLE}
+
+**Status:** Proposed | Accepted | Superseded
+**Date:** ${DATE}
+**Author:** Victoria Cheng
+
+## The Problem
+
+Identify the issue or opportunity. Why does this need to change?
+
+## Proposed Solution
+
+Technical details of the implementation. Use code snippets or diagrams.
+
+## Comparison / Alternatives Considered
+
+What else could we have done? Why is this path better?
+
+## Failure Modes (Operational Excellence)
+
+How does this break? How will we know when it's failing in production?
+
+## Conclusion
+
+Final summary and next steps.
+EOF
+
+
+echo "✅ Created: $FILENAME"


### PR DESCRIPTION
### Summary

This PR formalizes the project's engineering standards by establishing a structured Architectural Decision Record (ADR) process and restructuring the root documentation. It introduces automation to reduce documentation friction and aligns the project's public-facing README with a "Senior-level" design philosophy and technical overview.

### List of Changes

* **Documentation:**
  * Created `docs/decisions/README.md` to define the ADR lifecycle and conventions.
  * Restructured root `README.md` to prioritize design philosophy, architectural approach, and high-impact tech stack visibility.
  * Standardized legacy RFCs (001, 002) to align with new date and heading standards.
* **Automation & DX:**
  * Implemented `scripts/create_rfc.sh` to automate RFC scaffolding (ID incrementing, slugification, and template generation).
  * Added `make rfc` to the `Makefile` to streamline the developer workflow.
* **Standards:**
  * Enforced a 3-stage lifecycle (`Proposed`, `Accepted`, `Superseded`).
  * Integrated "Failure Modes" into technical proposals to prioritize operational excellence.

### Verification

* [x] Verified all Markdown files render correctly across the documentation hierarchy.
* [x] Validated `make rfc` automation correctly predicts IDs and generates compliant templates.
* [x] Manually audited existing RFCs (001-002) for stylistic consistency.
