### PR TITLE
feat(scripts): reorder sync logic to switch branch before safety check

### DIFF
--- a/scripts/gitops_sync.sh
+++ b/scripts/gitops_sync.sh
@@ -47,9 +47,15 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]]; then
     log "WARN" "Current branch ($CURRENT_BRANCH) is not $TARGET_BRANCH. Switching..."
     if ! git checkout "$TARGET_BRANCH"; then
-        log "ERROR" "Failed to switch to $TARGET_BRANCH. Check for uncommitted changes."
+        log "ERROR" "Failed to switch to $TARGET_BRANCH. Check for uncommitted changes or conflicts."
         exit 1
     fi
+fi
+
+# Safety Barrier: Check for uncommitted changes AFTER switching
+if [[ -n $(git status --porcelain) ]]; then
+    log "ERROR" "Uncommitted changes detected. Aborting sync to prevent data loss."
+    exit 1
 fi
 
 if ! git fetch origin "$TARGET_BRANCH" --quiet; then


### PR DESCRIPTION
### Summary

Enhances the reliability of the GitOps synchronization script by ensuring the repository attempts to switch to the target branch (main) before verifying the cleanliness of the working directory. This allows the script to recover automatically when left on a clean feature branch.

### List of Changes

- scripts/gitops_sync.sh: Moved `git checkout` logic before the uncommitted changes check.
- scripts/gitops_sync.sh: Implemented a safety barrier using `git status --porcelain` after ensuring the correct branch is active.
- scripts/gitops_sync.sh: Updated error messages to be more descriptive regarding branch switch failures and potential conflicts.

### Verification

- [x] Verified script aborts with "ERROR" when uncommitted changes are present after switching.
- [x] Verified successful sync (`git pull`) when on main with no changes.
