### PR TITLE
feat(promtail): enable systemd journal log scraping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 help:
 	@echo "Available commands:"
 	@echo "  make rfc                - Create a new RFC (Architecture Decision Record)"
+	@echo "  make up                 - Start all docker containers"
+	@echo "  make down               - Stop all docker containers"
 	@echo "  make create             - Create necessary docker volumes"
 	@echo "  make backup             - Backup docker volumes"
 	@echo "  make restore            - Restore docker volumes from backup"
@@ -19,6 +21,13 @@ help:
 # Architecture Decision Record Creation
 rfc:
 	@./scripts/create_rfc.sh
+
+# Docker Compose Management
+up:
+	@docker compose up -d
+
+down:
+	@docker compose down
 
 # Docker Volume Management
 create:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,13 +45,15 @@ services:
     logging: *default-logging
 
   promtail:
-    image: grafana/promtail:latest
+    image: grafana/promtail:2.9.17
     container_name: promtail_server
     volumes:
       - ./docker/promtail/promtail-config.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - promtail_data:/var/lib/promtail
+      - /var/log/journal:/var/log/journal:ro
+      - /etc/machine-id:/etc/machine-id:ro
     command: -config.file=/etc/promtail/config.yaml
     depends_on:
       - loki

--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -13,7 +13,6 @@ scrape_configs:
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
         refresh_interval: 5s
-    
     # Pipeline stages parse the content of the log line
     pipeline_stages:
       - json:
@@ -53,3 +52,25 @@ scrape_configs:
       - source_labels: ['__meta_docker_container_id']
         target_label: '__path__'
         replacement: '/var/lib/docker/containers/$1/*-json.log'
+  - job_name: systemd-journal
+    journal:
+      max_age: 48h
+      path: /var/log/journal
+      labels:
+        job: systemd-journal
+    relabel_configs:
+      # Extract the Systemd Unit name (e.g., gitops-sync@observability-hub.service)
+      - source_labels: ['__journal__systemd_unit']
+        target_label: 'unit'
+    pipeline_stages:
+      # 1. Filter: Drop everything NOT from our custom project services
+      - match:
+          selector: '{unit!~"(gitops-sync@.+|reading-sync|system-metrics).service"}'
+          action: drop
+      # 2. Parse: Extract our custom Logfmt fields
+      - regex:
+          expression: 'repo=(?P<repo>\S+) level=(?P<level>\S+) msg="(?P<msg>.*)"'
+      # 3. Label: Promote extracted fields to indexed labels for Grafana querying
+      - labels:
+          repo:
+          level:

--- a/page/content/data.yaml
+++ b/page/content/data.yaml
@@ -106,3 +106,8 @@ evolution:
       description: |
         - Implemented a secure GitOps reconciliation engine using templated Systemd units (@) to automate repository synchronization.
         - Adopted an "Allowlist" pattern for repository access control and "Logfmt" for native observability integration.
+    - date: "2026-01-11"
+      title: "Initial Systemd Log Ingestion via Promtail" 
+      description: |
+        - Established a pipeline to ingest systemd journal logs into Loki using Promtail, providing foundational observability for host-level services.
+        - Implemented initial log parsing and labeling for key systemd units (gitops-sync, reading-sync, and system-metrics).


### PR DESCRIPTION
### Summary

This change enables the containerized Promtail service to scrape `systemd` journal logs from the host. This allows logs from `systemd` services (e.g., `gitops-sync`, `reading-sync`) to be collected in Loki, making them available for querying and visualization in Grafana. The implementation involved updating the Promtail image to a version with `journald` support, adding the necessary volume mounts, and configuring a new scrape job. Additionally, a new event has been added to the project's evolution timeline to document this milestone.

### List of Changes

- **`docker-compose.yml`**
  - Pinned the `promtail` image to `grafana/promtail:2.9.17` to ensure a stable version with `journald` support is used.
  - Mounted `/var/log/journal` and `/etc/machine-id` as read-only volumes into the `promtail` container to grant access to host journal logs.

- **`docker/promtail/promtail-config.yaml`**
  - Added a new `systemd-journal` scrape job to read from the host's journal.
  - Configured a pipeline to filter for project-specific services (`gitops-sync`, `reading-sync`, `system-metrics`).
  - Added a regex parsing stage to extract structured `repo` and `level` fields from log messages, and promoted them to indexed labels.

- **`Makefile`**
  - Added `up` and `down` convenience targets for managing the Docker Compose stack.

- **`page/content/data.yaml`**
  - Added a new event to the `evolution` timeline with the title "Initial Systemd Log Ingestion via Promtail" and dated "2026-01-11". The description was revised to reflect the establishment of a pipeline for foundational observability.

### Verification

- [x] Verified in Grafana that logs with the label `{job="systemd-journal"}` are being received by Loki.
- [x] Confirmed that a time series visualization using `sum by (unit) (count_over_time({job="systemd-journal"}[$__interval]))` correctly displays separate lines for each `systemd` service.
- [x] Inspected `promtail` container logs to ensure the warning about `journald` support not being compiled was no longer present after updating the image.