### PR TITLE
feat(scripts,systemd): implement throttled heartbeat and increase sync frequency

### DIFF
--- a/scripts/gitops_sync.sh
+++ b/scripts/gitops_sync.sh
@@ -102,6 +102,20 @@ if [[ "$LOCAL_HASH" != "$REMOTE_HASH" ]]; then
         log "ERROR" "Pull failed: $SAFE_OUTPUT"
         exit 1
     fi
+else
+    # Throttled heartbeat logging (Every 1 hour / 3600s)
+    THROTTLE_FILE="/tmp/gitops-sync-${REPO_NAME}.lastlog"
+    NOW=$(date +%s)
+    LAST_LOG=0
+
+    if [[ -f "$THROTTLE_FILE" ]]; then
+        LAST_LOG=$(cat "$THROTTLE_FILE")
+    fi
+
+    if (( NOW - LAST_LOG >= 3600 )); then
+        log "INFO" "Already in sync (Heartbeat)"
+        echo "$NOW" > "$THROTTLE_FILE"
+    fi
 fi
 
 # 3. Cleanup Logic (delete all local branches except main)

--- a/systemd/reading-sync.timer
+++ b/systemd/reading-sync.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Daily Sync for Reading Analytics
+Description=Twice Daily Sync for Reading Analytics
 
 [Timer]
-# Run every day at 10:00 AM
-OnCalendar=*-*-* 10:00:00
+# Run every 12 hours
+OnCalendar=*-*-* 00,12:00:00
 # Ensure catch-up if the machine was off
 Persistent=true
 # Prevent thundering herd (30m window)


### PR DESCRIPTION
### Summary

This PR enhances the observability and data freshness of the platform's automation. It introduces a throttled heartbeat for the GitOps synchronization to maintain visibility without log spam and doubles the frequency of reading analytics synchronization to ensure near-real-time updates.

### List of Changes

#### scripts/

- **gitops_sync.sh**: Implemented a stateful heartbeat logging mechanism. If the repository is already in sync, it will now only log a confirmation message once every hour (3600s), using a temporary file in `/tmp` to track the last log event.

#### systemd/

- **reading-sync.timer**: Increased synchronization frequency from once daily (10:00 AM) to twice daily (Midnight and Noon). Added `Twice Daily` to the description for clarity.

### Verification

- **Log Throttling**: Verified `scripts/gitops_sync.sh` manually. First run emits JSON log; subsequent runs within the hour are silent.
- **Timer Accuracy**: Verified `systemd/reading-sync.timer` with `systemd-analyze calendar` to confirm triggers at 00:00 and 12:00.
- **JSON Formatting**: Confirmed `jq` parsing of the new heartbeat log levels.