### PR TITLE
chore(worker): update image tag for analytics and ingestion cronjobs

### DIFF
--- a/k3s/base/worker/analytics-cronjob.yaml
+++ b/k3s/base/worker/analytics-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
             - name: ghcr-auth
           containers:
           - name: worker
-            image: ghcr.io/victoriacheng15/observability-hub/worker:sha-b541d13
+            image: ghcr.io/victoriacheng15/observability-hub/worker:sha-60ae1e4
             imagePullPolicy: Always
             args: ["--mode", "analytics"]
             env:

--- a/k3s/base/worker/ingestion-cronjob.yaml
+++ b/k3s/base/worker/ingestion-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
             - name: ghcr-auth
           containers:
           - name: worker
-            image: ghcr.io/victoriacheng15/observability-hub/worker:sha-b541d13
+            image: ghcr.io/victoriacheng15/observability-hub/worker:sha-60ae1e4
             imagePullPolicy: Always
             args: ["--mode", "ingestion"]
             env:


### PR DESCRIPTION
### Summary
Update worker cronjob images to `sha-60ae1e4` to incorporate the latest ingestion audit consolidation and unified metrics features. This ensures that all worker-based workloads are synchronized with the most recent stable release.

### List of Changes
- Synchronized cronjob container images with the latest stable build of the worker service.
- Improved consistency across worker-based workloads by ensuring they run on the same release version.

### Verification
- Ran `kubectl kustomize k3s/base/worker` to verify manifest integrity.
- Manually confirmed that `sha-60ae1e4` matches the latest successful build in the CI/CD pipeline.

