### PR TITLE
refactor(obs-processor): summarize counter metrics

### DIFF
--- a/internal/mcp/tools/obs-processor/src/main.rs
+++ b/internal/mcp/tools/obs-processor/src/main.rs
@@ -129,6 +129,12 @@ pub struct MetricSummaryEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trend_delta: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average_rate_per_second: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resets_detected: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_timestamp: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_timestamp: Option<f64>,
@@ -368,9 +374,10 @@ pub fn process_metrics_response(response: MetricResponse) -> MetricSummaryResult
             "vector" => {
                 if let Some((timestamp, val_str)) = series.value {
                     if let Ok(current) = val_str.parse::<f64>() {
+                        let kind = metric_kind(&name);
                         final_entries.push(MetricSummaryEntry {
                             metric: name,
-                            kind: "gauge".to_string(),
+                            kind: kind.to_string(),
                             status: "normal".to_string(),
                             labels,
                             sample_count: 1,
@@ -384,6 +391,9 @@ pub fn process_metrics_response(response: MetricResponse) -> MetricSummaryResult
                             first: None,
                             last: None,
                             trend_delta: None,
+                            delta: None,
+                            average_rate_per_second: None,
+                            resets_detected: None,
                             first_timestamp: None,
                             last_timestamp: None,
                         });
@@ -404,6 +414,42 @@ pub fn process_metrics_response(response: MetricResponse) -> MetricSummaryResult
                         let first = samples[0].1;
                         let last_timestamp = samples[samples.len() - 1].0;
                         let last = samples[samples.len() - 1].1;
+                        let kind = metric_kind(&name);
+
+                        if kind == "counter" {
+                            let (delta, resets_detected) = counter_delta_and_resets(&samples);
+                            let elapsed_seconds = last_timestamp - first_timestamp;
+                            let average_rate_per_second = if elapsed_seconds > 0.0 {
+                                Some(delta / elapsed_seconds)
+                            } else {
+                                None
+                            };
+
+                            final_entries.push(MetricSummaryEntry {
+                                metric: name,
+                                kind: kind.to_string(),
+                                status: "normal".to_string(),
+                                labels,
+                                sample_count: samples.len(),
+                                timestamp: None,
+                                current: None,
+                                min: None,
+                                max: None,
+                                avg: None,
+                                p95: None,
+                                p99: None,
+                                first: Some(first),
+                                last: Some(last),
+                                trend_delta: None,
+                                delta: Some(delta),
+                                average_rate_per_second,
+                                resets_detected: Some(resets_detected),
+                                first_timestamp: Some(first_timestamp),
+                                last_timestamp: Some(last_timestamp),
+                            });
+                            continue;
+                        }
+
                         let trend_delta = last - first;
 
                         let mut floats: Vec<f64> =
@@ -436,6 +482,9 @@ pub fn process_metrics_response(response: MetricResponse) -> MetricSummaryResult
                             first: Some(first),
                             last: Some(last),
                             trend_delta: Some(trend_delta),
+                            delta: None,
+                            average_rate_per_second: None,
+                            resets_detected: None,
                             first_timestamp: Some(first_timestamp),
                             last_timestamp: Some(last_timestamp),
                         });
@@ -460,6 +509,36 @@ fn metric_labels(metric: &HashMap<String, String>) -> BTreeMap<String, String> {
         .filter(|(key, _)| key.as_str() != "__name__")
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect()
+}
+
+fn metric_kind(name: &str) -> &'static str {
+    if name.ends_with("_total") || name.ends_with("_count") || name.ends_with("_sum") {
+        "counter"
+    } else {
+        "gauge"
+    }
+}
+
+fn counter_delta_and_resets(samples: &[(f64, f64)]) -> (f64, usize) {
+    if samples.len() < 2 {
+        return (0.0, 0);
+    }
+
+    let mut delta = 0.0;
+    let mut resets = 0;
+
+    for window in samples.windows(2) {
+        let previous = window[0].1;
+        let current = window[1].1;
+        if current >= previous {
+            delta += current - previous;
+        } else {
+            resets += 1;
+            delta += current;
+        }
+    }
+
+    (delta, resets)
 }
 
 fn main() -> io::Result<()> {

--- a/internal/mcp/tools/obs-processor/src/tests.rs
+++ b/internal/mcp/tools/obs-processor/src/tests.rs
@@ -276,3 +276,83 @@ fn test_process_metrics_trend_down() {
     assert_eq!(result.entries[0].first_timestamp, Some(1.0));
     assert_eq!(result.entries[0].last_timestamp, Some(3.0));
 }
+
+#[test]
+fn test_process_metrics_counter_stats() {
+    let mut metric = HashMap::new();
+    metric.insert("__name__".to_string(), "http_requests_total".to_string());
+    metric.insert("service".to_string(), "proxy".to_string());
+
+    let values = vec![
+        (10.0, "100".to_string()),
+        (20.0, "125".to_string()),
+        (30.0, "175".to_string()),
+    ];
+
+    let resp = MetricResponse {
+        status: "success".to_string(),
+        data: MetricData {
+            result_type: "matrix".to_string(),
+            result: vec![MetricResult {
+                metric,
+                value: None,
+                values: Some(values),
+            }],
+        },
+    };
+
+    let result = process_metrics_response(resp);
+    let entry = &result.entries[0];
+
+    assert_eq!(entry.metric, "http_requests_total");
+    assert_eq!(entry.kind, "counter");
+    assert_eq!(entry.status, "normal");
+    assert_eq!(entry.labels.get("service").unwrap(), "proxy");
+    assert_eq!(entry.sample_count, 3);
+    assert_eq!(entry.first, Some(100.0));
+    assert_eq!(entry.last, Some(175.0));
+    assert_eq!(entry.delta, Some(75.0));
+    assert_eq!(entry.average_rate_per_second, Some(3.75));
+    assert_eq!(entry.resets_detected, Some(0));
+    assert_eq!(entry.trend_delta, None);
+    assert_eq!(entry.min, None);
+    assert_eq!(entry.p95, None);
+    assert_eq!(entry.p99, None);
+    assert_eq!(entry.first_timestamp, Some(10.0));
+    assert_eq!(entry.last_timestamp, Some(30.0));
+}
+
+#[test]
+fn test_process_metrics_counter_reset_detection() {
+    let mut metric = HashMap::new();
+    metric.insert("__name__".to_string(), "worker_jobs_count".to_string());
+
+    let values = vec![
+        (1.0, "90".to_string()),
+        (2.0, "100".to_string()),
+        (3.0, "4".to_string()),
+        (4.0, "10".to_string()),
+    ];
+
+    let resp = MetricResponse {
+        status: "success".to_string(),
+        data: MetricData {
+            result_type: "matrix".to_string(),
+            result: vec![MetricResult {
+                metric,
+                value: None,
+                values: Some(values),
+            }],
+        },
+    };
+
+    let result = process_metrics_response(resp);
+    let entry = &result.entries[0];
+
+    assert_eq!(entry.kind, "counter");
+    assert_eq!(entry.delta, Some(20.0));
+    assert_eq!(entry.average_rate_per_second, Some(20.0 / 3.0));
+    assert_eq!(entry.resets_detected, Some(1));
+    assert_eq!(entry.first, Some(90.0));
+    assert_eq!(entry.last, Some(10.0));
+}


### PR DESCRIPTION
### Summary
Make the Rust `obs-processor` metric summarizer counter-aware for conventional Prometheus counter names. Counter matrices now report operationally useful delta, average rate, and reset information instead of raw gauge-style trend stats.

### List of Changes
- Added counter detection for metric names ending in `_total`, `_count`, or `_sum`.
- Added counter matrix summaries with delta, average rate per second, reset count, first and last values, and timestamps.

### Verification
- [x] `cargo test -p obs-processor`
- [x] `go test ./internal/mcp/tools/telemetry`
- [x] Direct counter and reset metric payloads piped through the Rust processor return counter-aware summaries

