### PR TITLE
feat(proxy): add k3s experimental manifests and ADR 007

### DIFF
--- a/docs/decisions/007-k3s-shadow-deployment-orchestration.md
+++ b/docs/decisions/007-k3s-shadow-deployment-orchestration.md
@@ -1,0 +1,41 @@
+# RFC 007: k3s Shadow Deployment & Orchestration
+
+- **Status:** Proposed
+- **Date:** 2026-01-19
+- **Author:** Victoria Cheng
+
+## The Problem
+
+While Docker Compose remains a functional and reliable foundation for the current repository, there is a desire to explore the potential of k3s and industry-standard orchestration.
+
+Relying exclusively on Docker Compose limits the opportunity to evaluate:
+
+1. **Orchestration Patterns:** Native self-healing, rolling updates, and the Gateway API.
+2. **Platform Resiliency:** Moving toward a more robust reconciliation loop.
+3. **Architectural Scaling:** Understanding the trade-offs between simple container management and full-scale orchestration.
+
+## Proposed Solution
+
+Implement a **Shadow Deployment Strategy**. This involves running an experimental "v2" version of services in k3s alongside the production version in Docker.
+
+### Key Implementation Details
+
+1. **Isolation:** Use `NodePort` on high-range ports (e.g., `30080`) to prevent production conflicts.
+2. **Feature Toggling:** Use `SKIP_DB_INIT` environment variables to allow k3s pods to boot and serve static/dummy endpoints without needing complex database networking in the spike phase.
+3. **Outbound Verification:** Implement external fetch endpoints (e.g., `/api/dummy`) to validate cluster DNS and internet egress.
+4. **Local Image Injection:** Use `k3s ctr images import` to bridge the gap between Docker builds and the k3s containerd runtime without requiring an external registry.
+
+## Comparison / Alternatives Considered
+
+- **Full Migration:** High risk of downtime. Networking between k3s and Docker is non-trivial and requires careful planning for database access.
+- **k3d:** Excellent for local dev but k3s is better suited for a long-running "production-like" homelab on the host.
+
+## Failure Modes (Operational Excellence)
+
+- **Port Conflict:** If a NodePort is chosen that is already in use by a Docker container or host service. **Mitigation:** Use the `30000-32767` range and explicitly check availability.
+- **Image Stale State:** If the user forgets to `import` the new image, k3s will run the old one. **Mitigation:** Always use `imagePullPolicy: Never` to force a failure if the local image is missing.
+- **Memory Pressure:** k3s and Docker share host RAM. **Mitigation:** Enforce strict `resources.limits` on all k3s manifests.
+
+## Conclusion
+
+By adopting a Shadow Deployment model, we can safely prototype k3s orchestration features while maintaining the 100% uptime of the production Docker stack. Once the k3s environment is verified (Networking, Secrets, Persistence), a phased migration of individual services can occur.

--- a/k3s/proxy-v2/manifest.yaml
+++ b/k3s/proxy-v2/manifest.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-v2
+  labels:
+    app: proxy-v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-v2
+  template:
+    metadata:
+      labels:
+        app: proxy-v2
+    spec:
+      containers:
+      - name: proxy-v2
+        image: proxy_v2:latest
+        imagePullPolicy: Never # Critical for local images
+        ports:
+        - containerPort: 8086
+        env:
+        - name: SKIP_DB_INIT
+          value: "true"
+        - name: PORT
+          value: "8086"
+        resources:
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-v2-service
+spec:
+  type: NodePort
+  selector:
+    app: proxy-v2
+  ports:
+    - protocol: TCP
+      port: 8086
+      targetPort: 8086
+      nodePort: 30080

--- a/page/content/evolution.yaml
+++ b/page/content/evolution.yaml
@@ -77,3 +77,11 @@ timeline:
     description: |
       - Expanded the GitOps reliability boundary to include the 'mehub' repository, validating the multi-tenant capability of the sync engine.
       - Optimized the reconciliation interval from 5m to 15m to balance freshness with operational stability.
+  - date: "2026-01-19"
+    title: "Orchestration Exploration: k3s Spike"
+    artifacts:
+      - name: "RFC 007: k3s Shadow Deployment"
+        url: "docs/decisions/007-k3s-shadow-deployment-orchestration.md"
+    description: |
+      - Initiated a "Shadow Deployment" spike for k3s orchestration, successfully validating outbound networking and cross-platform isolation.
+      - Introduced a "Safe-Mode" feature toggle (`SKIP_DB_INIT`) in the Go proxy to decouple database dependencies during infrastructure prototyping.

--- a/proxy/utils/home.go
+++ b/proxy/utils/home.go
@@ -2,10 +2,32 @@ package utils
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 )
 
 func HomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"message": "Welcome to the Observability Hub."})
+}
+
+func DummyHandler(w http.ResponseWriter, r *http.Request) {
+	// 1. Fetch from an external API (GitHub Zen) to test outbound connectivity
+	resp, err := http.Get("https://api.github.com/zen")
+	zenMessage := "Could not fetch Zen"
+	if err == nil {
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		zenMessage = string(body)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Hello from k3s proxy_v2!",
+		"outbound_test": map[string]string{
+			"source":  "https://api.github.com/zen",
+			"content": zenMessage,
+		},
+		"status": "experimental",
+	})
 }


### PR DESCRIPTION
### Summary

Introduced a "shadow deployment" capability for the proxy service to enable safe k3s orchestration spikes without impacting production Docker infrastructure. This is formally documented in ADR 007.

### List of Changes

- **proxy**: added `SKIP_DB_INIT` environment variable to bypass database connections during testing.
- **proxy**: implemented `/api/dummy` endpoint with outbound HTTP fetch to GitHub Zen API for networking validation.
- **k3s**: created centralized `k3s/` directory with `proxy-v2` manifest for NodePort deployment.
- **docs**: added ADR 007 (Status: Proposed) documenting the k3s shadow deployment strategy.
- **page**: updated `evolution.yaml` with the k3s orchestration spike entry.

### Verification

- Ran `nix-shell --run "make go-test"` (All tests passed).
- Manually verified `proxy_v2` deployment on k3s via NodePort 30080.
- Confirmed `SKIP_DB_INIT` correctly bypasses Postgres/Mongo pings.****