### PR TITLE
docs: refactor documentation system to generic 'artifacts' and fix rfc numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A personal telemetry system that collects **system metrics** and **application e
 - **Continuous Contextual Telemetry:** Built to understand system behavior over time through continuous telemetry rather than one-off checks.
 - **Systemic Health Monitoring:** Tracks host health, debugs pipeline failures, and connects infrastructure metrics to application events.
 - **Data Ownership:** Prioritizes 100% self-hosted infrastructure and long-term data retention without cloud dependencies.
-- **Simplicity & Reliability:** Employs scheduled, stateless, and idempotent Go services over complex, heavy-weight agents.
+- **Simplicity & Reliability:** Employs scheduled, stateless, and idempotent services over complex, heavy-weight agents.
 - **Scale-Ready Storage:** Leverages TimescaleDB (PostgreSQL) for efficient time-series analysis and historical tracking.
 
 ---
@@ -24,7 +24,7 @@ A personal telemetry system that collects **system metrics** and **application e
 
 | Component | Approach |
 | :--- | :--- |
-| **Collectors** | Custom Go services—cron-driven, stateless, and idempotent. |
+| **Collectors** | Scheduled, stateless, and idempotent services. |
 | **Storage** | **TimescaleDB** with JSONB for unified metric/event storage. |
 | **Visualization** | **Grafana** dashboards separated by concern (infra vs. app). |
 | **Observability** | **Loki** (logs) and a **Go proxy** (ETL) for full telemetry coverage. |

--- a/docs/decisions/004-spatial-telemetry-keyboard.md
+++ b/docs/decisions/004-spatial-telemetry-keyboard.md
@@ -1,7 +1,7 @@
 # RFC 004: Spatial Keyboard Telemetry Pipeline
 
 **Status:** Proposed
-**Date:** Jan 2026
+**Date:** 2026-01-03
 **Author:** Victoria Cheng
 
 ## The Problem
@@ -24,7 +24,7 @@ A distributed IoT pipeline consisting of three tiers:
 - **Distributed Architecture:** Decouples the data collection (Desktop) from the visualization (Laptop), allowing the observability hub to remain centralized.
 - **Spatial Focus:** By using PostGIS, we can perform advanced spatial queries (e.g., "distance traveled between keypresses") that are impossible in standard time-series databases.
 
-## Comparison
+## Comparison / Alternatives Considered
 
 | Feature | Python / Node Script | C++ Agent (Proposed) |
 | :--- | :--- | :--- |
@@ -33,7 +33,7 @@ A distributed IoT pipeline consisting of three tiers:
 | **Latentcy** | GC Pauses possible | Deterministic |
 | **Portability** | Requires Runtime (interpreter) | Static Binary |
 
-## Operational Excellence (Failure Modes)
+## Failure Modes (Operational Excellence)
 
 | Scenario | Impact | Mitigation |
 | :--- | :--- | :--- |

--- a/docs/decisions/005-gitops-reconciliation-engine.md
+++ b/docs/decisions/005-gitops-reconciliation-engine.md
@@ -1,0 +1,58 @@
+# RFC 005: Centralized GitOps Reconciliation Engine
+
+**Status:** Proposed
+**Date:** 2026-01-03
+**Author:** Victoria Cheng
+
+## The Problem
+
+The primary bottleneck is the manual overhead and state drift that occurs when the repository is updated outside of the local terminal (e.g., merging a Pull Request via the GitHub Web UI).
+
+While merging via `gh pr merge -s -d` handles local synchronization, web-based merges leave the server's local repository behind. This requires manual intervention (`git pull origin main`) to sync the "live" state with the "git" state, leading to unnecessary manual commands and potential human error in keeping services up to date.
+
+## Proposed Solution
+
+Implement a "Pull-based" synchronization agent managed by **Systemd Timers**. To maintain simplicity and ensure stability, the rollout follows a structured three-phase roadmap:
+
+- **Phase 1: Observability Hub Sync:** Initial rollout focusing exclusively on automating `git pull` for the `observability-hub` repository. This validates the Systemd/Bash mechanism and eliminates the manual overhead for the core platform.
+- **Phase 2: Project Expansion:** Expand the automated synchronization mechanism to other repositories within the homelab environment.
+- **Phase 3: State Enforcement (Docker):** Once the synchronization mechanism is stable across all repositories, the agent will be expanded to trigger service restarts (e.g., `docker compose up -d`) to apply configuration changes automatically.
+
+- **Systemd Integration:** Using `Type=oneshot` services and `Persistent=true` timers ensures that synchronization is reliable, dependency-aware (starts after network/docker), and natively integrated with `journald` for observability.
+
+### Architecture Snippet (The Controller)
+
+```bash
+#!/bin/bash
+# gitops-sync: A repository synchronization agent
+set -euo pipefail
+
+REPO_PATH=$1
+cd "$REPO_PATH"
+
+git fetch origin main --quiet
+LOCAL_HASH=$(git rev-parse HEAD)
+REMOTE_HASH=$(git rev-parse origin/main)
+
+if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
+    echo "Changes detected. Synchronizing repository..."
+    git pull origin main
+    # TODO: Trigger container updates in Phase 3
+else
+    echo "Repository in sync."
+fi
+```
+
+## Comparison / Alternatives Considered
+
+- **ArgoCD / Flux:** While powerful, these tools introduce significant resource overhead (RAM/CPU) for a single-node homelab. A Bash-based agent provides $O(1)$ overhead.
+- **Standard Cron:** Functional but limited. While Cron is the standard for scheduled tasks, we are explicitly choosing Systemd Timers to **evaluate** their suitability for infrastructure orchestration. This decision is driven by a desire to benchmark Systemd's native dependency management and logging capabilities against the traditional Cron approach.
+
+## Failure Modes (Operational Excellence)
+
+- **Git Pull Conflict:** If the local state deviates manually, the sync will fail. **Mitigation:** The script will exit with a non-zero code, visible in `systemctl status`, and can be configured to send an alert to the Observability Hub.
+- **Runtime Downtime:** If Docker is down during a sync, docker commands will fail. **Mitigation:** Systemd's `After=docker.service` ensures the sync only runs when the cluster is healthy.
+
+## Conclusion
+
+This "Hub-and-Spoke" GitOps strategy provides a low-overhead automation pipeline that eliminates manual synchronization tasks. By using native Linux primitives, we ensure the system stays in sync with the remote repository reliably and without manual `git pull` commands.

--- a/page/content/data.yaml
+++ b/page/content/data.yaml
@@ -2,20 +2,20 @@ landing:
   page_title: "Self-Hosted Observability Hub"
   hero:
     title: "Monitor What Matters"
-    subtitle: "Real-time metrics and structured event logs from a lightweight, self-hosted Go proxy."
+    subtitle: "Real-time metrics and structured event logs from a lightweight, self-hosted telemetry engine."
     cta_text: "See the Journey"
     cta_link: "evolution.html"
     cta2_text: "View Dashboards"
     cta2_link: "dashboards.html"
   features:
-    - title: "Built in Go"
-      description: "Efficient, low-overhead proxy collecting system and application telemetry."
+    - title: "Stateless Collection Engine"
+      description: "Lightweight, scheduled services designed for idempotency and zero-maintenance reliability."
       icon: "rocket"
-    - title: "Single Source of Truth"
-      description: "All telemetry stored in PostgreSQL using JSONB—enabling flexible schema and powerful queries."
+    - title: "Unified Data Fabric"
+      description: "Bridging system metrics and application events into a single PostgreSQL schema with JSONB flexibility."
       icon: "database"
-    - title: "Grafana Dashboards"
-      description: "Visualizations powered by metrics—collected every minute."
+    - title: "Observability as Code"
+      description: "Infrastructure health and telemetry trends visualized via Git-controlled Grafana dashboards."
       icon: "chart-line"
 
 dashboards:
@@ -42,19 +42,31 @@ evolution:
         - Evaluated storage options—chose PostgreSQL for its flexibility over specialized time-series databases.
     - date: "2025-12 (early)"
       title: "Explored Grafana & Telemetry"
-      rfc: "docs/decisions/001-postgres-vs-influxdb.md"
+      artifacts:
+        - name: "RFC 001: Postgres vs InfluxDB"
+          url: "docs/decisions/001-postgres-vs-influxdb.md"
       description: |
         - Built a lightweight Go proxy to emit structured telemetry: HTTP requests, errors, and health events.
         - Adopted PostgreSQL with JSONB to unify logs and metrics in a single, flexible schema, moving away from InfluxDB.
     - date: "2025-12 (late)"
       title: "Hybrid Cloud Integration"
-      rfc: "docs/decisions/002-cloud-to-local-bridge.md"
+      artifacts:
+        - name: "RFC 002: Cloud-to-Local Bridge"
+          url: "docs/decisions/002-cloud-to-local-bridge.md"
       description: |
         - Designed a secure "Store-and-Forward" bridge to ingest telemetry from Azure Functions into the local private network.
         - Implemented a polling consumer in Go to bypass NAT restrictions without exposing ports or maintaining VPNs.
         - Decoupled stateless collectors from persistent storage to enable independent scaling.
     - date: "2026-01"
       title: "Platform Maturity & Knowledge Engine"
+      artifacts:
+        - name: "RFC 003: Shared Logging Library"
+          url: "docs/decisions/003-shared-logging-library.md"
+        - name: "RFC 004: Spatial Telemetry keyboard"
+          url: "docs/decisions/004-spatial-telemetry-keyboard.md"
+        - name: "RFC 005: GitOps Reconciliation"
+          url: "docs/decisions/005-gitops-reconciliation-engine.md"
       description: |
+        - Launched the project portal to visualize system evolution and technical constraints.
         - Formalized a "Documentation as Code" standard, treating architectural decisions (RFCs) as first-class artifacts.
-        - Launched the project portal to visualize system evolution and technical constraints, reducing onboarding time for new contributors.
+        - Implemented a unified logging strategy using a shared 'pkg/logger' module to ensure consistent structured observability across all services.

--- a/page/main.go
+++ b/page/main.go
@@ -36,12 +36,17 @@ type Landing struct {
 	Features  []Feature `yaml:"features"`
 }
 
+type Artifact struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+}
+
 type Event struct {
-	Date             string   `yaml:"date"`
-	Title            string   `yaml:"title"`
-	Description      string   `yaml:"description"`
-	DescriptionLines []string `yaml:"-"`
-	RFC              string   `yaml:"rfc"`
+	Date             string     `yaml:"date"`
+	Title            string     `yaml:"title"`
+	Description      string     `yaml:"description"`
+	DescriptionLines []string   `yaml:"-"`
+	Artifacts        []Artifact `yaml:"artifacts"`
 }
 
 type Evolution struct {

--- a/page/templates/base.html
+++ b/page/templates/base.html
@@ -205,6 +205,13 @@
             }
         }
 
+        .rfc-tags {
+            display: flex;
+            flex-direction: column;
+            width:max-content;
+            gap: var(--space-sm);
+        }
+
         /* Page specific */
         .hero {
             text-align: center;
@@ -311,14 +318,15 @@
                 border-radius: var(--radius-main);
                 border: 1px solid var(--border-light);
                 box-shadow: 0 1px 3px 0 var(--shadow);
+                display: flex;
+                flex-direction: column ;
+                gap: var(--space-lg);
 
                 h3 {
-                    margin-bottom: var(--space-sm);
                     color: var(--primary);
                 }
 
                 ul {
-                    padding-left: 0;
                     list-style: disc;
                     color: var(--text-main);
                     display: grid;

--- a/page/templates/evolution.html
+++ b/page/templates/evolution.html
@@ -13,22 +13,24 @@
     <li>
         <time class="timeline-date" datetime="{{ .Date }}">{{ .Date }}</time>
         <article class="timeline-content">
-            <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem;">
-                <h3>{{ .Title }}</h3>
-                {{if .RFC}}
-                <a href="https://github.com/victoriacheng15/observability-platform/blob/main/{{ .RFC }}" 
-                   class="btn-rfc" 
-                   target="_blank" 
-                   rel="noopener noreferrer">
-                   📄 Read Decision
-                </a>
-                {{end}}
-            </div>
+            <h3>{{ .Title }}</h3>
             <ul>
                 {{range .DescriptionLines}}
                 <li>{{ . }}</li>
                 {{end}}
             </ul>
+            {{if .Artifacts}}
+            <div class="rfc-tags">
+                {{range .Artifacts}}
+                <a href="https://github.com/victoriacheng15/observability-platform/blob/main/{{ .URL }}" 
+                    class="btn-rfc" 
+                    target="_blank" 
+                    rel="noopener noreferrer">
+                    📄 {{ .Name }}
+                </a>
+                {{end}}
+            </div>
+            {{end}}
         </article>
     </li>
     {{end}}


### PR DESCRIPTION
### Summary

Refactors the documentation and landing page system to support a broader range of technical artifacts (architecture docs, RFCs) rather than just RFCs. This includes backend Go struct updates, template changes, and fixing a numbering mismatch in the existing RFCs.

### List of Changes

- **Landing Page Generator:**
  - Renamed `RFC` struct to `Artifact`.
  - Updated `data.yaml` schema to use `artifacts` key.
  - Updated `evolution.html` template to render the new `Artifacts` list.
- **RFC Corrections:**
  - Swapped titles for RFC 004 and RFC 005 to match their filenames (Spatial Telemetry vs GitOps).
- **README:**
  - Updated the "Architectural Approach" section to align with the new structure.

### Verification

- [x] Verified `go build` passes in `page/` directory.
- [x] Confirmed `data.yaml` maps correctly to the new Go structs.
- [x] Validated that RFC links in the Evolution page point to the correct files.
