### PR TITLE
feat(scripts): add safety check for uncommitted changes in gitops sync

### DIFF
--- a/scripts/gitops_sync.sh
+++ b/scripts/gitops_sync.sh
@@ -41,6 +41,12 @@ fi
 # 2. Sync Logic
 cd "$REPO_PATH"
 
+# Safety Barrier: Check for uncommitted changes
+if [[ -n $(git status --porcelain) ]]; then
+    log "ERROR" "Uncommitted changes detected. Aborting sync to prevent data loss."
+    exit 1
+fi
+
 TARGET_BRANCH="main"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
### Summary

Introduces a safety barrier in the GitOps synchronization script to ensure the repository is in a clean state before performing sync operations. This prevents potential data loss or merge conflicts during automated syncs.

### List of Changes

- scripts/gitops_sync.sh: Added a check using `git status --porcelain` to detect uncommitted changes.
- scripts/gitops_sync.sh: Implemented a "fail-fast" mechanism that aborts the sync if the working directory is dirty.
- scripts/gitops_sync.sh: Added structured logging for the error state to facilitate troubleshooting via Loki.

### Verification

- [x] Manually verified that the script exits with an error when there are uncommitted changes.
- [x] Manually verified that the script continues to sync when the repository is clean.
