### PR TITLE
docs(evolution): add missing artifacts to phase 2 gitops entry

### DIFF
--- a/page/content/evolution.yaml
+++ b/page/content/evolution.yaml
@@ -71,6 +71,9 @@ timeline:
       - Implemented initial log parsing and labeling for key systemd units (gitops-sync, reading-sync, and system-metrics).
   - date: "2026-01-14"
     title: "Phase 2 Kickoff: Multi-Repo Expansion"
+    artifacts:
+      - name: "RFC 005: GitOps Reconciliation"
+        url: "docs/decisions/005-gitops-reconciliation-engine.md"
     description: |
       - Expanded the GitOps reliability boundary to include the 'mehub' repository, validating the multi-tenant capability of the sync engine.
       - Optimized the reconciliation interval from 5m to 15m to balance freshness with operational stability.


### PR DESCRIPTION
### Summary

Updates the "Project Evolution" timeline in `evolution.yaml` to include missing artifact links for the "Phase 2 Kickoff: Multi-Repo Expansion" entry, ensuring traceability to the relevant RFC.

### List of Changes

- **page/content/evolution.yaml**: Added `artifacts` section linking to "RFC 005: GitOps Reconciliation" under the January 14th entry.

### Verification

- [x] Verified `evolution.yaml` syntax is correct.
- [x] Confirmed RFC 005 path exists.