### PR TITLE
feat(ci): add label-based PR merge workflow

### DIFF
--- a/.github/workflows/label-merge.yml
+++ b/.github/workflows/label-merge.yml
@@ -1,0 +1,20 @@
+name: Label-Based PR Merge
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'merge'
+    steps:
+      - uses: victoriacheng15hub/platform-actions/merge-on-label@v0
+        with:
+          label: merge
+          merge_method: squash
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

Introduces a new GitHub Actions workflow that automates pull request merging based on the presence of a specific label (`merge`). This streamlines the review-to-merge lifecycle by reducing manual intervention.

### List of Changes

- Add `.github/workflows/label-merge.yml`: Configures the workflow to trigger on `pull_request_target` when labeled, using the `victoriacheng15hub/platform-actions/merge-on-label` action.

### Verification

- [x] Verified workflow syntax matches GitHub Actions standards.
- [x] Confirmed usage of `pull_request_target` is scoped to the `labeled` type and `merge` label for security.