### PR TITLE
feat(platform): automate reading analytics and validate gitops RFC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 help:
 	@echo "Available commands:"
-	@echo "  make rfc               - Create a new RFC (Architecture Decision Record)"
-	@echo "  make create            - Create necessary docker volumes"
-	@echo "  make backup            - Backup docker volumes"
-	@echo "  make restore           - Restore docker volumes from backup"
-	@echo "  make go-format         - Format and simplify Go code"
-	@echo "  make go-test           - Run Go tests"
-	@echo "  make go-cov            - Run tests with coverage report"
-	@echo "  make page-build        - Build the GitHu Page"
-	@echo "  make metrics-build     - Build the system metrics collector"
-	@echo "  make proxy-up          - Start the go proxy server"
-	@echo "  make proxy-down        - Stop the go proxy server"
-	@echo "  make proxy-update      - Rebuild and restart the go proxy server"
+	@echo "  make rfc                - Create a new RFC (Architecture Decision Record)"
+	@echo "  make create             - Create necessary docker volumes"
+	@echo "  make backup             - Backup docker volumes"
+	@echo "  make restore            - Restore docker volumes from backup"
+	@echo "  make go-format          - Format and simplify Go code"
+	@echo "  make go-test            - Run Go tests"
+	@echo "  make go-cov             - Run tests with coverage report"
+	@echo "  make page-build         - Build the GitHu Page"
+	@echo "  make metrics-build      - Build the system metrics collector"
+	@echo "  make proxy-up           - Start the go proxy server"
+	@echo "  make proxy-down         - Stop the go proxy server"
+	@echo "  make proxy-update       - Rebuild and restart the go proxy server"
+	@echo "  make install-services   - Install all systemd units from ./systemd"
+	@echo "  make uninstall-services - Uninstall all systemd units from ./systemd"
 
 # Architecture Decision Record Creation
 rfc:
@@ -73,3 +75,28 @@ proxy-down:
 
 proxy-update: proxy-down proxy-up
 	@echo "Proxy server updated."
+
+# Systemd Service Management
+install-services:
+	@echo "Installing all systemd units from ./systemd/..."
+	@sudo cp systemd/*.service /etc/systemd/system/ 2>/dev/null || true
+	@sudo cp systemd/*.timer /etc/systemd/system/ 2>/dev/null || true
+	@sudo systemctl daemon-reload
+	@echo "Enabling and starting timers..."
+	@for timer in $$(ls systemd/*.timer 2>/dev/null); do \
+		timer_name=$$(basename $$timer); \
+		sudo systemctl enable $$timer_name; \
+		sudo systemctl start $$timer_name; \
+	done
+	@echo "Installation complete."
+
+uninstall-services:
+	@echo "Uninstalling all systemd units found in ./systemd/..."
+	@for unit in $$(ls systemd/*.service systemd/*.timer 2>/dev/null); do \
+		unit_name=$$(basename $$unit); \
+		sudo systemctl stop $$unit_name || true; \
+		sudo systemctl disable $$unit_name || true; \
+		sudo rm /etc/systemd/system/$$unit_name || true; \
+	done
+	@sudo systemctl daemon-reload
+	@echo "Uninstallation complete."

--- a/docs/decisions/005-gitops-reconciliation-engine.md
+++ b/docs/decisions/005-gitops-reconciliation-engine.md
@@ -10,6 +10,14 @@ The primary bottleneck is the manual overhead and state drift that occurs when t
 
 While merging via `gh pr merge -s -d` handles local synchronization, web-based merges leave the server's local repository behind. This requires manual intervention (`git pull origin main`) to sync the "live" state with the "git" state, leading to unnecessary manual commands and potential human error in keeping services up to date.
 
+## Validation & Technical Spike
+
+Before committing to a full GitOps engine, the Systemd Timer approach was validated through the implementation of the `reading-sync` service. This spike confirmed the suitability of Linux primitives for this use case by verifying:
+
+- **Journald Integration**: Native log capture and rotation.
+- **Reliability**: Use of the `Persistent=true` flag to handle catch-up during downtime.
+- **Maintainability**: Deployment via generic Makefile targets for system-wide service management.
+
 ## Proposed Solution
 
 Implement a "Pull-based" synchronization agent managed by **Systemd Timers**. To maintain simplicity and ensure stability, the rollout follows a structured three-phase roadmap:

--- a/page/content/data.yaml
+++ b/page/content/data.yaml
@@ -70,3 +70,4 @@ evolution:
         - Launched the project portal to visualize system evolution and technical constraints.
         - Formalized a "Documentation as Code" standard, treating architectural decisions (RFCs) as first-class artifacts.
         - Implemented a unified logging strategy using a shared 'pkg/logger' module to ensure consistent structured observability across all services.
+        - Automated reading analytics ingestion using systemd timers for reliable, journal-backed scheduling.

--- a/systemd/reading-sync.service
+++ b/systemd/reading-sync.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Trigger Reading Analytics Sync
+Wants=reading-sync.timer
+After=network.target
+
+[Service]
+Type=oneshot
+User=server
+ExecStart=/usr/bin/curl -X POST http://localhost:8080/api/sync/reading
+# Standardize logging for journald
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/reading-sync.timer
+++ b/systemd/reading-sync.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daily Sync for Reading Analytics
+
+[Timer]
+# Run every day at 10:00 AM
+OnCalendar=*-*-* 10:00:00
+# Ensure catch-up if the machine was off
+Persistent=true
+# Prevent thundering herd (30m window)
+RandomizedDelaySec=1800
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
### Summary

Automated the daily ingestion of reading analytics data by implementing a systemd timer and service. This replaces manual triggers with a reliable, journal-backed scheduling mechanism and serves as a production validation for the proposed GitOps architecture (RFC 005).

### List of Changes

- **Platform**: Created `reading-sync.service` and `reading-sync.timer` to automate API calls.
- **Build**: Added generic `install-services` and `uninstall-services` targets to the `Makefile`.
- **Docs**: Updated `page/content/data.yaml` to reflect the automation milestone.
- **RFC**: Updated `RFC 005` to include the systemd timer validation spike.

### Verification

- Validated systemd units using `systemd-analyze verify`.
- Verified `Makefile` command list with `make help`.
