### PR TITLE
fix(systemd): improve timer reliability after system reboot

### DIFF
--- a/systemd/gitops-sync@.timer
+++ b/systemd/gitops-sync@.timer
@@ -2,6 +2,7 @@
 Description=Run GitOps Sync for %i every 15 minutes
 
 [Timer]
+OnBootSec=5m
 OnUnitActiveSec=15m
 Unit=gitops-sync@%i.service
 

--- a/systemd/system-metrics.timer
+++ b/systemd/system-metrics.timer
@@ -4,6 +4,7 @@ Description=Timer for System Metrics Collection
 [Timer]
 OnCalendar=*:*:00
 AccuracySec=1s
+Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
### Summary

This change improves the reliability of systemd timers after a server reboot by ensuring they trigger even if the previous execution window was missed or the monotonic clock reset.

### List of Changes

- systemd: Added `OnBootSec=5m` to `gitops-sync@.timer` to initiate the sync loop after boot.
- systemd: Added `Persistent=true` to `system-metrics.timer` to ensure telemetry collection resumes immediately if the schedule was missed during downtime.

### Verification

- [x] `systemctl list-timers` shows active `NEXT` times for all units.
- [x] Verified `gitops-sync` triggered its first run after the manual restart.
- [x] Verified `system-metrics` continues to run every minute.