### PR TITLE
docs(arch): sync architecture diagrams and document systemd automation

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,23 +8,24 @@ The hub integrates standard observability tools with custom Go services.
 
 ```mermaid
 graph TD
-    subgraph "Host Environment"
-        Hardware[Host Hardware]
-        Docker[Docker Containers]
-        GitOpsAgent[GitOps Reconciliation Agent]
+    subgraph "External Sources"
+        Apps[Client Apps]
+        Mongo[(MongoDB Atlas)]
     end
 
-    subgraph "External Data"
-        Mongo[(MongoDB)]
+    subgraph "Host Environment"
+        Hardware[Host Hardware]
+        HostServices[Host Systemd Services]
     end
 
     subgraph "Observability Hub"
         direction TB
         
-        subgraph "Collection"
+        subgraph "Collection & ETL"
             Metrics[System Metrics Collector]
-            Promtail[Promtail Agent]
+            Sync[Reading Sync Service]
             Proxy[Proxy Service / ETL]
+            Promtail[Promtail]
         end
 
         subgraph "Storage"
@@ -33,23 +34,32 @@ graph TD
         end
 
         subgraph "Visualization"
-            Grafana[Grafana Dashboard]
+            Grafana[Grafana]
         end
     end
 
-    %% Data Flows
-    Hardware -->|Stats: CPU, RAM, Disk, Memory| Metrics
+    %% Application Data Flow
+    Apps -->|Events| Mongo
+    Sync -->|Triggers ETL| Proxy
+    Mongo -->|Reads Events| Proxy
+    Proxy -->|Writes Structured Data| PG
+
+    %% System Metrics Flow
+    Hardware -->|Stats: CPU, RAM, Disk, Net| Metrics
     Metrics -->|Writes Metrics| PG
-    
-    Mongo -->|Reads 'ingested' docs| Proxy
-    Proxy -->|Writes Analytics| PG
-    
-    Docker -->|Logs| Promtail
+
+    %% GitOps & Automation
+    HostServices -->|Manages| Metrics
+    HostServices -->|Manages| Sync
+
+    %% Logging Flow
+    Proxy -.->|Docker Logs| Promtail
+    HostServices -.->|Systemd Logs| Promtail
+    Metrics -.->|Systemd Logs| Promtail
     Promtail -->|Pushes Logs| Loki
-    
-    GitOpsAgent -->|Manages Code Synchronization| Hardware
-    
-    PG -->|Query Metrics| Grafana
+
+    %% Visualization
+    PG -->|Query Data| Grafana
     Loki -->|Query Logs| Grafana
 ```
 
@@ -57,9 +67,10 @@ graph TD
 
 | Component | Description |
 | :----------- | :------------- |
-| **[Proxy Service](./proxy-service.md)** | Architecture of the Go-based API Gateway and ETL Engine. It bridges external data sources with the PostgreSQL. |
+| **[Proxy Service](./proxy-service.md)** | Architecture of the Go-based API Gateway and ETL Engine. Bridges external data (MongoDB) with PostgreSQL via triggered sync. |
 | **[System Metrics](./system-metrics.md)** | Details on the custom host telemetry collector (`gopsutil`). Pushes data directly to the `system_metrics` table in PostgreSQL (TimescaleDB). |
 | **[Infrastructure](./infrastructure.md)** | Deployment (Docker), Storage (Postgres/Loki), and Security config. |
+| **[Systemd Services](./systemd-services.md)** | Automation architecture for GitOps, ETL triggers, and telemetry using systemd units and timers. |
 | **[GitOps Reconciliation](./../decisions/005-gitops-reconciliation-engine.md)** | Systemd-driven agent for automated, self-healing repository synchronization. |
 
 ## Related Documentation

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -16,12 +16,14 @@ The infrastructure layer manages storage, log aggregation, and visualization, or
 
 ```mermaid
 sequenceDiagram
-    participant Apps as Apps/Containers
+    participant Containers as Docker Containers
+    participant Systemd as Systemd Services
     participant Promtail as Promtail
     participant Loki as Loki
     participant Grafana as Grafana
 
-    Apps->>Promtail: Write to stdout/stderr
+    Containers->>Promtail: Write stdout/stderr
+    Systemd->>Promtail: Write Journal Logs
     Promtail->>Loki: Push logs with labels
     Grafana->>Loki: LogQL Query
     Loki-->>Grafana: Return log streams

--- a/docs/architecture/systemd-services.md
+++ b/docs/architecture/systemd-services.md
@@ -1,0 +1,67 @@
+# Systemd Service Architecture
+
+The Observability Hub leverages **Systemd** not just for process management, but as a core automation and reconciliation engine. By running lightweight agents and timers directly on the host, we ensure reliability independent of the Docker container runtime.
+
+## Core Philosophy
+
+- **Decoupling**: Critical maintenance (like GitOps sync) runs outside containers to avoid "circular dependencies" (e.g., waiting for Docker to start to fix a Docker config).
+- **Native Scheduling**: We use `systemd` timers instead of cron for better logging, dependency management, and accuracy.
+- **Unified Logging**: All services emit logs to `standard output`, which are captured by `journald` and scraped by Promtail.
+
+## Service Inventory
+
+The system consists of three main service families, each with a `.service` unit (the logic) and a `.timer` unit (the schedule).
+
+| Service Name | Type | Schedule | Responsibility |
+| :--- | :--- | :--- | :--- |
+| **`gitops-sync`** | `oneshot` | Every 15 min | **Reconciliation**: Pulls the latest Git code and applies changes (e.g., reloading units, syncing scripts). |
+| **`reading-sync`** | `oneshot` | Daily (10:00 AM) | **ETL Trigger**: Calls the Proxy Service API (`/api/sync/reading`) to sync MongoDB data to Postgres. |
+| **`system-metrics`** | `oneshot` | Every 1 min | **Telemetry**: Collects host hardware stats (CPU/RAM/Disk/Net) and flushes them to the database. |
+
+## Operational Excellence (Senior+ Patterns)
+
+Our systemd configurations employ several production-grade patterns:
+
+- **Persistence (`Persistent=true`)**: Used in `reading-sync`. If the host is powered off during the scheduled time (10:00 AM), systemd will trigger the service immediately upon the next boot.
+- **Jitter (`RandomizedDelaySec`)**: Prevents "thundering herd" issues by adding a random delay (up to 30 mins for `reading-sync`) to the start time, which is critical when multiple instances are managed across a fleet.
+- **Accuracy (`AccuracySec=1s`)**: Used in `system-metrics` to ensure high-fidelity sampling intervals for time-series data.
+
+## Architectural Patterns
+
+### 1. The "Timer-Trigger" Pattern
+
+For periodic tasks like ETL or GitOps, we use the `oneshot` service pattern triggered by a timer. This ensures:
+
+- **Idempotency**: Services are designed to run, complete their task, and exit.
+- **Resilience**: If a job fails, systemd handles the retry logic or logs the failure state without crashing a long-running daemon.
+
+```mermaid
+sequenceDiagram
+    participant Timer as Systemd Timer
+    participant Service as Systemd Service
+    participant Target as External Target
+    participant Journal as Journald
+
+    Timer->>Service: Trigger Start
+    Service->>Target: Perform Action
+    Target-->>Service: Result
+    Service->>Journal: Log Output
+    Service-->>Timer: Exit
+```
+
+### 2. Logging & Observability Integration
+
+Unlike traditional "write to file" approaches, our systemd units write strictly to `stdout`/`stderr`. This creates a unified pipeline:
+
+1. **Emission**: Service writes to `stdout`.
+2. **Capture**: `journald` captures the stream and adds metadata (timestamp, unit name, PID).
+3. **Collection**: Promtail (configured with `job_name: systemd-journal`) tails the journal.
+4. **Ingestion**: Promtail pushes logs to Loki for visualization in Grafana.
+
+## Configuration Structure
+
+All unit files are stored in the `systemd/` directory of the repository and are deployed/updated by the `gitops-sync` script itself.
+
+- **`[Unit]`**: Defines dependencies (e.g., `After=network.target`).
+- **`[Service]`**: Defines the `ExecStart` command and `User=server`.
+- **`[Install]`**: Defines the target (usually `multi-user.target`).


### PR DESCRIPTION
### Summary

This PR synchronizes the system architecture documentation across the repository to reflect the current state of the logging pipeline and ETL process. It introduces a dedicated architectural overview for host-level Systemd services, ensuring that automation patterns like GitOps and triggered ETL are properly documented.

### List of Changes

- **README.md**: Updated the primary architecture diagram to include "Client Apps" and "MongoDB Atlas". Added `reading-sync` to the component table and refined the "Data Flow" section to describe the triggered ETL pipeline and unified logging.
- **docs/architecture/README.md**: Aligned the system context diagram with the main README and added a reference to the new Systemd services documentation.
- **docs/architecture/infrastructure.md**: Updated the Promtail logging sequence diagram to explicitly include Systemd journal logs alongside Docker containers.
- **docs/architecture/systemd-services.md**: Created a new document detailing the "Timer-Trigger" pattern, service inventory, and operational best practices (Persistence, Jitter, Accuracy) for host automation.

### Verification

- Validated Mermaid diagram syntax in all updated files.
- Cross-referenced Systemd timer schedules with unit files in `systemd/`.
- Verified internal document linking and Markdown formatting.