### PR TITLE
feat(ops): kickoff phase 2 with multi-repo gitops and symlinked infra

### DIFF
--- a/page/content/evolution.yaml
+++ b/page/content/evolution.yaml
@@ -69,3 +69,8 @@ timeline:
     description: |
       - Established a pipeline to ingest systemd journal logs into Loki using Promtail, providing foundational observability for host-level services.
       - Implemented initial log parsing and labeling for key systemd units (gitops-sync, reading-sync, and system-metrics).
+  - date: "2026-01-14"
+    title: "Phase 2 Kickoff: Multi-Repo Expansion"
+    description: |
+      - Expanded the GitOps reliability boundary to include the 'mehub' repository, validating the multi-tenant capability of the sync engine.
+      - Optimized the reconciliation interval from 5m to 15m to balance freshness with operational stability.

--- a/scripts/gitops_sync.sh
+++ b/scripts/gitops_sync.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_NAME=${1:-""}
-ALLOWED_REPOS=("observability-hub")
+ALLOWED_REPOS=("observability-hub" "mehub")
 BASE_DIR="/home/server/software"
 
 # Log helper using jq for safe JSON generation

--- a/systemd/gitops-sync@.timer
+++ b/systemd/gitops-sync@.timer
@@ -1,8 +1,8 @@
 [Unit]
-Description=Run GitOps Sync for %i every 5 minutes
+Description=Run GitOps Sync for %i every 15 minutes
 
 [Timer]
-OnUnitActiveSec=5m
+OnUnitActiveSec=15m
 Unit=gitops-sync@%i.service
 
 [Install]


### PR DESCRIPTION
### Summary

Transitioned the infrastructure management to a symlink-based "Source of Truth" model and officially launched Phase 2 of the GitOps expansion by onboarding the `mehub` repository and optimizing sync intervals.

### List of Changes

- **Infrastructure (Makefile):**
  - Refactored `install-services` to use symlinks (`ln -sf`) instead of copies, ensuring the repository is the single source of truth for systemd units.
  - Improved `uninstall-services` to robustly handle template instances and cleanup.
- **GitOps Engine:**
  - Onboarded `mehub` to the repository allowlist.
  - Optimized the reconciliation timer from 5m to 15m for improved operational stability.
- **Observability (Promtail & Go):**
  - Optimized Promtail ingestion using early-drop relabeling filters.
  - Automated `service` label extraction from systemd units.
  - Refactored `reading-sync` handler with context propagation and enriched JSON metadata.
- **Documentation:**
  - Updated `evolution.yaml` to record the Phase 2 kickoff.

### Verification

- [x] manual check: `make install-services` correctly creates symlinks in `/etc/systemd/system/`.
- [x] manual check: `gitops-sync@mehub.timer` is active and running on a 15m interval.
- [x] manual check: Promtail correctly labels logs from new units in Grafana.
- [x] manual check: `reading-sync` API response includes enriched metadata and respects context.