### PR TITLE
docs(grafana): refresh readme and dashboard signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,115 @@
 # Observability Hub
 
-A resilient, self-hosted platform meticulously engineered to showcase advanced Site Reliability Engineering (SRE) and Platform Engineering principles. It delivers full-stack observability (Logs, Metrics, Traces), GitOps-driven infrastructure management, and standardized telemetry ingestion for complex cloud-native environments.
+## What is this?
 
-Built using Go and orchestrated on Kubernetes (K3s), the platform unifies system metrics, application events, and logs into a single queryable layer leveraging OpenTelemetry, High-Availability (HA) PostgreSQL via CloudNativePG (CNPG), Grafana Loki, Prometheus, and Grafana. It's designed for operational excellence, demonstrating how to build a robust, observable, and maintainable system from the ground up.
+This is a self-hosted Kubernetes platform built on my homelab.
 
-🌐 [Project Portal](https://victoriacheng15.github.io/observability-hub/)
+It demonstrates how a real DevOps / Platform Engineering team would:
+- deploy applications using GitOps (Argo CD)
+- collect logs, metrics, and traces using OpenTelemetry
+- monitor systems with Grafana, Prometheus, and Loki
+- manage infrastructure using OpenTofu (Terraform)
+- handle failures with high-availability databases and backups
 
-📚 [Documentation Hub: Architecture, ADRs, Operations & Visual Gallery](./docs/README.md)
+The goal is to simulate a production-like environment and show how to build a reliable, observable system from scratch.
 
----
-
-## 📚 Project Evolution
-
-This platform evolved through intentional phases. See the full journey with ADRs:
-
-[View Complete Evolution Log](https://victoriacheng15.github.io/observability-hub/evolution.html)
-
-### Key Milestones
-
-- **Ch 1-3: Foundations** – Docker lab, Shared Go libraries, and Host-level visibility.
-- **Ch 4-6: Kubernetes Pivot** – Cluster migration, Event-driven GitOps, and Vault (OpenBao) security.
-- **Ch 7-9: SRE & Maturity** – Full OpenTelemetry (LMT) stack, Library-first modularity, and OpenTofu/Terraform IaC.
-- **Ch 10: MCP Era** – AI-native operations via a unified, domain-isolated Model Context Protocol gateway.
-- **Ch 11: eBPF-Native Efficiency & Networking** – Kepler energy monitoring and Cilium eBPF-native networking for high-fidelity L7 visibility.
-- **Ch 12: GitOps & Operational Maturity** – Centralized orchestration via ArgoCD and a layered infrastructure architecture.
+- 🌐 [Project Portal](https://victoriacheng15.github.io/observability-hub/)  
+- 📚 [Full Documentation & Visual Gallery](./docs/README.md)
 
 ---
 
-## 🛠️ Tech Stack & Architecture
+## 🔍 What I Built (Quick Proof)
 
-The platform leverages a robust set of modern technologies for its core functions:
+- Kubernetes (K3s) homelab running 10+ platform components
+- GitOps deployment using Argo CD (App-of-Apps pattern)
+- Full observability: logs, metrics, traces (OpenTelemetry + Grafana stack)
+- High-availability PostgreSQL with automated failover (CloudNativePG)
+- Centralized dashboards for monitoring and debugging
+- Secrets management without hardcoding credentials
+- Infrastructure as Code using OpenTofu (layered architecture)
+- Data ingestion pipeline with worker-based processing
+- eBPF-based networking and visibility using Cilium
+- Backup and storage integration with Azure Blob + MinIO
 
-![Go](https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white)
+---
 
-![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-%23000000.svg?style=for-the-badge&logo=opentelemetry&logoColor=white)
-![Cilium](https://img.shields.io/badge/Cilium-60BAE3.svg?style=for-the-badge&logo=Cilium&logoColor=white)
-![Grafana Loki](https://img.shields.io/badge/Loki-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white)
-![Grafana](https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white)
-![Grafana Tempo](https://img.shields.io/badge/Tempo-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white)
-![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white)
+## 📦 Platform Projects
 
-![ArgoCD](https://img.shields.io/badge/Argo-EF7B4D.svg?style=for-the-badge&logo=Argo&logoColor=white)
-![OpenTofu](https://img.shields.io/badge/OpenTofu-FFDA18.svg?style=for-the-badge&logo=OpenTofu&logoColor=black)
-![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5.svg?style=for-the-badge&logo=Kubernetes&logoColor=white)
-![Helm](https://img.shields.io/badge/Helm-0F1689.svg?style=for-the-badge&logo=Helm&logoColor=white)
-![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
-![Tailscale](https://img.shields.io/badge/Tailscale-%235d21d0.svg?style=for-the-badge&logo=tailscale&logoColor=white)
-![Azure Blob Storage](https://img.shields.io/badge/Azure_Blob_Storage-%230072C6.svg?style=for-the-badge&logo=microsoftazure&logoColor=white)
+This platform is built as a collection of smaller DevOps projects:
 
-![PostgreSQL (CNPG)](https://img.shields.io/badge/postgres-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white)
-![MinIO (S3)](https://img.shields.io/badge/MinIO-be172d?style=for-the-badge&logo=minio&logoColor=white)
+1. **GitOps Deployment (Argo CD)**
+   - Declarative cluster management with self-healing
 
-### System Architecture Overview
+2. **Observability Stack**
+   - Prometheus, Grafana, Loki, Tempo dashboards and alerts
 
-The diagram below illustrates the high-level flow of telemetry data from collection to visualization, highlighting the hybrid orchestration model between host-level entry points and the Kubernetes-native data worker.
+3. **Telemetry Pipeline**
+   - OpenTelemetry for logs, metrics, and traces
+
+4. **High Availability Database**
+   - PostgreSQL with failover and Azure Blob backups
+
+5. **Secrets Management**
+   - Dynamic secrets using OpenBao
+
+6. **Infrastructure as Code**
+   - OpenTofu layered architecture (00–09 separation)
+
+7. **Networking with Cilium**
+   - eBPF-based observability and traffic control
+
+8. **CI/CD + GitOps Flow**
+   - Webhook-triggered deployments and reconciliation
+
+9. **Failure Simulation**
+   - Chaos testing and system recovery
+
+10. **Data Ingestion Pipeline**
+   - Worker-based batch processing system
+
+---
+
+## 🧠 Problems I Solved
+
+- Manual deployments → replaced with GitOps automation
+- No visibility into systems → added logs, metrics, and tracing
+- Secrets stored in code → moved to dynamic secret management
+- Single point of failure → implemented HA database and backups
+- Hard to debug issues → centralized dashboards and alerts
+- Infrastructure drift → enforced declarative state with Argo CD
+
+---
+
+## 🛠️ Tech Stack
+
+**Platform & Infrastructure**
+- Kubernetes (K3s), Helm, Docker
+- Argo CD (GitOps)
+- OpenTofu (Terraform alternative)
+
+**Observability**
+- OpenTelemetry
+- Prometheus, Grafana
+- Loki (logs), Tempo (traces), Thanos (metrics scaling)
+
+**Data & Storage**
+- PostgreSQL (CloudNativePG)
+- MinIO (S3-compatible)
+- Azure Blob Storage
+
+**Networking & Security**
+- Cilium (eBPF networking)
+- OpenBao (Secrets Management)
+- Tailscale
+
+**Languages**
+- Go (backend services)
+
+---
+
+## 🏗️ System Architecture
+
+The diagram below shows how telemetry flows through the system and how components interact.
 
 ```mermaid
 flowchart TB
@@ -71,131 +127,82 @@ flowchart TB
             end
 
             Proxy["Go Proxy (Host API Gateway)"]
-            MCP["MCP Gateway - Telemetry, Pods, Hub, Network"]
-            Worker["Unified Worker (K3s CronJob)"]
-            K3S["Kubernetes API (Cluster State)"]
+            MCP["MCP Gateway"]
+            Worker["Unified Worker"]
+            K3S["Kubernetes API"]
 
-            subgraph DataPlatform ["Observability & Messaging"]
+            subgraph DataPlatform ["Observability"]
                 OTEL[OpenTelemetry Collector]
-                Observability["Loki, Tempo, and Prometheus (Thanos)"]
-                subgraph Simulation ["Hardware Simulation"]
-                    Sensors["Sensor Pods"]
-                    Chaos["Chaos Controller"]
-                    EMQX["EMQX (MQTT Broker)"]
-                end
+                Observability["Loki, Tempo, Prometheus"]
             end
         end
 
-        subgraph Storage ["Data Engines"]
-            PG[(HA Postgres - CNPG)]
-            S3[(MinIO - S3)]
-            Azure[(Azure Blob Storage)]
+        subgraph Storage ["Storage"]
+            PG[(Postgres)]
+            S3[(MinIO)]
+            Azure[(Azure Blob)]
         end
-        
 
         subgraph Visualization ["Visualization"]
-            Grafana[Grafana Dashboards]
+            Grafana[Grafana]
         end
     end
 
-    %% GitOps Loop
-    GitOps -- "Reconciles State" --> K3S
-
-    %% Data Pipeline Connections
+    GitOps --> K3S
     GH --> Worker
-    GH -- "Webhook" --> Proxy
-    Mongo --> Worker
-    
-    %% Unified MCP Paths
-    Observability -- "Query Data" --> MCP
-    K3S -- "Cluster State" --> MCP
-
-    %% Simulation & Chaos
-    Chaos -- "Inject Failure" --> EMQX
-    EMQX -- "Deliver Command" --> Sensors
-
-    %% Telemetry & Storage Connections
-    Observability -- "Host Metrics" --> Worker
-    Worker -- "Batch Data" --> PG
-    Proxy -- Data --> PG
-
-    %% Telemetry Pipeline (OTLP)
-    Proxy & MCP & Worker -- "Logs, Metrics, Traces" --> OTEL
+    Proxy & Worker --> OTEL
     OTEL --> Observability
-    
-    %% Resilience & Backup
-    Observability -- "Offload" --> S3
-    PG -- "Streaming Backup" --> Azure
-
-    %% Visualization Connections
-    Observability & PG & EMQX --> Grafana
+    Observability --> Grafana
+    Worker --> PG
+    PG --> Azure
 ```
 
 ---
 
-## 🚀 Key Achievements & Capabilities
+## ⚠️ Challenges
 
-### ☸️ Platform Engineering & Infrastructure
+One challenge was debugging service communication with Cilium networking.
 
-- **High-Availability Data Tier:** Deployed Loki, Tempo, and Thanos on Kubernetes with CloudNativePG for automated PostgreSQL failover and Azure Blob Storage for off-cluster backups.
-- **GitOps Orchestration:** Centralized cluster lifecycle management via ArgoCD, using an `App-of-Apps` pattern to maintain declarative state and automated self-healing.
-- **Layered IaC:** Implemented a domain-isolated OpenTofu architecture (00-09) to decouple foundation, networking, and application tiers for high-fidelity maintainability.
-- **Secrets Orchestration:** Integrated OpenBao to replace static environment variables with dynamic, on-demand credential retrieval.
+- **Problem:** Services were unreachable even though pods were running  
+- **Cause:** Incorrect network policies blocking traffic  
+- **Fix:** Used logs and metrics to identify dropped packets and corrected policies  
 
-### 🏗️ Software Architecture & Design
+---
 
-- **Service Consolidation:** Unified legacy analytics and ingestion services into a single `worker` binary, reducing resource fragmentation and standardizing batch task lifecycles.
-- **Dependency Consolidation:** Unified fragmented Go modules into a single monorepo, removing 17 `replace` directives.
-- **Architectural Isolation:** Implemented `Thin Main` patterns and strict `internal/` package scoping to decouple domain logic from infrastructure plumbing.
-- **GitOps Engine:** Built a custom HMAC-secured webhook listener to trigger automated repository state reconciliation across the cluster.
+## 🚀 Project Evolution
 
-### 🔭 Observability & Agentic Intelligence
+This platform evolved through multiple phases:
 
-- **Full-Stack Telemetry:** Standardized on OpenTelemetry (Logs, Metrics, Traces) for unified signal correlation across host and Kubernetes services.
-- **Agentic Interface (MCP):** Implemented a unified Model Context Protocol gateway to expose system state to AI agents, using domain isolation to enforce platform security.
-- **Store-and-Forward Bridge:** Built a secure telemetry relay to ingest host-level data into Kubernetes without exposing internal cluster ports.
+- **Foundations:** Docker, Go services, host-level visibility  
+- **Kubernetes Migration:** Moved workloads to K3s + GitOps  
+- **SRE Maturity:** Full observability (logs, metrics, traces)  
+- **Infrastructure:** OpenTofu layered architecture  
+- **Advanced Networking:** Cilium (eBPF)  
+- **Operational Maturity:** Argo CD orchestration + HA systems  
 
-### 📋 Operational Governance
-
-- **Decision Framework:** Adopted Architectural Decision Records (ADRs) and Incident RCA templates to document system evolution and manage technical debt.
+👉 [View Full Evolution Log](https://victoriacheng15.github.io/observability-hub/evolution.html)
 
 ---
 
 ## 🚀 Getting Started
 
 <details>
-<summary><b>Local Development Guide</b></summary>
-
-This guide will help you set up and run the `observability-hub` locally using Kubernetes (K3s).
+<summary><b>Local Setup</b></summary>
 
 ### Prerequisites
+- Go
+- K3s
+- Helm
+- Make
+- Nix
 
-Ensure you have the following installed on your system:
-
-- [Go](https://go.dev/doc/install)
-- [K3s](https://k3s.io/) (Lightweight Kubernetes)
-- [Helm](https://helm.sh/)
-- `make` (GNU Make)
-- [Nix](https://nixos.org/download.html) (for reproducible toolchains)
-
-### 1. Configuration
-
-The project uses a `.env` file to manage environment variables, especially for database connections and API keys.
+### Setup
 
 ```bash
-# Start by copying the example file
 cp .env.example .env
 ```
 
-You will need to edit the newly created `.env` file to configure connections for MongoDB Atlas, PostgreSQL (K3s NodePort), and other services.
-
-### 2. Build and Run the Stack
-
-The platform utilizes a hybrid orchestration model. You must deploy both the Kubernetes data tier and the native host services.
-
-#### A. Data Infrastructure (K3s)
-
-Deploy the observability backend using OpenTofu (IaC):
+### Deploy Infrastructure
 
 ```bash
 cd tofu
@@ -203,30 +210,31 @@ tofu init
 tofu apply
 ```
 
-This will provision PostgreSQL, MinIO, Loki, Tempo, Prometheus, Thanos, Grafana, and the OpenTelemetry Collector. Application workloads (Worker, Sensors) are automatically managed by ArgoCD.
-
-#### B. Native Host Services
-
-Build and initialize the API gateway and agentic interface on the host:
+### Run Services
 
 ```bash
-# Build Go binaries
 make proxy-build
 make mcp-build
-
-# Install and start Systemd services (requires sudo)
 make install-services
 ```
 
-### 3. Verification
+### Verify
 
-Once the stack is running, you can verify the end-to-end telemetry flow:
-
-- **Cluster Health:** Access Grafana at `http://localhost:30000` (NodePort).
-- **Service Logs:** Check logs for host components via Grafana Loki.
-
-### 4. Managing the Cluster
-
-To stop or remove resources, use the standard `kubectl delete` commands targeting the `observability` namespace.
+- Grafana: http://localhost:30000  
+- Check logs via Loki  
 
 </details>
+
+---
+
+## 📌 Summary
+
+This project demonstrates how to build a production-like DevOps platform using:
+
+- Kubernetes + GitOps  
+- Full observability (logs, metrics, traces)  
+- Infrastructure as Code  
+- High availability systems  
+- Real-world debugging and failure handling  
+
+It reflects how modern platform teams operate in real environments.

--- a/k3s/base/infra/grafana/dashboards/cilium-hubble-health.json
+++ b/k3s/base/infra/grafana/dashboards/cilium-hubble-health.json
@@ -57,7 +57,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 8,
         "x": 0,
         "y": 0
       },
@@ -136,8 +136,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 8,
+        "x": 8,
         "y": 0
       },
       "id": 8,
@@ -199,83 +199,14 @@
               }
             ]
           },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-provisioned"
-          },
-          "editorMode": "code",
-          "expr": "sum(cilium_unreachable_nodes)",
-          "legendFormat": "Unreachable Nodes",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Unreachable Nodes",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-provisioned"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
+        "w": 8,
+        "x": 16,
         "y": 0
       },
       "id": 4,
@@ -1165,7 +1096,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 24
       },
@@ -1202,92 +1133,6 @@
       ],
       "title": "eBPF Map Pressure (per Map)",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-provisioned"
-      },
-      "description": "List of unreachable nodes with details",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 24
-      },
-      "id": 15,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-provisioned"
-          },
-          "editorMode": "code",
-          "expr": "cilium_unreachable_nodes",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Unreachable Nodes Details",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "job": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Unreachable Count",
-              "instance": "Node IP",
-              "node": "Node Name"
-            }
-          }
-        }
-      ],
-      "type": "table"
     },
     {
       "datasource": {
@@ -1549,12 +1394,12 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Cilium & Hubble Health",
   "uid": "cilium-hubble-health",
-  "version": 13
+  "version": 1
 }

--- a/k3s/base/infra/grafana/dashboards/edge-simulation.json
+++ b/k3s/base/infra/grafana/dashboards/edge-simulation.json
@@ -988,5 +988,5 @@
   "timezone": "",
   "title": "Edge Simulation: Chaos & FinOps",
   "uid": "edge-sim-finops-v1",
-  "version": 13
+  "version": 1
 }

--- a/k3s/base/infra/grafana/dashboards/finops-sustainability.json
+++ b/k3s/base/infra/grafana/dashboards/finops-sustainability.json
@@ -29,264 +29,6 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
-                "color": "green",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "(sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m])) / sum(rate(kepler_node_cpu_joules_total{zone=\"package\"}[5m]))) * 100",
-          "refId": "A"
-        }
-      ],
-      "title": "Efficiency Score",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "postgresql-provisioned"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "joules"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      "id": 304,
-      "options": {
-        "displayLabels": [
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "format": "table",
-          "rawSql": "SELECT feature_id as metric, SUM(value) as value FROM analytics_metrics WHERE kind = 'energy' AND feature_id != 'node-total' AND $__timeFilter(time) GROUP BY 1;",
-          "refId": "A"
-        }
-      ],
-      "title": "Energy Distribution by Feature",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-provisioned"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "id": 305,
-      "options": {
-        "displayLabels": [
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "sum by (namespace) (rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\"))))",
-          "legendFormat": "{{namespace}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Power Distribution by Namespace (Watts)",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-provisioned"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "massg"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 306,
-      "options": {
-        "displayLabels": [
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "sum by (namespace) (rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) * ($carbon_intensity_kwh / 1000)",
-          "legendFormat": "{{namespace}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Carbon Distribution by Namespace (gCO2/h)",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-provisioned"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
             "fixedColor": "orange",
             "mode": "fixed"
           },
@@ -312,7 +54,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 7
+        "y": 0
       },
       "id": 3,
       "options": {
@@ -377,7 +119,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 7
+        "y": 0
       },
       "id": 4,
       "options": {
@@ -442,7 +184,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 7
+        "y": 0
       },
       "id": 5,
       "options": {
@@ -507,7 +249,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 7
+        "y": 0
       },
       "id": 6,
       "options": {
@@ -567,7 +309,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 11
+        "y": 4
       },
       "id": 11,
       "options": {
@@ -627,7 +369,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 11
+        "y": 4
       },
       "id": 12,
       "options": {
@@ -687,7 +429,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 11
+        "y": 4
       },
       "id": 13,
       "options": {
@@ -747,7 +489,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 11
+        "y": 4
       },
       "id": 14,
       "options": {
@@ -777,6 +519,431 @@
       ],
       "title": "Annual Waste Carbon Debt",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-provisioned"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 305,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "sort": "desc",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "sum by (namespace) (rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\"))))",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Power / Carbon Share by Namespace",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-provisioned"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "massg"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 306,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 10,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {},
+        "valueMode": "text"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "topk(3, sum by (namespace) ((rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) * ($carbon_intensity_kwh / 1000)))",
+          "instant": true,
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 3 Emitters (gCO2/h)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-provisioned"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "massg"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 309,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "(sum(rate(kepler_node_cpu_joules_total{zone=\"package\"}[5m])) - sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]))) * ($carbon_intensity_kwh / 1000)",
+          "legendFormat": "gCO2/h",
+          "refId": "A"
+        }
+      ],
+      "title": "Unattributed Carbon",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "postgresql-provisioned"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "joules"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 304,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "sort": "desc",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "SELECT feature_id as metric, SUM(value) as value FROM analytics_metrics WHERE kind = 'energy' AND feature_id != 'node-total' AND $__timeFilter(time) GROUP BY 1 ORDER BY 2 DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Energy Distribution by Feature",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "postgresql-provisioned"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1000000
+              },
+              {
+                "color": "red",
+                "value": 5000000
+              }
+            ]
+          },
+          "unit": "joules"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 307,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 10,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {},
+        "valueMode": "text"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "SELECT feature_id as metric, SUM(value) as value FROM analytics_metrics WHERE kind = 'energy' AND feature_id != 'node-total' AND $__timeFilter(time) GROUP BY 1 ORDER BY 2 DESC LIMIT 3;",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 3 Energy Consumers",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "postgresql-provisioned"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "CAD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 308,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 10,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {},
+        "valueMode": "text"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "SELECT feature_id as metric, SUM(value) / 3600000 * $energy_cost_kwh as value FROM analytics_metrics WHERE kind = 'energy' AND feature_id != 'node-total' AND $__timeFilter(time) GROUP BY 1 ORDER BY 2 DESC LIMIT 3;",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 3 Feature Costs",
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -879,10 +1046,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 24,
+        "h": 12,
+        "w": 12,
         "x": 0,
-        "y": 15
+        "y": 24
       },
       "id": 302,
       "options": {
@@ -972,25 +1139,45 @@
           },
           "unit": "watt"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Carbon/"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "massg"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 12,
         "w": 12,
-        "x": 0,
-        "y": 23
+        "x": 12,
+        "y": 24
       },
       "id": 7,
       "options": {
         "legend": {
-          "calcs": [],
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -1005,107 +1192,19 @@
           "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]))",
           "legendFormat": "Total Pods Energy",
           "refId": "B"
-        }
-      ],
-      "title": "Power Utilization: Host vs. Pods",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-provisioned"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "massg"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 23
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
         {
           "expr": "sum(rate(kepler_node_cpu_joules_total{zone=\"package\"}[5m])) * ($carbon_intensity_kwh / 1000)",
           "legendFormat": "Host Carbon",
-          "refId": "A"
+          "refId": "C"
         },
         {
           "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m])) * ($carbon_intensity_kwh / 1000)",
           "legendFormat": "Total Pods Carbon",
-          "refId": "B"
+          "refId": "D"
         }
       ],
-      "title": "Carbon Intensity Breakdown",
+      "title": "Power & Carbon Intensity Breakdown",
       "type": "timeseries"
     }
   ],
@@ -1162,5 +1261,5 @@
   "timezone": "",
   "title": "FinOps & Sustainability Hub",
   "uid": "finops-sustainability-hub",
-  "version": 20
+  "version": 1
 }

--- a/k3s/base/infra/grafana/dashboards/infrastructure-health.json
+++ b/k3s/base/infra/grafana/dashboards/infrastructure-health.json
@@ -42,12 +42,16 @@
                 "value": 0
               },
               {
+                "color": "orange",
+                "value": 70
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 90
               }
             ]
           },
-          "unit": "none"
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -78,12 +82,12 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"\", namespace=\"observability\"}[5m]))",
-          "legendFormat": "Total Cores",
+          "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])))",
+          "legendFormat": "Host CPU %",
           "refId": "A"
         }
       ],
-      "title": "Total CPU Usage",
+      "title": "Host CPU Utilization",
       "type": "stat"
     },
     {
@@ -106,12 +110,16 @@
                 "value": 0
               },
               {
+                "color": "orange",
+                "value": 75
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 90
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -142,12 +150,12 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{container!=\"\", namespace=\"observability\"})",
-          "legendFormat": "Total RAM",
+          "expr": "100 * (1 - (sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)))",
+          "legendFormat": "Host Memory %",
           "refId": "A"
         }
       ],
-      "title": "Total Memory Usage",
+      "title": "Host Memory Utilization",
       "type": "stat"
     },
     {
@@ -340,12 +348,12 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info{namespace=\"observability\"}, \"pod_id\", \"$1\", \"uid\", \"(.*)\"))))",
-          "legendFormat": "Current Power",
+          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\"))))",
+          "legendFormat": "Cluster Workload Power",
           "refId": "A"
         }
       ],
-      "title": "Total Power (Kepler)",
+      "title": "Cluster Workload Power (Kepler)",
       "type": "stat"
     },
     {
@@ -405,12 +413,12 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info{namespace=\"observability\"}, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) / 1000 * $energy_cost_kwh * 24",
+          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) / 1000 * $energy_cost_kwh * 24",
           "legendFormat": "CAD/day",
           "refId": "A"
         }
       ],
-      "title": "Daily Burn Rate",
+      "title": "Cluster Daily Burn Rate",
       "type": "stat"
     },
     {
@@ -471,13 +479,13 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info{namespace=\"observability\"}, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) / 1000 * $energy_cost_kwh * 24 * 30",
+          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) / 1000 * $energy_cost_kwh * 24 * 30",
           "legendFormat": "CAD/mo",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Monthly Spend Projection",
+      "title": "Cluster Monthly Spend Projection",
       "type": "stat"
     },
     {
@@ -538,13 +546,13 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info{namespace=\"observability\"}, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) / 1000 * $energy_cost_kwh * 24 * 365",
+          "expr": "sum(rate(kepler_container_cpu_joules_total{container_name!=\"\", pod_id!=\"\", zone=\"package\"}[5m]) * on(pod_id) group_left(namespace) (max by (pod_id, namespace) (label_replace(kube_pod_info, \"pod_id\", \"$1\", \"uid\", \"(.*)\")))) / 1000 * $energy_cost_kwh * 24 * 365",
           "legendFormat": "CAD/yr",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Annual Spend Projection",
+      "title": "Cluster Annual Spend Projection",
       "type": "stat"
     },
     {
@@ -631,12 +639,12 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"\", namespace=\"observability\"}[5m])) by (pod)",
-          "legendFormat": "{{pod}}",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"\"}[5m])) by (namespace, pod)",
+          "legendFormat": "{{namespace}}/{{pod}}",
           "refId": "A"
         }
       ],
-      "title": "Pod CPU Usage (Cores)",
+      "title": "Cluster Pod CPU Usage (Cores)",
       "type": "timeseries"
     },
     {
@@ -724,12 +732,12 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{container!=\"\", namespace=\"observability\"}) by (pod)",
-          "legendFormat": "{{pod}}",
+          "expr": "sum(container_memory_usage_bytes{container!=\"\"}) by (namespace, pod)",
+          "legendFormat": "{{namespace}}/{{pod}}",
           "refId": "A"
         }
       ],
-      "title": "Pod Memory Usage",
+      "title": "Cluster Pod Memory Usage",
       "type": "timeseries"
     },
     {
@@ -849,7 +857,7 @@
           "refId": "C"
         }
       ],
-      "title": "Thermal vs. Power Draw Correlation",
+      "title": "Host Thermal vs. Power Draw",
       "type": "timeseries"
     },
     {
@@ -942,7 +950,7 @@
           "refId": "A"
         }
       ],
-      "title": "Sub-System Thermal Trends (Storage & SoC)",
+      "title": "Host Sub-System Thermal Trends",
       "type": "timeseries"
     },
     {
@@ -1039,7 +1047,7 @@
           "refId": "B"
         }
       ],
-      "title": "Network Health: Cluster Packet Flow",
+      "title": "Cluster Network Health: Packet Flow",
       "type": "timeseries"
     },
     {
@@ -1131,7 +1139,7 @@
           "refId": "A"
         }
       ],
-      "title": "Network Security: Drops by Reason (Hubble)",
+      "title": "Cluster Network Security: Drops by Reason",
       "type": "timeseries"
     }
   ],
@@ -1169,7 +1177,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Infrastructure Health Intelligence",
+  "title": "Host & Cluster Infrastructure Health",
   "uid": "infra-health-intelligence",
   "version": 1
 }

--- a/k3s/base/infra/grafana/dashboards/unified-services-hub.json
+++ b/k3s/base/infra/grafana/dashboards/unified-services-hub.json
@@ -1718,5 +1718,5 @@
   "timezone": "browser",
   "title": "Unified Services Hub",
   "uid": "unified-services-hub",
-  "version": 17
+  "version": 1
 }


### PR DESCRIPTION
### Summary
This change refreshes the project README and tightens several Grafana dashboards so they present clearer operational signals for infrastructure, sustainability, and network health. It reduces duplicated panels, aligns dashboard scope to host and cluster usage, and removes low-value or distracting views that were not helping day-to-day review.

### List of Changes
- Rewrote the README to present the platform as a clearer homelab and DevOps portfolio story with simplified architecture, capabilities, challenges, and setup guidance.
- Reworked the FinOps and sustainability layout to combine overlapping power and carbon views, highlight the top carbon emitters, and surface unattributed carbon as a direct signal.
- Converted the infrastructure dashboard into a true host-and-cluster view by using host utilization in the summary row and widening workload panels to cluster scope with clearer labels.
- Simplified the Cilium and Hubble dashboard by removing unreachable-node panels and rebalancing the layout so the remaining health views are easier to scan.
- Captured the current Grafana dashboard state in related dashboards by updating their stored version metadata alongside the main dashboard edits.

### Verification
- `git diff --stat HEAD`
- `jq empty k3s/base/infra/grafana/dashboards/finops-sustainability.json`
- `jq empty k3s/base/infra/grafana/dashboards/infrastructure-health.json`
- `jq empty k3s/base/infra/grafana/dashboards/cilium-hubble-health.json`
- Reviewed the updated README and dashboard diffs against the current worktree to confirm the staged files match the intended documentation and dashboard changes.

