### PR TITLE
fix(scripts): fix volume backup execution and enable promtail observability

### DIFF
--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -64,11 +64,11 @@ scrape_configs:
         target_label: 'unit'
       # 1. Early Drop: Only keep logs from our custom services
       - source_labels: ['unit']
-        regex: '(gitops-sync@.+|reading-sync|system-metrics)\.service'
+        regex: '(gitops-sync@.+|reading-sync|system-metrics|volume-backup)\.service'
         action: keep
       # 2. Robustness: Derive 'service' label directly from the Unit name
       - source_labels: ['unit']
-        regex: '(gitops-sync|reading-sync|system-metrics).*'
+        regex: '(gitops-sync|reading-sync|system-metrics|volume-backup).*'
         target_label: 'service'
         replacement: '$1'
     pipeline_stages:

--- a/scripts/manage_volume.sh
+++ b/scripts/manage_volume.sh
@@ -2,8 +2,17 @@
 set -euo pipefail
 
 # --- CONFIG ---
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BACKUP_BASE="/home/server/backups"
 RETENTION_DAYS=7
+
+# Ensure we are in the project root for docker compose commands
+cd "$PROJECT_ROOT"
+
+if [[ ! -f "docker-compose.yml" ]]; then
+    echo "Error: docker-compose.yml not found in $PROJECT_ROOT" >&2
+    exit 1
+fi
 
 # Embedded volume list as a clean Bash array
 VOLUMES=(

--- a/systemd/volume-backup.service
+++ b/systemd/volume-backup.service
@@ -5,6 +5,7 @@ After=docker.service
 
 [Service]
 Type=oneshot
+WorkingDirectory=/home/server/software/observability-hub
 ExecStart=/home/server/software/observability-hub/scripts/manage_volume.sh backup
 User=server
 


### PR DESCRIPTION
### Summary

Resolved an execution failure in `volume-backup.service` by implementing environment-aware path resolution in the backup script and enabling log ingestion in Promtail. This ensures the backup process is resilient to different execution contexts (Systemd vs. manual) and provides visibility into the backup status via Grafana.

### List of Changes

- **scripts/manage_volume.sh**: Added dynamic `PROJECT_ROOT` detection and explicit `cd` to ensure `docker compose` finds the configuration file regardless of execution context.
- **systemd/volume-backup.service**: Added `WorkingDirectory` as a redundant safety measure to align with project standards.
- **docker/promtail/promtail-config.yaml**: Whitelisted `volume-backup.service` in the `systemd-journal` scrape configuration to ensure logs are ingested into Loki.

### Verification

- Manual execution of `manage_volume.sh backup` from outside the project root (verified success).
- Systemd service trigger via `systemctl start volume-backup.service` (verified `SUCCESS` status).
- Promtail configuration reload verified via container logs.
- Log presence in Grafana confirmed (via user verification)