### PR TITLE
feat(observability): standardize structured logging across Go and Bash services

### DIFF
--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -67,10 +67,15 @@ scrape_configs:
       - match:
           selector: '{unit!~"(gitops-sync@.+|reading-sync|system-metrics).service"}'
           action: drop
-      # 2. Parse: Extract our custom Logfmt fields
-      - regex:
-          expression: 'repo=(?P<repo>\S+) level=(?P<level>\S+) msg="(?P<msg>.*)"'
-      # 3. Label: Promote extracted fields to indexed labels for Grafana querying
+      # 2. Parse: Expect JSON from all our services (Go & Bash)
+      - json:
+          expressions:
+            level: level
+            service: service
+            msg: msg
+            repo: repo
+      # 3. Label: Promote fields to indexed labels
       - labels:
-          repo:
           level:
+          service:
+          repo:

--- a/proxy/utils/logging.go
+++ b/proxy/utils/logging.go
@@ -10,14 +10,33 @@ import (
 func WithLogging(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		// We could wrap ResponseWriter to capture status code, but for now we keep it simple
-		next(w, r)
+
+		// Wrap the ResponseWriter to capture the status code
+		lrw := newLoggingResponseWriter(w)
+
+		next(lrw, r)
 
 		slog.Info("request_processed",
 			"http_method", r.Method,
 			"path", r.URL.Path,
 			"remote_ip", r.RemoteAddr,
+			"status", lrw.statusCode,
 			"duration", time.Since(start).String(),
 		)
 	}
+}
+
+// loggingResponseWriter wraps http.ResponseWriter to capture the status code.
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func newLoggingResponseWriter(w http.ResponseWriter) *loggingResponseWriter {
+	return &loggingResponseWriter{w, http.StatusOK}
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(code int) {
+	lrw.statusCode = code
+	lrw.ResponseWriter.WriteHeader(code)
 }

--- a/scripts/gitops_sync.sh
+++ b/scripts/gitops_sync.sh
@@ -5,11 +5,17 @@ REPO_NAME=${1:-""}
 ALLOWED_REPOS=("observability-hub")
 BASE_DIR="/home/server/software"
 
-# Log helper to make Grafana/Loki filtering easy
+# Log helper using jq for safe JSON generation
+# Ensures newlines and quotes in 'msg' are properly escaped
 log() {
     local level=$1
     local msg=$2
-    echo "repo=${REPO_NAME:-unknown} level=${level} msg=\"${msg}\""
+    jq -n -c \
+        --arg service "gitops-sync" \
+        --arg repo "${REPO_NAME:-unknown}" \
+        --arg level "$level" \
+        --arg msg "$msg" \
+        '{service: $service, repo: $repo, level: $level, msg: $msg}'
 }
 
 # 1. Validation Logic (Security Barrier)
@@ -46,7 +52,7 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]]; then
     log "WARN" "Current branch ($CURRENT_BRANCH) is not $TARGET_BRANCH. Switching..."
-    if ! git checkout "$TARGET_BRANCH"; then
+    if ! git checkout "$TARGET_BRANCH" >/dev/null 2>&1; then
         log "ERROR" "Failed to switch to $TARGET_BRANCH. Check for uncommitted changes or conflicts."
         exit 1
     fi
@@ -68,7 +74,17 @@ REMOTE_HASH=$(git rev-parse origin/main)
 
 if [[ "$LOCAL_HASH" != "$REMOTE_HASH" ]]; then
     log "SUCCESS" "New changes detected. Synchronizing..."
-    git pull origin main
+    # Capture output to prevent raw text leaking to stdout (which breaks JSON parsing)
+    if OUTPUT=$(git pull origin main 2>&1); then
+        # Truncate output to protect JSON integrity in journald (max 2KB)
+        SAFE_OUTPUT=$(echo "$OUTPUT" | head -c 2048)
+        if [[ ${#OUTPUT} -gt 2048 ]]; then SAFE_OUTPUT="${SAFE_OUTPUT}... (truncated)"; fi
+        log "INFO" "$SAFE_OUTPUT"
+    else
+        SAFE_OUTPUT=$(echo "$OUTPUT" | head -c 2048)
+        log "ERROR" "Pull failed: $SAFE_OUTPUT"
+        exit 1
+    fi
 else
     # INFO level can be filtered out in Grafana to reduce noise
     log "INFO" "Already in sync."
@@ -78,8 +94,16 @@ fi
 LOCAL_BRANCHES=$(git branch --format='%(refname:short)' 2>/dev/null | grep -v '^main$' || true)
 if [[ -n "$LOCAL_BRANCHES" ]]; then
     log "INFO" "Local branches to delete: ${LOCAL_BRANCHES}"
-    echo "$LOCAL_BRANCHES" | xargs -r git branch -D
-    log "SUCCESS" "Deleted local branches: ${LOCAL_BRANCHES}"
+    # Capture output of branch deletion
+    if OUTPUT=$(echo "$LOCAL_BRANCHES" | xargs -r git branch -D 2>&1); then
+        SAFE_OUTPUT=$(echo "$OUTPUT" | head -c 2048)
+        if [[ ${#OUTPUT} -gt 2048 ]]; then SAFE_OUTPUT="${SAFE_OUTPUT}... (truncated)"; fi
+        log "INFO" "$SAFE_OUTPUT"
+        log "SUCCESS" "Deleted local branches: ${LOCAL_BRANCHES}"
+    else
+        SAFE_OUTPUT=$(echo "$OUTPUT" | head -c 2048)
+        log "WARN" "Failed to delete some branches: $SAFE_OUTPUT"
+    fi
 else
     log "INFO" "No local branches to delete"
 fi


### PR DESCRIPTION
### Summary

This change standardizes the logging pipeline by ensuring all core services (Go-based proxy and Bash-based GitOps scripts) output structured JSON. It also refines observability by capturing HTTP status codes in the proxy middleware and updating Promtail to use a unified JSON parsing stage for Systemd journal logs, while safeguarding against log truncation issues.

### List of Changes

- **Proxy Service**: Added `loggingResponseWriter` middleware to capture and log HTTP status codes, enabling SLI (Service Level Indicator) tracking for error rates.
- **GitOps Script**:
  - Refactored `gitops_sync.sh` to use `jq` for generating safe, structured JSON logs.
  - Implemented output truncation (max 2KB) for `git pull` and `git branch -D` commands to prevent excessively long lines from being cut by `journald`, which previously caused JSON parsing failures (`JSONParserErr`) in Promtail.
- **Promtail Configuration**: Updated the `systemd-journal` scrape config to use the `json` pipeline stage, promoting common fields (`level`, `service`, `repo`) to indexed labels.

### Verification

- **Unit Tests**: Verified `proxy/utils` tests pass with the new logging wrapper.
- **Manual Check**: Executed `gitops_sync.sh` manually and confirmed valid JSON output even with command output.
- **Infrastructure Check**: Inspected `promtail_server` and `loki_server` logs to confirm configuration reload and successful processing of JSON log streams without `JSONParserErr`.