### PR TITLE
feat(scripts): add local branch cleanup to gitops sync

### DIFF
--- a/scripts/gitops_sync.sh
+++ b/scripts/gitops_sync.sh
@@ -67,3 +67,15 @@ else
     # INFO level can be filtered out in Grafana to reduce noise
     log "INFO" "Already in sync."
 fi
+
+# 3. Cleanup Logic (delete all local branches except main)
+log "INFO" "Cleaning up local branches..."
+
+LOCAL_BRANCHES=$(git branch --format='%(refname:short)' 2>/dev/null | grep -v '^main$' || true)
+if [[ -n "$LOCAL_BRANCHES" ]]; then
+    log "INFO" "Local branches to delete: ${LOCAL_BRANCHES}"
+    echo "$LOCAL_BRANCHES" | xargs -r git branch -D
+    log "SUCCESS" "Deleted local branches: ${LOCAL_BRANCHES}"
+else
+    log "INFO" "No local branches to delete"
+fi


### PR DESCRIPTION
### Summary

Updated `scripts/gitops_sync.sh` to automatically delete any local branches other than `main` after a successful sync. This ensures the execution environment remains clean and prevents the accumulation of stale feature branches on the deployment server.

### List of Changes

- Added a cleanup section to `scripts/gitops_sync.sh`.
- Implemented logic to identify local branches excluding `main`.
- Added `xargs` pipeline to delete (`git branch -D`) identified stale branches.
- Added structured logging for the cleanup operation.

### Verification

- [x] Ran the script in a repository with multiple local branches.
- [x] Verified that `main` remained untouched.