### PR TITLE
feat(page): display rfc artifacts on evolution timeline

### DIFF
--- a/docs/decisions/005-gitops-reconciliation-engine.md
+++ b/docs/decisions/005-gitops-reconciliation-engine.md
@@ -12,11 +12,12 @@ While merging via `gh pr merge -s -d` handles local synchronization, web-based m
 
 ## Validation & Technical Spike
 
-Before committing to a full GitOps engine, the Systemd Timer approach was validated through the implementation of the `reading-sync` service. This spike confirmed the suitability of Linux primitives for this use case by verifying:
+Before committing to a full GitOps engine, the Systemd Timer approach was validated through the implementation of the `reading-sync` and `system-metrics` services. This spike confirmed the suitability of Linux primitives for this use case by verifying:
 
 - **Journald Integration**: Native log capture and rotation.
 - **Reliability**: Use of the `Persistent=true` flag to handle catch-up during downtime.
 - **Maintainability**: Deployment via generic Makefile targets for system-wide service management.
+- **Unified Scheduling**: Benchmarking systemd's ability to manage diverse telemetry collectors (API polling vs. system probing) consistently.
 
 ## Proposed Solution
 
@@ -54,7 +55,7 @@ fi
 ## Comparison / Alternatives Considered
 
 - **ArgoCD / Flux:** While powerful, these tools introduce significant resource overhead (RAM/CPU) for a single-node homelab. A Bash-based agent provides $O(1)$ overhead.
-- **Standard Cron:** Functional but limited. While Cron is the standard for scheduled tasks, we are explicitly choosing Systemd Timers to **evaluate** their suitability for infrastructure orchestration. This decision is driven by a desire to benchmark Systemd's native dependency management and logging capabilities against the traditional Cron approach.
+- **Standard Cron:** Functional but limited. While Cron is the standard for scheduled tasks, we are explicitly choosing Systemd Timers to **evaluate** their suitability for infrastructure unified scheduling. This decision is driven by a desire to benchmark Systemd's native dependency management and logging capabilities against the traditional Cron approach.
 
 ## Failure Modes (Operational Excellence)
 

--- a/page/content/data.yaml
+++ b/page/content/data.yaml
@@ -40,22 +40,22 @@ evolution:
   page_title: "Project Evolution"
   intro_text: "From experimenting with local infrastructure to building a focused observability tool—driven by telemetry needs."
   events:
-    - date: "2025-11"
+    - date: "2025-11-20"
       title: "Built a Reliable Local Lab"
       description: |
         - Set up a Docker environment with core services: Jenkins, PostgreSQL, InfluxDB, and more.
         - Automated volume management, backups, and service isolation with custom scripts.
         - Evaluated storage options—chose PostgreSQL for its flexibility over specialized time-series databases.
-    - date: "2025-12 (early)"
-      title: "Explored Grafana & Telemetry"
+    - date: "2025-12-25"
+      title: "Telemetry Engine Initialization"
       artifacts:
         - name: "RFC 001: Postgres vs InfluxDB"
           url: "docs/decisions/001-postgres-vs-influxdb.md"
       description: |
         - Built a lightweight Go proxy to emit structured telemetry: HTTP requests, errors, and health events.
         - Adopted PostgreSQL with JSONB to unify logs and metrics in a single, flexible schema, moving away from InfluxDB.
-    - date: "2025-12 (late)"
-      title: "Hybrid Cloud Integration"
+    - date: "2025-12-31"
+      title: "Hybrid Cloud Architecture"
       artifacts:
         - name: "RFC 002: Cloud-to-Local Bridge"
           url: "docs/decisions/002-cloud-to-local-bridge.md"
@@ -63,17 +63,26 @@ evolution:
         - Designed a secure "Store-and-Forward" bridge to ingest telemetry from Azure Functions into the local private network.
         - Implemented a polling consumer in Go to bypass NAT restrictions without exposing ports or maintaining VPNs.
         - Decoupled stateless collectors from persistent storage to enable independent scaling.
-    - date: "2026-01"
-      title: "Platform Maturity & Knowledge Engine"
+    - date: "2026-01-01"
+      title: "Project Portal Launch"
+      description: |
+        - Released the self-hosted visualization portal to track system evolution and technical constraints.
+        - Implemented a unified dashboard for real-time system metrics and personal reading analytics.
+    - date: "2026-01-03"
+      title: "Standardization & Logging"
       artifacts:
         - name: "RFC 003: Shared Logging Library"
           url: "docs/decisions/003-shared-logging-library.md"
+      description: |
+        - Implemented a unified logging strategy using a shared 'pkg/logger' module to ensure consistent structured observability across all services.
+        - Formalized a "Documentation as Code" standard, treating architectural decisions (RFCs) as first-class artifacts.
+    - date: "2026-01-08"
+      title: "Automated Insights & GitOps Strategy"
+      artifacts:
         - name: "RFC 004: Spatial Telemetry keyboard"
           url: "docs/decisions/004-spatial-telemetry-keyboard.md"
         - name: "RFC 005: GitOps Reconciliation"
           url: "docs/decisions/005-gitops-reconciliation-engine.md"
       description: |
-        - Launched the project portal to visualize system evolution and technical constraints.
-        - Formalized a "Documentation as Code" standard, treating architectural decisions (RFCs) as first-class artifacts.
-        - Implemented a unified logging strategy using a shared 'pkg/logger' module to ensure consistent structured observability across all services.
-        - Automated reading analytics ingestion and system metrics collection using systemd timers for reliable, journal-backed scheduling.
+        - Automated reading analytics ingestion using systemd timers for reliable, journal-backed scheduling.
+        - Validated GitOps strategy for automated repository synchronization and configuration management.

--- a/page/main.go
+++ b/page/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -46,6 +47,7 @@ type Event struct {
 	Title            string     `yaml:"title"`
 	Description      string     `yaml:"description"`
 	DescriptionLines []string   `yaml:"-"`
+	FormattedDate    string     `yaml:"-"`
 	Artifacts        []Artifact `yaml:"artifacts"`
 }
 
@@ -99,8 +101,9 @@ func main() {
 		log.Fatalf("Failed to load data: %v", err)
 	}
 
-	// Process Descriptions
+	// Process Descriptions and Dates
 	for i := range data.Evolution.Events {
+		// 1. Process description lines
 		lines := strings.Split(data.Evolution.Events[i].Description, "\n")
 		var cleanLines []string
 		for _, line := range lines {
@@ -111,6 +114,16 @@ func main() {
 			}
 		}
 		data.Evolution.Events[i].DescriptionLines = cleanLines
+
+		// 2. Process and format date
+		t, err := time.Parse("2006-01-02", data.Evolution.Events[i].Date)
+		if err != nil {
+			// Fallback to raw string if parsing fails
+			log.Printf("Warning: failed to parse date %s: %v", data.Evolution.Events[i].Date, err)
+			data.Evolution.Events[i].FormattedDate = data.Evolution.Events[i].Date
+		} else {
+			data.Evolution.Events[i].FormattedDate = t.Format("Jan 02, 2006")
+		}
 	}
 
 	// Reverse Evolution Events (Newest First)

--- a/page/templates/evolution.html
+++ b/page/templates/evolution.html
@@ -11,7 +11,7 @@
 <ul class="timeline">
     {{range .Evolution.Events}}
     <li>
-        <time class="timeline-date" datetime="{{ .Date }}">{{ .Date }}</time>
+        <time class="timeline-date" datetime="{{ .Date }}">{{ .FormattedDate }}</time>
         <article class="timeline-content">
             <h3>{{ .Title }}</h3>
             <ul>
@@ -22,10 +22,8 @@
             {{if .Artifacts}}
             <div class="rfc-tags">
                 {{range .Artifacts}}
-                <a href="https://github.com/victoriacheng15/observability-platform/blob/main/{{ .URL }}" 
-                    class="btn-rfc" 
-                    target="_blank" 
-                    rel="noopener noreferrer">
+                <a href="https://github.com/victoriacheng15/observability-platform/blob/main/{{ .URL }}" class="btn-rfc"
+                    target="_blank" rel="noopener noreferrer">
                     📄 {{ .Name }}
                 </a>
                 {{end}}


### PR DESCRIPTION
### Summary

Enhances the "Project Evolution" timeline by dynamically rendering links to Architectural Decision Records (ADRs). This change associates specific timeline events with their corresponding RFC documents, making the project's technical history more transparent and accessible directly from the portal.

### List of Changes

- **`page/content/data.yaml`**: Updated timeline events with an `artifacts` list, linking events to their respective RFC documents.
- **`page/main.go`**: Modified the `Event` data model to include a slice of `Artifact` structs.
- **`page/templates/evolution.html`**: Updated the template to iterate over artifacts and render them as styled links.
- **`page/templates/base.html`**: Added CSS styles for `rfc-tags` and `btn-rfc` to format the new artifact links.
- **`docs/decisions/`**: Added new RFCs (`004`, `005`) and updated the `README.md` to provide the content for linking.

### Verification

- [x] `go run main.go` executes without error.
- [x] The "Project Evolution" page (`dist/evolution.html`) correctly displays links for events that have associated RFCs.
- [x] Links point to the correct files in the GitHub repository.
- [x] The page remains visually correct and the new links are styled as buttons.