### PR TITLE
fix(platform): update proxy port and format ADR metadata

### DIFF
--- a/docs/decisions/001-postgres-vs-influxdb.md
+++ b/docs/decisions/001-postgres-vs-influxdb.md
@@ -1,8 +1,8 @@
 # RFC 001: PostgreSQL vs. InfluxDB for Metrics Storage
 
-**Status:** Accepted
-**Date:** 2025-11-01
-**Author:** Victoria Cheng
+- **Status:** Accepted
+- **Date:** 2025-11-01
+- **Author:** Victoria Cheng
 
 ## The Problem
 

--- a/docs/decisions/002-cloud-to-local-bridge.md
+++ b/docs/decisions/002-cloud-to-local-bridge.md
@@ -1,8 +1,8 @@
 # RFC 002: Cloud-to-Homelab Telemetry Bridge
 
-**Status:** Accepted
-**Date:** 2025-12-01
-**Author:** Victoria Cheng
+- **Status:** Accepted
+- **Date:** 2025-12-01
+- **Author:** Victoria Cheng
 
 ## The Problem
 

--- a/docs/decisions/003-shared-logging-library.md
+++ b/docs/decisions/003-shared-logging-library.md
@@ -1,8 +1,8 @@
 # RFC 003: Shared Structured Logging Library
 
-**Status:** Accepted
-**Date:** 2026-01-03
-**Author:** Victoria Cheng
+- **Status:** Accepted
+- **Date:** 2026-01-03
+- **Author:** Victoria Cheng
 
 ## The Problem
 

--- a/docs/decisions/004-spatial-telemetry-keyboard.md
+++ b/docs/decisions/004-spatial-telemetry-keyboard.md
@@ -1,8 +1,8 @@
 # RFC 004: Spatial Keyboard Telemetry Pipeline
 
-**Status:** Proposed
-**Date:** 2026-01-03
-**Author:** Victoria Cheng
+- **Status:** Proposed
+- **Date:** 2026-01-03
+- **Author:** Victoria Cheng
 
 ## The Problem
 

--- a/docs/decisions/005-gitops-reconciliation-engine.md
+++ b/docs/decisions/005-gitops-reconciliation-engine.md
@@ -1,8 +1,8 @@
 # RFC 005: Centralized GitOps Reconciliation Engine
 
-**Status:** Proposed
-**Date:** 2026-01-03
-**Author:** Victoria Cheng
+- **Status:** Proposed
+- **Date:** 2026-01-03
+- **Author:** Victoria Cheng
 
 ## The Problem
 

--- a/systemd/reading-sync.service
+++ b/systemd/reading-sync.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=oneshot
 User=server
-ExecStart=/usr/bin/curl -X POST http://localhost:8080/api/sync/reading
+ExecStart=/usr/bin/curl -X POST http://localhost:8085/api/sync/reading
 # Standardize logging for journald
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
### Summary

Corrects the proxy port in the systemd service to match the Go proxy's default and standardizes the metadata formatting in the Architectural Decision Records (ADRs).

### List of Changes

- **platform**: Update `reading-sync.service` port from 8080 to 8085.
- **docs**: Format ADR headers (Status, Date, Author) as lists across all decision records for consistency.

### Verification

- [x] Verified `reading-sync.service` manually to confirm it reaches the proxy on port 8085.
- [x] Confirmed ADR formatting matches the project's markdown standards.