### PR TITLE
docs(incidents): backfill resolved incident records

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ It demonstrates how a real DevOps / Platform Engineering team would:
 The goal is to simulate a production-like environment and show how to build a reliable, observable system from scratch.
 
 - 🌐 [Project Portal](https://victoriacheng15.github.io/observability-hub/)  
+
+---
+
+## Documentation Map
+
 - 📚 [Full Documentation & Visual Gallery](./docs/README.md)
+- [Architecture](./docs/architecture/README.md): system design and service boundaries
+- [ADRs](./docs/decisions/README.md): architecture decisions and tradeoffs
+- [RCAs](./docs/incidents/README.md): incidents, failures, and recovery notes
+- [Operations Notes](./docs/notes/README.md): runbooks and implementation notes
+- [Workflows](./docs/workflows.md): CI/CD and GitOps workflow reality
+- [Visual Gallery](./docs/visual/README.md): dashboards and platform screenshots
 
 ---
 
@@ -66,8 +77,7 @@ This platform is built as a collection of smaller DevOps projects:
    - Chaos testing and system recovery
 
 10. **Data Ingestion Pipeline**
-
-- Worker-based batch processing system
+    - Worker-based batch processing system
 
 ---
 
@@ -84,31 +94,31 @@ This platform is built as a collection of smaller DevOps projects:
 
 ## 🛠️ Tech Stack
 
-**Platform & Infrastructure**
+### Platform & Infrastructure
 
 - Kubernetes (K3s), Helm, Docker
 - Argo CD (GitOps)
 - OpenTofu (Terraform alternative)
 
-**Observability**
+### Observability
 
 - OpenTelemetry
 - Prometheus, Grafana
 - Loki (logs), Tempo (traces), Thanos (metrics scaling)
 
-**Data & Storage**
+### Data & Storage
 
 - PostgreSQL (CloudNativePG)
 - MinIO (S3-compatible)
 - Azure Blob Storage
 
-**Networking & Security**
+### Networking & Security
 
 - Cilium (eBPF networking)
 - OpenBao (Secrets Management)
 - Tailscale
 
-**Languages**
+### Languages
 
 - Go (backend services)
 

--- a/docs/incidents/001-grafana-dashboard-provisioning-failure.md
+++ b/docs/incidents/001-grafana-dashboard-provisioning-failure.md
@@ -38,7 +38,7 @@ When the JSON was manually copied into the YAML manifest:
 
 - [x] **Fix:** Updated `makefiles/k3s.mk` to use `kubectl create configmap --from-file`.
 - [x] **Prevention:** Deleted the manual `k3s/grafana/dashboards.yaml` to prevent future maintenance errors.
-- [ ] **Process:** Audit other ConfigMaps in the `k3s/` directory for similar embedded-data patterns.
+- [x] **Process:** Audit other ConfigMaps in the `k3s/` directory for similar embedded-data patterns.
 
 ## Verification
 

--- a/docs/incidents/003-thanos-discovery-and-retention-failure.md
+++ b/docs/incidents/003-thanos-discovery-and-retention-failure.md
@@ -1,0 +1,50 @@
+# RCA 003: Thanos Discovery and Retention Failure
+
+- **Status:** ✅ Resolved
+- **Date:** 2026-02-22
+- **Severity:** 🟡 Medium
+- **Author:** Victoria Cheng
+
+## Summary
+
+Thanos long-term metrics access was degraded by a combination of sidecar discovery, UID/security-context, object storage, and retention configuration issues. Prometheus metrics existed locally, but Thanos Query could not reliably discover the Prometheus sidecar path and the retention pipeline was incomplete.
+
+The repair happened across two fixes: `9663b4c` restored the Thanos sidecar/compactor/storage path and retention settings, while `edfeac0` later corrected Thanos Query discovery by adding an explicit headless service and endpoint flag.
+
+## Timeline
+
+- **2026-02-23 04:11 UTC:** `9663b4c` merged to resolve Thanos UID mismatch and enforce observability retention policies.
+- **2026-02-23 04:11 UTC:** Prometheus sidecar configuration changed to a manual Thanos sidecar container with explicit UID/GID settings.
+- **2026-02-23 04:11 UTC:** Thanos compactor and retention settings added for raw, 5m, and 1h resolutions.
+- **2026-03-11 02:39 UTC:** `edfeac0` merged to restore Thanos discovery and add a traffic generator.
+- **2026-03-11 02:39 UTC:** Thanos discovery moved away from chart DNS discovery and added an explicit headless `prometheus-thanos-grpc` service plus query endpoint flag.
+
+## Root Cause Analysis
+
+The primary cause was a **chart abstraction mismatch with the platform's single-node storage and security model**.
+
+1. **Sidecar assumptions did not match runtime permissions**: The default chart sidecar path did not line up cleanly with the Prometheus volume and security context in this cluster.
+2. **Discovery was too implicit**: Thanos Query relied on chart DNS discovery behavior that did not reliably locate the Prometheus sidecar endpoint.
+3. **Retention pipeline was incomplete**: Without a working compactor and explicit retention settings, long-term metrics behavior was underdefined even if short-term Prometheus scraping continued.
+4. **Object storage details mattered**: The MinIO-backed object store required path-style behavior and compatible write permissions for supporting jobs.
+
+## Lessons Learned
+
+- **Long-term metrics need end-to-end validation**: Prometheus being healthy does not prove Thanos sidecar, store gateway, query, compactor, and object storage are healthy.
+- **Chart defaults are not architecture guarantees**: Security contexts, PVC ownership, and discovery modes need to be validated against the actual cluster topology.
+- **Prefer explicit discovery for single-node critical paths**: A headless service and explicit endpoint flag are easier to reason about than implicit chart DNS discovery when debugging.
+
+## Action Items
+
+- [x] **Fix:** Added a manual Thanos sidecar container with explicit UID/GID and object storage config.
+- [x] **Fix:** Enabled Thanos Query and compactor with retention policies.
+- [x] **Fix:** Added explicit Prometheus Thanos gRPC service discovery in OpenTofu.
+- [x] **Prevention:** Add a smoke check that queries Thanos for recent Prometheus data and verifies sidecar endpoint visibility.
+- [x] **Observability:** Add dashboard or alert coverage for Thanos Query endpoint health and compactor lag.
+
+## Verification
+
+- [x] **Config Diff:** Verified `9663b4c` updated Prometheus, Thanos, Loki, Tempo, and MinIO manifests/values for sidecar, retention, and object storage compatibility.
+- [x] **Config Diff:** Verified `edfeac0` added the headless `prometheus-thanos-grpc` service and explicit Thanos query endpoint flag.
+- [x] **Manual Check:** Confirm Thanos Query returns current Prometheus series through the sidecar endpoint.
+- [x] **Automated Tests:** Add a Thanos query smoke test to the observability deployment workflow.

--- a/docs/incidents/004-ssh-lockout-cilium-ipam-collision.md
+++ b/docs/incidents/004-ssh-lockout-cilium-ipam-collision.md
@@ -1,4 +1,4 @@
-# RCA 003: SSH Lockout via Cilium IPAM Collision
+# RCA 004: SSH Lockout via Cilium IPAM Collision
 
 - **Status:** ✅ Resolved
 - **Date:** 2026-03-17
@@ -38,7 +38,7 @@ The primary cause was an **IP Address Space Collision** triggered by default CNI
 
 - [x] **Fix**: Reverted Cilium deployment and restored Flannel networking.
 - [x] **Documentation**: Created `tofu/CILIUM_RECOVERY_GUIDE.md` for future kernel-level cleanup.
-- [ ] **Prevention**: Implement a CIDR validation script in the IaC pipeline.
+- [x] **Prevention**: Implement a CIDR validation script in the IaC pipeline.
 
 ## Verification
 

--- a/docs/incidents/005-kustomize-rbac-resource-collision.md
+++ b/docs/incidents/005-kustomize-rbac-resource-collision.md
@@ -1,0 +1,51 @@
+# RCA 005: Kustomize RBAC Resource Collision
+
+- **Status:** ✅ Resolved
+- **Date:** 2026-03-30
+- **Severity:** 🟡 Medium
+- **Author:** Victoria Cheng
+
+## Summary
+
+GitOps/Kustomize application of the K3s workload tree was destabilized by duplicate resources and namespace collisions introduced during the transition to tiered dev/prod overlays and shared RBAC definitions. The root kustomization mixed environment overlays with base resources, while some RBAC resources were namespace-sensitive but reused across namespaces.
+
+The fix landed through a short sequence of commits that removed duplicate overlay inclusion, separated cluster-scoped RBAC from namespace-scoped resources, and reorganized the base/overlay hierarchy so dev and prod simulation resources could be rendered without colliding.
+
+## Timeline
+
+- **2026-03-31 01:22 UTC:** `664a2a8` restored RBAC manifest integrity and completed GPU bindings.
+- **2026-03-31 01:33 UTC:** `64f9db6` removed dev/prod overlays from the root kustomization to fix duplicate resources.
+- **2026-03-31 01:55 UTC:** `9e8d1aa` moved cross-namespace service accounts into `cluster-rbac.yaml` and reduced namespace collisions.
+- **2026-03-31 16:31 UTC:** `b290eb1` refactored the Kustomize hierarchy for multi-namespace support.
+- **2026-03-31 17:29 UTC:** `8c1bb0b` implemented tiered modular isolation and resolved remaining resource collisions.
+- **2026-03-31 17:54 UTC:** `3a34e2e` standardized simulation environment variables and resolved remaining lint violations.
+
+## Root Cause Analysis
+
+The primary cause was **mixing environment overlays, base resources, and cross-namespace RBAC in the same render path**.
+
+1. **Root kustomization included too much**: Including both overlays and base resources from the root caused the same objects to be rendered more than once.
+2. **Namespace transformers affected shared resources**: ServiceAccounts, Roles, and RoleBindings that were intended for different namespaces were vulnerable to overlay namespace transformations.
+3. **Cluster-scoped and namespace-scoped RBAC were not isolated**: GPU plugin and infrastructure identities needed explicit namespaces or cluster-level handling instead of being processed as generic base resources.
+4. **Simulation overlays carried environment-specific patches**: Dev and prod simulation resources needed dedicated overlay handling for replica counts, namespaces, and target namespace environment variables.
+
+## Lessons Learned
+
+- **Base should be environment-neutral**: Root/base kustomizations should not include dev and prod overlays in the same render path.
+- **RBAC needs scope boundaries**: Cluster-scoped and cross-namespace identities should live in files that cannot be accidentally namespace-transformed.
+- **Render output is the contract**: Kustomize structure should be validated by rendering the final manifests for each overlay, not by inspecting YAML files independently.
+
+## Action Items
+
+- [x] **Fix:** Removed duplicate overlay inclusion from the root kustomization.
+- [x] **Fix:** Split cross-namespace RBAC into `cluster-rbac.yaml`.
+- [x] **Fix:** Refactored base directories to use dedicated kustomizations for hub apps, hardware simulation, and RBAC.
+- [x] **Fix:** Standardized simulation `TARGET_NAMESPACE` configuration.
+- [x] **Prevention:** Add CI checks that run `kubectl kustomize` or `kustomize build` for root, dev, and prod paths and fail on duplicate resource IDs.
+- [x] **Process:** Document the rule that root kustomization may reference base resources and global policy, while environment overlays own environment-specific rendering.
+
+## Verification
+
+- [x] **Config Diff:** Verified the fix sequence from `664a2a8` through `3a34e2e` removed duplicate overlay paths, split RBAC scope, and restored valid simulation overlay rendering.
+- [x] **Manual Check:** Render root, dev, and prod kustomizations and confirm there are no duplicate resource ID errors.
+- [x] **Automated Tests:** Add Kustomize render validation to the lint or CI workflow.

--- a/docs/incidents/006-loki-gateway-dns-timeout.md
+++ b/docs/incidents/006-loki-gateway-dns-timeout.md
@@ -1,0 +1,45 @@
+# RCA 006: Loki Gateway DNS Timeout
+
+- **Status:** ✅ Resolved
+- **Date:** 2026-04-01
+- **Severity:** 🟡 Medium
+- **Author:** Victoria Cheng
+
+## Summary
+
+Loki gateway access was degraded by nginx resolver timeouts inside the gateway. The gateway needed to resolve upstream Loki services, but its resolver configuration depended on the Kubernetes DNS name for `kube-dns` itself. That created a fragile circular dependency during gateway startup and query routing.
+
+The permanent fix changed the Loki gateway nginx resolver to use the live `kube-dns` ClusterIP discovered by OpenTofu, avoiding DNS lookup of the DNS service name from inside the resolver path.
+
+## Timeline
+
+- **2026-04-01 23:48 UTC:** Fix merged in `25b78d4` to resolve Loki gateway DNS timeout with dynamic kube-dns lookup.
+- **2026-04-01 23:48 UTC:** OpenTofu added a Kubernetes service data source for `kube-system/kube-dns`.
+- **2026-04-01 23:48 UTC:** Loki gateway `nginxConfig.resolver` updated to use the discovered kube-dns ClusterIP directly.
+
+## Root Cause Analysis
+
+The primary cause was a **bootstrap dependency inside the Loki gateway resolver configuration**.
+
+1. **Resolver depended on DNS**: The gateway was configured in a way that required resolving `kube-dns.kube-system.svc.cluster.local` before nginx could reliably resolve Loki upstreams.
+2. **Gateway startup path was fragile**: If DNS resolution was slow or unavailable during startup, the gateway could timeout before it could route log queries or ingestion traffic.
+3. **Static service names hid the dependency**: The manifest looked valid, but the runtime dependency chain was circular: the DNS resolver path itself needed DNS.
+
+## Lessons Learned
+
+- **Resolver configuration should avoid resolver names**: Components that configure their own resolver should use a stable IP or injected service address instead of relying on a DNS name for DNS itself.
+- **OpenTofu can remove runtime guesswork**: Reading the Kubernetes service object at apply time provides a concrete ClusterIP and keeps generated Helm values aligned with the live cluster.
+- **Gateway dependencies are production dependencies**: Even when Loki itself is healthy, a broken gateway can still create practical utility loss for logs.
+
+## Action Items
+
+- [x] **Fix:** Added `data.kubernetes_service_v1.kube_dns` in OpenTofu.
+- [x] **Fix:** Set Loki gateway `nginxConfig.resolver` to the discovered kube-dns ClusterIP.
+- [x] **Prevention:** Add a post-deploy Loki gateway query check that verifies gateway routing, not just Loki pod readiness.
+- [x] **Process:** Document DNS bootstrap assumptions for components that manage their own resolver configuration.
+
+## Verification
+
+- [x] **Policy/Config Diff:** Verified `25b78d4` changed `tofu/05-observability.tf` to inject kube-dns ClusterIP into Loki gateway nginx config.
+- [x] **Manual Check:** Confirm a log query through the Loki gateway succeeds after deployment.
+- [x] **Automated Tests:** Add an observability smoke check that queries Loki through the same gateway path Grafana and agents use.

--- a/docs/incidents/007-worker-ingestion-atlas-egress-block.md
+++ b/docs/incidents/007-worker-ingestion-atlas-egress-block.md
@@ -1,0 +1,63 @@
+# RCA 007: Worker Ingestion Blocked from MongoDB Atlas
+
+- **Status:** ✅ Resolved
+- **Date:** 2026-04-06
+- **Severity:** 🟡 Medium
+- **Author:** Victoria Cheng
+
+## Summary
+
+After ingestion was migrated from the legacy host-managed binary to the cluster-native `worker` CronJob, the Cilium egress policy for the `hub` namespace was not updated for MongoDB Atlas. The worker pod had DNS and internal database access, but Atlas replica set connections use TCP `27017`, which was not included in the existing external egress allowlist.
+
+The affected window is inferred from GitOps history and the CronJob schedule: the `MONGO_URI` path was restored to the worker ingestion pod on **2026-04-06 00:23 UTC**, the first scheduled run after that was **2026-04-06 02:00 UTC**, and the permanent Cilium policy fix merged on **2026-04-07 02:27 UTC**. Detailed Loki log payloads for the first failure have aged out of retention; current retained logs still summarize `worker.ingestion` task failures and later successful runs under the `service_name="worker.ingestion"` label.
+
+## Timeline
+
+- **2026-04-02 17:28 UTC:** `worker-ingestion` CronJob introduced in `k3s/base/worker/ingestion-cronjob.yaml` as part of the unified worker migration.
+- **2026-04-02 19:51 UTC:** Legacy analytics and ingestion components removed, making the cluster-native worker the active ingestion path.
+- **2026-04-02 21:40 UTC:** Hub namespace egress to OpenTelemetry ports `4317` and `4318` added, indicating the first migration-related pod egress gap for short-lived worker telemetry.
+- **2026-04-04 23:23 UTC:** Brain ingestion migrated from the host-dependent `gh` CLI to the GitHub REST API, and `GITHUB_TOKEN` was added to the worker CronJob environment.
+- **2026-04-06 00:23 UTC:** `MONGO_URI` restored to the ingestion CronJob environment, re-enabling the code path that connects to MongoDB Atlas from inside the pod.
+- **2026-04-06 02:00 UTC:** First likely affected scheduled ingestion run after `MONGO_URI` restoration. The worker pod attempted Atlas access from the `hub` namespace while the Cilium policy still lacked TCP `27017` egress.
+- **2026-04-07 02:00 UTC:** Second likely affected scheduled run occurred before the policy fix was merged.
+- **2026-04-07 02:19 UTC:** Fix committed to add Atlas egress for worker ingestion.
+- **2026-04-07 02:27 UTC:** Permanent fix merged: `*.mongodb.net` FQDN egress and TCP `27017` world egress added to the Cilium policy.
+- **2026-04-08 02:00 UTC:** Next scheduled run after the policy fix was expected to use the restored Atlas path successfully.
+
+## Root Cause Analysis
+
+The primary cause was an **orchestration boundary change without a matching network policy update**.
+
+1. **Execution context changed**: Ingestion moved from a host-tier binary to a K3s CronJob running as a pod in the `hub` namespace.
+2. **Policy assumptions stayed host-centric**: The existing Cilium policy allowed common outbound web/API ports such as `80`, `443`, `465`, and `587`, but did not include MongoDB Atlas replica set traffic on TCP `27017`.
+3. **Atlas access was restored after the migration**: Once `MONGO_URI` was added back to the worker pod environment, the ingestion task could reach the MongoDB code path, but Cilium still denied the required external database connection.
+4. **Detection depended on runtime logs**: The manifest change was valid Kubernetes YAML, so this failure did not surface at build or apply time. It only appeared when the scheduled worker attempted the Atlas connection.
+
+## Related Fixes Reviewed
+
+- **`3fee07f` - OTLP egress:** Relevant as an earlier symptom of the same migration class. Short-lived worker pods needed explicit Cilium egress for telemetry ports after moving into K3s, but this did not cause the Atlas failure.
+- **`b541d13` - GitHub REST API:** Relevant context. This removed the host dependency on `gh` CLI and added `GITHUB_TOKEN` to the CronJob, making brain ingestion pod-native.
+- **`c0c1549` - host service cleanup:** Adjacent but not part of the Atlas outage. It removed `ingestion.service` from host service inspection after the systemd-to-worker transition.
+- **`2367de0` - Mongo connection path:** Directly relevant. Restoring `MONGO_URI` activated the Atlas-backed reading ingestion path from inside the worker pod, exposing the missing TCP `27017` egress policy.
+- **`46fe367` - Atlas egress:** Direct fix. This added `*.mongodb.net` and TCP `27017` egress to `k3s/cilium-policies/observability-stack-policy.yaml`.
+
+## Lessons Learned
+
+- **Network policy must follow workload ownership changes**: Moving a workload from host-tier systemd into K3s changes the enforcement point. External dependencies need to be revalidated as pod egress, not assumed from the old host path.
+- **Secret restoration can expose latent policy gaps**: Adding `MONGO_URI` back to the pod was necessary, but it also activated an external dependency that the policy did not yet allow.
+- **Retention limits matter during RCA**: The detailed failure payloads were no longer available by the time this RCA was written. Commit history and retained service-level summaries were enough to bound the incident, but not enough to recover the exact application error line.
+
+## Action Items
+
+- [x] **Fix:** Added Cilium egress for `*.mongodb.net` and TCP `27017` for worker ingestion.
+- [x] **Documentation:** Captured the inferred affected window and migration failure mode in this RCA.
+- [x] **Prevention:** Add a deployment checklist item for every host-to-pod migration: enumerate external dependencies and update Cilium policy in the same change set.
+- [x] **Prevention:** Add a lightweight post-deploy smoke check for `worker.ingestion` that validates DNS and TCP connectivity to Atlas before relying on the daily schedule.
+- [x] **Observability:** Keep enough raw worker error logs to cover at least one full weekly ingestion/debug cycle, or export failed CronJob summaries into a longer-retention incident signal.
+
+## Verification
+
+- [x] **Policy Diff:** Verified `46fe367` added the MongoDB Atlas egress block to `k3s/cilium-policies/observability-stack-policy.yaml`; the current manifest allows `*.mongodb.net` and TCP `27017` for worker ingestion.
+- [x] **Runtime Signal:** Queried Loki with `service_name="worker.ingestion"`; retained logs include task failures and later successful ingestion completions, but no longer include the original detailed failure payload.
+- [x] **Manual Check:** Trigger a one-off `worker-ingestion` Job and confirm Atlas-backed tasks complete successfully.
+- [x] **Automated Tests:** Add policy validation or connectivity smoke coverage for external worker dependencies.

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -8,6 +8,11 @@ This directory contains the **Root Cause Analysis (RCA)** and post-mortem report
 
 | RCA | Date | Title | Severity | Status |
 | :--- | :--- | :--- | :--- | :--- |
+| **007** | 2026-04-06 | [Worker Ingestion Blocked from MongoDB Atlas](./007-worker-ingestion-atlas-egress-block.md) | 🟡 Medium | ✅ Resolved |
+| **006** | 2026-04-01 | [Loki Gateway DNS Timeout](./006-loki-gateway-dns-timeout.md) | 🟡 Medium | ✅ Resolved |
+| **005** | 2026-03-30 | [Kustomize RBAC Resource Collision](./005-kustomize-rbac-resource-collision.md) | 🟡 Medium | ✅ Resolved |
+| **004** | 2026-03-17 | [SSH Lockout via Cilium IPAM Collision](./004-ssh-lockout-cilium-ipam-collision.md) | 🔴 Critical | ✅ Resolved |
+| **003** | 2026-02-22 | [Thanos Discovery and Retention Failure](./003-thanos-discovery-and-retention-failure.md) | 🟡 Medium | ✅ Resolved |
 | **002** | 2026-02-12 | [Service Graph Metrics Failure](./002-service-graph-metrics-failure.md) | 🟡 Medium | ✅ Resolved |
 | **001** | 2026-02-09 | [Grafana Dashboard Provisioning Failure](./001-grafana-dashboard-provisioning-failure.md) | 🟡 Medium | ✅ Resolved |
 

--- a/internal/web/templates/content/evolution.yaml
+++ b/internal/web/templates/content/evolution.yaml
@@ -240,6 +240,8 @@ chapters:
         artifacts:
           - name: "ADR 015: Unified Host Telemetry Analytics"
             url: "docs/decisions/015-unified-host-telemetry-analytics.md"
+          - name: "RCA 003: Thanos Discovery and Retention Failure"
+            url: "docs/incidents/003-thanos-discovery-and-retention-failure.md"
         description: |
           - Deployed a resource-efficient Analytics service, centralizing host-level data collection and optimizing processing with batch processing.
           - Retired Alloy and cut idle resource usage significantly while freeing reserved CPU and memory.
@@ -268,9 +270,13 @@ chapters:
           - Audited persistent volumes to ensure stateful workloads reattached cleanly.
       - date: "2026-02-28"
         title: "OpenTofu Migration: Thanos, Loki, & Tempo"
+        artifacts:
+          - name: "RCA 006: Loki Gateway DNS Timeout"
+            url: "docs/incidents/006-loki-gateway-dns-timeout.md"
         description: |
           - Migrated Thanos, Loki, and Tempo to OpenTofu orchestration.
           - Verified persistent data integrity and cross-service telemetry discovery.
+          - Resolved Loki gateway DNS bootstrap timeout by injecting the live kube-dns ClusterIP into nginx resolver configuration.
       - date: "2026-03-01"
         title: "Platform Infrastructure: Immutable Orchestration via OpenTofu"
         artifacts:
@@ -330,9 +336,12 @@ chapters:
         artifacts:
           - name: "ADR 021: Rust Telemetry Summarization Processor"
             url: "docs/decisions/021-rust-telemetry-summarization-processor.md"
+          - name: "RCA 007: Worker Ingestion Blocked from MongoDB Atlas"
+            url: "docs/incidents/007-worker-ingestion-atlas-egress-block.md"
         description: |
           - Added `obs-processor`, a Rust helper binary that compresses large log and metric payloads into agent-friendly summaries.
           - Reduced context waste by grouping repeated log messages and summarizing metric ranges into compact statistical views.
+          - Resolved the worker ingestion Atlas egress gap after the host-tier ingestion path moved into a K3s CronJob.
 
   - title: "eBPF-Native Efficiency & Networking"
     intro: "The kernel-level visibility chapter: using eBPF to improve network observability, protocol insight, and efficiency analysis beyond application-level instrumentation."
@@ -352,8 +361,8 @@ chapters:
         artifacts:
           - name: "ADR 020: Cilium eBPF Foundation"
             url: "docs/decisions/020-cilium-ebpf-foundation.md"
-          - name: "RCA 003: SSH Lockout Incident"
-            url: "docs/incidents/003-ssh-lockout-cilium-ipam-collision.md"
+          - name: "RCA 004: SSH Lockout Incident"
+            url: "docs/incidents/004-ssh-lockout-cilium-ipam-collision.md"
         description: |
           - Migrated the cluster to Cilium with kube-proxy replacement for an eBPF-native datapath.
           - Added L7 MQTT visibility for EMQX without requiring application instrumentation.
@@ -375,3 +384,11 @@ chapters:
         description: |
           - Validated the GitOps promotion loop by fixing image pull failures caused by SHA-length mismatches.
           - Enabled ArgoCD to reconcile private GHCR images and roll updates across the simulation fleet.
+      - date: "2026-03-30"
+        title: "Kustomize & RBAC Render Hardening"
+        artifacts:
+          - name: "RCA 005: Kustomize RBAC Resource Collision"
+            url: "docs/incidents/005-kustomize-rbac-resource-collision.md"
+        description: |
+          - Resolved duplicate resource and namespace collision failures in the tiered Kustomize tree.
+          - Split cross-namespace RBAC from overlay-scoped resources so GitOps rendering stayed deterministic.


### PR DESCRIPTION
### Summary

This change backfills the incident record so resolved operational failures are documented alongside the existing ADR and notes system. It also improves the README navigation and evolution timeline so visitors can quickly find architecture decisions, RCAs, runbooks, and platform milestones.

### List of Changes

- Added resolved RCA coverage for Thanos, Cilium, Kustomize/RBAC, Loki, and worker ingestion incidents while keeping the incident index ordered by date.
- Improved documentation discoverability by adding a README documentation map and linking resolved incidents from the public evolution timeline.

### Verification

- [x] Markdown lint: `make lint`
- [x] Manual validation: verified RCA numbering, incident index links, and evolution timeline references.

