### PR TITLE
docs: standardize AGENTS.md, remove em dashes, and group dependabot actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/pkg/db"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,76 +1,61 @@
-# Repository Agents & Personas
+# Agent Guide for Observability Hub
 
-## 1. Staff Software Engineer (Current Persona)
+This document provides context and instructions for AI agents working on the **Observability Hub** project, a Go-based observability platform and mentorship sandbox.
 
-- **Role:** Mentor & Tech Lead
-- **Context:** 15+ years experience. Staff Generalist with deep expertise in Platform, Backend, Observability, and PostGIS.
-- **Directives:**
-  - **Audit for Seniority:** Flag narrow-scope solutions; push for systemic thinking across the full stack.
-  - **Production Readiness:** Prioritize logging, metrics, and explicit error handling.
-  - **PostGIS/Geospatial:** Leverage spatial indexing and efficient telemetry storage where applicable.
-  - **Challenge "Happy Path":** Ask "How does this fail?" and "How do we debug this in production?".
+## 1. Project Overview
 
-## 2. Documentation Steward
+**Observability Hub** is a modular observability platform designed for hybrid and edge environments. It bridges local `systemd` services with cloud-native patterns (Loki, Promtail, Postgres).
 
-- **Role:** Technical Writer
-- **Directives:**
-  - Ensure architectural decisions (`docs/decisions`) are up to date and strictly follow the ADR format.
-  - Maintain the `README.md` for clarity and freshness.
-  - Verify that documentation matches the actual code implementation.
+- **Role & Persona**: Act as a **Staff Software Engineer & Mentor** (15+ years experience).
+- **Mentorship Goal**: Accelerate the mentee's transition from Junior/Mid-level execution to Senior+ Systemic Thinking.
+- **Core Tech**: Go (Golang), PostgreSQL, Loki, Promtail, Systemd, Nix.
+- **Styling**: Native HTML/CSS (Dark Theme via CSS Variables).
+- **Architecture**: Modular Monorepo (`pkg/`, `proxy/`, `system-metrics/`, `page/`).
 
----
+## 2. Build and Test Commands
 
-## Repository Context Map
+The project relies on **Nix** for a reproducible environment. **Always use the `make nix-<target>` variants** (e.g., `make nix-go-test`, `make nix-go-update`) for all Go-related tasks to ensure the toolchain is correctly loaded.
 
-Agents must reference this map to understand the operational boundaries of the codebase.
-
-| Directory | Purpose |
+| Command | Description |
 | :--- | :--- |
-| **`docker/`** | Infrastructure-as-Code (IaC) for containerized services (Loki, Promtail, Postgres, Proxy). |
-| **`docs/`** | The Source of Truth. Includes Architecture (`/architecture`), and ADRs (`/decisions`). |
-| **`page/`** | The visual frontend. A Go-based web server rendering dashboards via `html/template`. |
-| **`pkg/`** | Shared libraries intended for re-use across services (e.g., structured `logger`, standardized `db` connections). |
-| **`proxy/`** | The ingress/logic layer handling requests and routing them to appropriate backends or databases. |
-| **`scripts/`** | Automation for maintenance, setup, and RFC creation. |
-| **`system-metrics/`** | A standalone Go service acting as a telemetry collector (CPU, Memory, Network) feeding into the data store. |
-| **`systemd/`** | Production service definitions. This project uses `systemd` (not just Docker) for process management on the host. |
+| `make rfc` | **Primary ADR Command**. Creates a new Request for Comments (RFC) or Architecture Decision Record (ADR). |
+| `make nix-go-format` | Automatically formats all Go code inside `nix-shell`. |
+| `make nix-go-test` | Runs all Go unit tests inside `nix-shell`. |
+| `make nix-go-update` | Updates Go dependencies and runs `go mod tidy` inside `nix-shell`. |
+| `make nix-page-build` | Builds the `page` service (Dashboard) inside `nix-shell`. |
+| `make nix-metrics-build` | Builds the `system-metrics` collector inside `nix-shell`. |
+| `make proxy-update` | Rebuilds and restarts the proxy service container. |
+| `make install-services` | Installs and updates `systemd` units for production. |
 
----
+## 3. Code Style Guidelines
 
-## Engineering Standards
+### Go (Backend)
 
-### 1. Go (Backend)
+- **Strict Adherence**: Code must pass `gofmt` and strict linting.
+- **Testing**: **Table-Driven Tests** are preferred. Use the standard library `testing` package.
+- **Error Handling**: **Explicit, wrapped errors** (e.g., `fmt.Errorf("failed to connect: %w", err)`). Do not swallow errors.
 
-- **Style:** Strictly `gofmt`.
-- **Testing:** Table-Driven Tests preferred. Use standard library `testing` package.
-- **Error Handling:** Explicit, wrapped errors (e.g., `fmt.Errorf("failed to connect: %w", err)`). Do not swallow errors.
+### HTML/CSS (Frontend)
 
-### 2. Frontend (HTML/CSS)
+- **Frameworks**: None. Native HTML/CSS only.
+- **Styling**: Use CSS Variables defined in `:root` (Dark Theme). Layouts via CSS Grid and Flexbox.
+- **Structure**: Semantic HTML5 (header, nav, main, footer).
 
-- **Frameworks:** None. Native HTML/CSS only.
-- **Styling:**
-  - Use CSS Variables defined in `:root` (Dark Theme palette).
-  - Layouts via CSS Grid and Flexbox.
-  - No inline styles (except dynamic values); keep styles in `style` blocks or files.
-- **Structure:** Semantic HTML5 (header, nav, main, footer).
+### Documentation
 
----
+- **ADRs**: Architectural decisions (`docs/decisions`) must strictly follow the ADR format.
+- **Freshness**: Maintain `README.md` clarity and ensure documentation matches implementation.
 
-## Development Environment & Operational Commands
+## 4. Testing Instructions
 
-This project uses `nix-shell` to manage the Go environment. All Go-related commands must be executed via `make` through the nix shell.
+- **Unit Tests**: Run `make nix-go-test` to execute the standard Go test suite.
+- **Coverage**: Run `make nix-go-cov` to generate coverage reports in the terminal.
+- **New Features**: Any new logic must include accompanying table-driven unit tests.
 
-### Execution Standard
+## 5. Security & Automation
 
-```bash
-nix-shell --run "make <target>"
-```
-
-### Key Commands
-
-- **RFC Creation:** `make rfc`
-- **Go Formatting:** `nix-shell --run "make go-format"`
-- **Testing:** `nix-shell --run "make go-test"` (use `go-cov` for coverage)
-- **Builds:** `nix-shell --run "make page-build"` or `nix-shell --run "make metrics-build"`
-- **Proxy Management:** `make proxy-update` (Primary command for rebuild/restart)
-- **Production Services:** `make install-services` (Systemd units)
+- **Infrastructure**:
+  - **`docker/`**: IaC for containerized services (Loki, Postgres).
+  - **`systemd/`**: Production service definitions for host-level management.
+- **Production Readiness**: Prioritize logging, metrics, and explicit error handling in all code contributions.
+- **Secrets**: Never commit secrets. Ensure `.env` is used for sensitive configuration.

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ help:
 nix-%:
 	@nix-shell --run "make $*"
 
-
 # Architecture Decision Record Creation
 rfc:
 	@./scripts/create_rfc.sh

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A resilient and reliability-focused unified telemetry platform architected to de
 - **Unified Observability & Standardization:** Eliminates data silos by correlating host-level infrastructure metrics (CPU/Memory/IO) with application-level business events. This provides a "Golden Path" for telemetry, ensuring all services are observed via a consistent standard.
 - **API-Driven Abstraction:** The `proxy` service acts as a Platform Interface, decoupling data ingestion from storage. Client apps (like Cover Craft) emit events to a simple endpoint (MongoDB), while the platform handles the complexity of Data Pipeline and efficient TimescaleDB storage.
 - **GitOps & Self-Healing:** Implements a custom reconciliation engine (`gitops-sync`) to enforce state consistency between the Git repository and the host, ensuring configuration drift is automatically corrected without manual intervention.
-- **Hybrid Runtime Architecture:** Leverages the right tool for the job—containerizing stateless services (Docker) while running privileged automation agents directly on the host (Systemd) for reliability and access to kernel-level stats.
+- **Hybrid Runtime Architecture:** Leverages the right tool for the job: containerizing stateless services (Docker) while running privileged automation agents directly on the host (Systemd) for reliability and access to kernel-level stats.
 - **High-Performance Storage:** Optimizes for high-volume time-series write throughput and geospatial analysis using TimescaleDB hypertables and PostGIS, avoiding the operational overhead of managing separate specialized databases.
 
 ---

--- a/docs/decisions/004-spatial-telemetry-keyboard.md
+++ b/docs/decisions/004-spatial-telemetry-keyboard.md
@@ -43,4 +43,4 @@ A distributed IoT pipeline consisting of three tiers:
 
 ## Conclusion
 
-This architecture provides a high-signal portfolio piece that demonstrates full-stack systems engineering—from hardware-level C++ to cloud-native Go and advanced SQL.
+This architecture provides a high-signal portfolio piece that demonstrates full-stack systems engineering, from hardware-level C++ to cloud-native Go and advanced SQL.

--- a/docs/notes/postgres.md
+++ b/docs/notes/postgres.md
@@ -103,4 +103,4 @@ dbname=homelab
 sslmode=disable
 ```
 
-> 🔒 **Security tip**: Store credentials in environment variables or a secrets manager — never hardcode!
+> 🔒 **Security tip**: Store credentials in environment variables or a secrets manager; never hardcode!


### PR DESCRIPTION
### Summary

Standardized the repository documentation and consolidated Dependabot configurations to improve maintainability and reduce noise. This includes a full refactor of `AGENTS.md` to match the established standard across resume projects and the removal of non-standard punctuation from markdown files.

### List of Changes

- **Documentation**: Refactored `AGENTS.md` to match the `example_agents.md` format, incorporating specific mentorship goals and updating all operational commands to use the `make nix-<target>` pattern.
- **Punctuation**: Removed em dashes (`—`) from `README.md`, `docs/decisions/004-spatial-telemetry-keyboard.md`, and `docs/notes/postgres.md`, replacing them with standard punctuation (commas, colons, or semicolons).
- **Dependabot**: Updated `.github/dependabot.yml` to group GitHub Actions updates into a single "actions" PR to minimize pull request volume.

### Verification

- Verified `AGENTS.md` content matches the standardized format.
- Manually reviewed all markdown files to ensure em dash removal and correct replacement punctuation.
- Validated YAML syntax for `.github/dependabot.yml`.