### PR TITLE
refactor(pkg): extract shared database configuration into pkg/db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ restore:
 
 go-format:
 	@echo "Formatting Go code..."
-	@gofmt -w -s ./proxy ./system-metrics ./page
+	@gofmt -w -s ./proxy ./system-metrics ./page ./pkg
 
 go-test:
 	@echo "Running Go tests..."

--- a/docs/decisions/006-shared-database-module.md
+++ b/docs/decisions/006-shared-database-module.md
@@ -1,0 +1,51 @@
+# RFC 006: Shared Database Configuration Module
+
+- **Status:** Accepted
+- **Date:** 2026-01-09
+- **Author:** Victoria Cheng
+
+## The Problem
+
+As the platform expands to include multiple services (`proxy`, `system-metrics`) connecting to the same PostgreSQL database, configuration logic has become duplicated and inconsistent.
+
+- **Drift Risk:** Services maintain separate connection strings. Changing a default (e.g., enforcing `sslmode` or changing `timezone`) requires updates across multiple codebases.
+- **Code Duplication:** Environment variable parsing logic (`DB_HOST`, `DB_PORT`, etc.) is repeated in every service.
+- **Timezone Ambiguity:** Some services (like `system-metrics`) were missing the `timezone=UTC` flag, potentially leading to inconsistent data storage.
+
+## Proposed Solution (Shared `pkg/db`)
+
+Extract the database connection configuration into a shared `pkg/db` module, following the "Paved Road" pattern established by `pkg/logger`.
+
+### The "Single Source of Truth" Approach
+
+A root-level module `pkg/db` will centralize how services connect to persistence layers. This module enforces "safe by default" configurations (e.g., `timezone=UTC`, `sslmode=disable`) and handles environment variable parsing.
+
+### Interface Design
+
+The module provides a standardized function to generate the Data Source Name (DSN). It respects the `DATABASE_URL` environment variable if present, otherwise it constructs the DSN from individual components.
+
+```go
+package db
+
+// GetPostgresDSN returns the formatted connection string based on environment variables.
+// It prioritizes DATABASE_URL if set, otherwise it uses DB_HOST, DB_PORT, etc.
+func GetPostgresDSN() (string, error)
+```
+
+## Comparison / Alternatives Considered
+
+| Feature | Ad-Hoc Configuration (Old) | Shared `db` Module (Proposed) |
+| :--- | :--- | :--- |
+| **Consistency** | High risk of drift | Enforced by library |
+| **Maintenance** | Manual updates in all services | Centralized in `pkg/db` |
+| **Timezone** | Manual/Inconsistent | Forced `UTC` by default |
+| **Simplicity** | Boilerplate in every `main.go` | Clean service initialization |
+
+## Failure Modes (Operational Excellence)
+
+- **Missing Configuration:** If required environment variables are missing, the module returns a descriptive error.
+- **Dependency Bloat:** The module does not import SQL drivers, ensuring it remains lightweight and compatible with any driver (`lib/pq`, `pgx`, etc.) chosen by the service.
+
+## Conclusion
+
+Standardizing database configuration is a critical step towards architectural maturity. It ensures that all services interact with the persistence layer in a predictable, consistent, and observable manner.

--- a/page/content/data.yaml
+++ b/page/content/data.yaml
@@ -86,3 +86,12 @@ evolution:
       description: |
         - Automated reading analytics ingestion using systemd timers for reliable, journal-backed scheduling.
         - Validated GitOps strategy for automated repository synchronization and configuration management.
+    - date: "2026-01-09"
+      title: "Standardized Postgres Database Configuration"
+      artifacts:
+        - name: "RFC 006: Shared Database Connection"
+          url: "docs/decisions/006-shared-database-module.md"
+      description: |
+        - Centralized database connection logic into a shared module (pkg/db) to ensure consistency.
+        - Enforced standardized defaults (e.g., UTC timezone) for all service database interactions.
+        - Refactored proxy and system-metrics to consume the shared database module.

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// GetPostgresDSN returns the formatted connection string based on environment variables.
+// It prioritizes DATABASE_URL if set. Otherwise, it constructs the DSN from:
+// DB_HOST, DB_PORT, DB_USER, SERVER_DB_PASSWORD, DB_NAME.
+// It enforces critical defaults like timezone=UTC and sslmode=disable.
+func GetPostgresDSN() (string, error) {
+	if dsn := os.Getenv("DATABASE_URL"); dsn != "" {
+		// If DATABASE_URL is provided, we assume it's correctly formatted.
+		// We could append defaults, but usually DATABASE_URL is self-contained.
+		return dsn, nil
+	}
+
+	host := getEnv("DB_HOST", "")
+	port := getEnv("DB_PORT", "5432")
+	user := getEnv("DB_USER", "")
+	password := os.Getenv("SERVER_DB_PASSWORD")
+	dbname := getEnv("DB_NAME", "")
+
+	if host == "" || user == "" || dbname == "" || password == "" {
+		var missing []string
+		if host == "" {
+			missing = append(missing, "DB_HOST")
+		}
+		if user == "" {
+			missing = append(missing, "DB_USER")
+		}
+		if dbname == "" {
+			missing = append(missing, "DB_NAME")
+		}
+		if password == "" {
+			missing = append(missing, "SERVER_DB_PASSWORD")
+		}
+		return "", fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
+	}
+
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable timezone=UTC",
+		host, port, user, password, dbname,
+	), nil
+}
+
+func getEnv(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/pkg/db/go.mod
+++ b/pkg/db/go.mod
@@ -1,0 +1,3 @@
+module db
+
+go 1.25.2

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -3,12 +3,15 @@ module proxy
 go 1.25.2
 
 require (
+	db v0.0.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 	go.mongodb.org/mongo-driver v1.17.6
 	logger v0.0.0
 )
+
+replace db => ../pkg/db
 
 replace logger => ../pkg/logger
 

--- a/proxy/utils/dbConnection.go
+++ b/proxy/utils/dbConnection.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -11,6 +10,8 @@ import (
 	_ "github.com/lib/pq"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"db"
 )
 
 func getEnv(key, fallback string) string {
@@ -30,16 +31,11 @@ func getRequiredEnv(key string) string {
 }
 
 func InitPostgres(driverName string) *sql.DB {
-	host := getRequiredEnv("DB_HOST")
-	port := getEnv("DB_PORT", "5432")
-	user := getRequiredEnv("DB_USER")
-	password := os.Getenv("SERVER_DB_PASSWORD")
-	dbname := getRequiredEnv("DB_NAME")
-
-	connStr := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable timezone=UTC",
-		host, port, user, password, dbname,
-	)
+	connStr, err := db.GetPostgresDSN()
+	if err != nil {
+		slog.Error("db_config_failed", "error", err)
+		os.Exit(1)
+	}
 
 	// If using sqlmock, the connection string might need to be ignored or specific
 	// For now, we keep the logic as is.

--- a/system-metrics/go.mod
+++ b/system-metrics/go.mod
@@ -3,11 +3,14 @@ module system-metrics
 go 1.25.2
 
 require (
+	db v0.0.0
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/joho/godotenv v1.5.1
 	github.com/shirou/gopsutil/v4 v4.25.11
 	logger v0.0.0
 )
+
+replace db => ../pkg/db
 
 replace logger => ../pkg/logger
 

--- a/system-metrics/main_test.go
+++ b/system-metrics/main_test.go
@@ -2,52 +2,27 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
+
+	"db"
 )
 
-func TestGetEnv(t *testing.T) {
-	tests := []struct {
-		name     string
-		key      string
-		val      string
-		fallback []string
-		expected string
-	}{
-		{"existing env", "TEST_ENV_VAR", "hello", nil, "hello"},
-		{"missing with fallback", "MISSING_VAR", "", []string{"world"}, "world"},
-		{"missing without fallback", "MISSING_VAR", "", nil, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.val != "" {
-				os.Setenv(tt.key, tt.val)
-				defer os.Unsetenv(tt.key)
-			} else {
-				os.Unsetenv(tt.key)
-			}
-
-			result := getEnv(tt.key, tt.fallback...)
-			if result != tt.expected {
-				t.Errorf("getEnv(%s) = %s, want %s", tt.key, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestGetConnStr_DatabaseURL(t *testing.T) {
+func TestGetPostgresDSN_DatabaseURL(t *testing.T) {
 	os.Setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/db")
 	defer os.Unsetenv("DATABASE_URL")
 
 	expected := "postgres://user:pass@localhost:5432/db"
-	if result := getConnStr(); result != expected {
-		t.Errorf("getConnStr() = %s, want %s", result, expected)
+	result, err := db.GetPostgresDSN()
+	if err != nil {
+		t.Errorf("GetPostgresDSN() error = %v", err)
+	}
+	if result != expected {
+		t.Errorf("GetPostgresDSN() = %s, want %s", result, expected)
 	}
 }
 
-func TestGetConnStr_Parts(t *testing.T) {
+func TestGetPostgresDSN_Parts(t *testing.T) {
 	os.Unsetenv("DATABASE_URL")
 	os.Setenv("DB_HOST", "localhost")
 	os.Setenv("DB_USER", "testuser")
@@ -60,30 +35,33 @@ func TestGetConnStr_Parts(t *testing.T) {
 		os.Unsetenv("SERVER_DB_PASSWORD")
 	}()
 
-	result := getConnStr()
+	result, err := db.GetPostgresDSN()
+	if err != nil {
+		t.Errorf("GetPostgresDSN() error = %v", err)
+	}
 	if !strings.Contains(result, "host=localhost") ||
 		!strings.Contains(result, "user=testuser") ||
 		!strings.Contains(result, "dbname=testdb") ||
 		!strings.Contains(result, "password=secret") {
-		t.Errorf("getConnStr() returned unexpected string: %s", result)
+		t.Errorf("GetPostgresDSN() returned unexpected string: %s", result)
 	}
 }
 
-func TestGetConnStr_MissingRequired(t *testing.T) {
-	// Subprocess test for log.Fatal
-	if os.Getenv("BE_CRASHER") == "1" {
-		os.Unsetenv("DATABASE_URL")
+func TestGetPostgresDSN_MissingRequired(t *testing.T) {
+	os.Unsetenv("DATABASE_URL")
+	os.Unsetenv("DB_HOST")
+	os.Unsetenv("DB_USER")
+	os.Unsetenv("DB_NAME")
+	os.Unsetenv("SERVER_DB_PASSWORD")
+	defer func() {
 		os.Unsetenv("DB_HOST")
-		getConnStr()
-		return
-	}
+		os.Unsetenv("DB_USER")
+		os.Unsetenv("DB_NAME")
+		os.Unsetenv("SERVER_DB_PASSWORD")
+	}()
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestGetConnStr_MissingRequired")
-	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
-	err := cmd.Run()
-
-	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
-		return
+	_, err := db.GetPostgresDSN()
+	if err == nil {
+		t.Error("GetPostgresDSN() expected error for missing env vars, got nil")
 	}
-	t.Fatalf("process ran with err %v, want exit status 1", err)
 }


### PR DESCRIPTION
### Summary

Extracted the database connection configuration logic into a new shared module `pkg/db` to eliminate code duplication and enforce consistent defaults (e.g., UTC timezone) across the `proxy` and `system-metrics` services. This change implements [RFC 006: Shared Database Configuration Module](docs/decisions/006-shared-database-module.md).

### List of Changes

- **Docs:** Added ADR 006 documenting the decision to centralize database configuration.
- **Page:** Updated `page/content/data.yaml` to include the timeline entry for RFC 006.
- **Pkg:** Created `pkg/db` with `GetPostgresDSN()` to standardize connection strings and environment variable parsing.
- **Proxy:** Updated `utils/dbConnection.go` to use the shared `db` package.
- **System Metrics:** Refactored `main.go` to use `db.GetPostgresDSN()` and removed redundant `getConnStr` logic.
- **Build:** Updated `go.mod` in both services to reference `pkg/db` via local replacement.
- **Makefile:** Updated `go-format` target to include `./pkg` directory.

### Verification

- [x] Ran `make go-format` to ensure code formatting.
- [x] Ran `go test ./proxy/...` to ensure proxy service's tests pass.
- [x] Ran `go test ./system-metrics/...` to ensure system-metrics service's tests pass.
- [x] Manual check: Verified `proxy` and `system-metrics` services start and connect to PostgreSQL successfully.