### PR TITLE
feat(gitops): add reading-analytics, platform-actions, and bioHub to sync allowlist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,9 @@ install-services:
 	@echo "Enabling GitOps for repos..."
 	@sudo systemctl enable --now gitops-sync@observability-hub.timer
 	@sudo systemctl enable --now gitops-sync@mehub.timer
+	@sudo systemctl enable --now gitops-sync@personal-reading-analytics.timer
+	@sudo systemctl enable --now gitops-sync@platform-actions.timer
+	@sudo systemctl enable --now gitops-sync@bioHub.timer
 	@echo "Installation complete."
 
 reload-services:
@@ -128,6 +131,9 @@ uninstall-services:
 	# 1. Explicitly handle known instances
 	@sudo systemctl disable --now gitops-sync@observability-hub.timer 2>/dev/null || true
 	@sudo systemctl disable --now gitops-sync@mehub.timer 2>/dev/null || true
+	@sudo systemctl disable --now gitops-sync@personal-reading-analytics.timer 2>/dev/null || true
+	@sudo systemctl disable --now gitops-sync@platform-actions.timer 2>/dev/null || true
+	@sudo systemctl disable --now gitops-sync@bioHub.timer 2>/dev/null || true
 	# 2. Generic cleanup for all units in ./systemd
 	@for unit in $$(ls systemd/*.service systemd/*.timer 2>/dev/null); do \
 		unit_name=$$(basename $$unit); \

--- a/scripts/gitops_sync.sh
+++ b/scripts/gitops_sync.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_NAME=${1:-""}
-ALLOWED_REPOS=("observability-hub" "mehub")
+ALLOWED_REPOS=("observability-hub" "mehub" "personal-reading-analytics" "platform-actions" bioHub)
 BASE_DIR="/home/server/software"
 
 # Log helper using jq for safe JSON generation


### PR DESCRIPTION
### Summary

Expanded the GitOps synchronization mechanism to include three additional repositories. This ensures that the host-level reconciliation agent can manage and synchronize these services alongside the existing ones.

### List of Changes

- **scripts**: Updated `gitops_sync.sh` to include `personal-reading-analytics`, `platform-actions`, and `bioHub` in the `ALLOWED_REPOS` allowlist.
- **Makefile**: Updated `install-services` and `uninstall-services` targets to explicitly manage systemd timers for the new repositories.

### Verification

- Verified `gitops_sync.sh` allowlist logic via manual execution with valid/invalid repo names.
- Validated `Makefile` target expansion by running `make install-services` (dry-run/manual check of commands).