### PR TITLE
fix(observability): update promtail filter to include proxy service logs

### DIFF
--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -65,7 +65,7 @@ scrape_configs:
     pipeline_stages:
       # 1. Filter: Drop everything NOT from our custom project services
       - match:
-          selector: '{unit!~"(gitops-sync@.+|reading-sync|system-metrics).service"}'
+          selector: '{unit!~"(gitops-sync@.+|proxy|system-metrics).service"}'
           action: drop
       # 2. Parse: Expect JSON from all our services (Go & Bash)
       - json:


### PR DESCRIPTION
### Summary

Updates the Promtail configuration to ingest logs from the `proxy` service via systemd-journal. The `reading-sync` entry is replaced by `proxy` to better align with the architecture where sync logs are handled through the proxy's API.

### List of Changes

- **docker/promtail/promtail-config.yaml**:
  - Replaced `reading-sync` with `proxy` in the allowed systemd unit selector.

### Verification

- [x] Manual Check: Confirm `reading-sync` logs (via proxy) are still searchable.