### PR TITLE
feat(infra): migrate system metrics to systemd and standardize UTC telemetry

### DIFF
--- a/page/content/data.yaml
+++ b/page/content/data.yaml
@@ -70,4 +70,4 @@ evolution:
         - Launched the project portal to visualize system evolution and technical constraints.
         - Formalized a "Documentation as Code" standard, treating architectural decisions (RFCs) as first-class artifacts.
         - Implemented a unified logging strategy using a shared 'pkg/logger' module to ensure consistent structured observability across all services.
-        - Automated reading analytics ingestion using systemd timers for reliable, journal-backed scheduling.
+        - Automated reading analytics ingestion and system metrics collection using systemd timers for reliable, journal-backed scheduling.

--- a/proxy/utils/dbConnection.go
+++ b/proxy/utils/dbConnection.go
@@ -37,7 +37,7 @@ func InitPostgres(driverName string) *sql.DB {
 	dbname := getRequiredEnv("DB_NAME")
 
 	connStr := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable timezone=UTC",
 		host, port, user, password, dbname,
 	)
 

--- a/proxy/utils/reading.go
+++ b/proxy/utils/reading.go
@@ -57,12 +57,12 @@ func (s *ReadingService) ensureReadingAnalyticsTable() error {
 	_, err := s.DB.Exec(`CREATE TABLE IF NOT EXISTS reading_analytics (
 		id SERIAL PRIMARY KEY,
 		mongo_id TEXT UNIQUE NOT NULL,
-		event_timestamp TIMESTAMP,
+		event_timestamp TIMESTAMPTZ,
 		source TEXT,
 		event_type TEXT,
 		payload JSONB,
 		meta JSONB,
-		created_at TIMESTAMP DEFAULT NOW()
+		created_at TIMESTAMPTZ DEFAULT NOW()
 	)`)
 	return err
 }

--- a/scripts/run_metrics.sh
+++ b/scripts/run_metrics.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-cd /home/server/software/observability-hub/system-metrics
-
-./metrics-collector.exe >> /var/log/system-metrics.log 2>&1

--- a/systemd/system-metrics.service
+++ b/systemd/system-metrics.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Collect System Metrics (CPU/Mem/Disk/Net)
+After=network.target postgresql.service
+
+[Service]
+Type=oneshot
+User=server
+WorkingDirectory=/home/server/software/observability-hub/system-metrics
+ExecStart=/home/server/software/observability-hub/system-metrics/metrics-collector.exe
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/system-metrics.timer
+++ b/systemd/system-metrics.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer for System Metrics Collection
+
+[Timer]
+OnCalendar=*:*:00
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
### Summary

Standardizes the observability infrastructure by migrating system metrics collection to systemd timers and enforcing UTC timezone consistency across the PostgreSQL telemetry fabric.

### List of Changes

- **Infrastructure:**
  - Added `systemd/system-metrics.service` and `system-metrics.timer` for managed scheduling.
  - Standardized `reading_analytics` schema to use `TIMESTAMPTZ` for timezone-aware telemetry.
  - Enforced `timezone=UTC` in the Go proxy database connection string.
- **Documentation:**
  - Updated `page/content/data.yaml` to reflect the unified automation strategy.

### Verification

- [x] Schema migration verified: `reading_analytics` columns are `timestamp with time zone`.
- [x] Connection string verified: Session defaults to UTC.