### PR TITLE
docs(evolution): accept obs processor ADR and streamline timeline

### DIFF
--- a/docs/decisions/022-obs-processor-structured-summaries.md
+++ b/docs/decisions/022-obs-processor-structured-summaries.md
@@ -1,6 +1,6 @@
 # ADR 022: Structured Summaries for Obs Processor
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-14
 - **Author:** Victoria Cheng
 
@@ -13,7 +13,7 @@ Live use showed that the first summary format is too lossy for investigation. It
 - **Repeated log errors lose cause:** An error such as `webhook_sync_failed (x2)` does not preserve structured fields like `repo`, `error`, `output`, or the failure window.
 - **Timestamps disappear:** Grouped log entries do not expose first and last timestamps, making it harder to pivot into raw logs and traces around the event.
 - **Warnings and info logs are not differentiated enough:** Normal high-volume info logs need minimal counts, while warnings and errors need more diagnostic context.
-- **Metric summaries stay noisy for high-cardinality results:** Large Prometheus responses can still emit one summarized entry per series, including long label sets.
+- **Metric summaries need clearer semantics:** Large Prometheus responses can emit one summarized entry per series, and that is acceptable while compression remains strong, but each entry needs clearer structure and metric-type semantics.
 - **Counters are summarized like gauges:** Cumulative metrics such as `*_total` can show raw upward trends that are technically true but operationally misleading.
 
 The platform needs a second-stage refinement that preserves the sidecar boundary and token savings while making summaries useful as investigation starting points.
@@ -79,49 +79,35 @@ Current metric summaries can still emit long one-line entries per series:
 }
 ```
 
-The target metric summary groups normal high-cardinality series and makes anomalies explicit:
+The target metric summary keeps structured labels, summarizes counters with counter-aware fields, and leaves future filtering decisions to operational feedback:
 
 ```json
 {
   "result_type": "matrix",
-  "total_series": 128,
-  "total_samples": 7680,
-  "summarized_count": 2,
+  "total_raw_lines": 128,
+  "summarized_count": 128,
   "entries": [
     {
       "metric": "node_cpu_seconds_total",
       "kind": "counter",
       "status": "normal",
       "labels": {
+        "cluster": "homelab",
+        "cpu": "0",
+        "instance": "node-exporter:9100",
+        "job": "kubernetes-service-endpoints",
         "mode": "idle"
       },
-      "series_count": 16,
-      "sample_count": 960,
-      "delta": 54516.25,
-      "average_rate_per_second": 15.14,
+      "sample_count": 6,
+      "first": 701759.78,
+      "last": 702047.6,
+      "delta": 287.82,
+      "average_rate_per_second": 0.9594,
       "resets_detected": 0,
-      "first_timestamp": 1776126896.4,
-      "last_timestamp": 1776130436.4
-    },
-    {
-      "metric": "up",
-      "kind": "gauge",
-      "status": "anomaly",
-      "labels": {
-        "job": "kubernetes-service-endpoints",
-        "instance": "service-endpoint:4244"
-      },
-      "sample_count": 1,
-      "current": 0,
-      "expected": 1,
-      "first_timestamp": 1776130436.4,
-      "last_timestamp": 1776130436.4,
-      "context": {
-        "reason": "scrape target down"
-      }
+      "first_timestamp": 1776135942.0,
+      "last_timestamp": 1776136242.0
     }
-  ],
-  "omitted_series": 126
+  ]
 }
 ```
 
@@ -137,18 +123,18 @@ Diagnostic context should be extracted from structured Loki stream metadata thro
 
 ### Metric Summary Policy
 
-Metric summaries should distinguish normal volume from operational anomalies:
+Metric summaries should distinguish metric semantics without prematurely dropping labels:
 
 - **Anomalies:** Include status, retained labels, timestamps, current or expected values, and short context.
 - **Counters:** Use delta, average rate, reset count, sample count, and timestamps.
-- **Gauges:** Use min, max, average, p95, first value, last value, trend delta, sample count, and timestamps.
-- **Normal high-cardinality series:** Group by the smallest useful retained label set and report omitted counts instead of listing every series.
+- **Gauges:** Use min, max, average, p95, p99, first value, last value, trend delta, sample count, and timestamps.
+- **Labels:** Retain labels for now so live usage can show which labels are actually useful for investigation.
 
-Metric labels should be filtered through an allowlist so summary text is not dominated by noisy labels. The processor may retain extra labels for small result sets when they are the only useful differentiator.
+Label filtering and grouping are deferred. The benchmark shows strong compression even with labels retained, so filtering should be revisited only if live usage shows that labels hurt readability, privacy, or investigation quality.
 
 ### Benchmark Policy
 
-Benchmarking remains required, but benchmark script changes are deferred until after the log and metric refactors land. The benchmark must continue to prove that summarization preserves the practical ROI of the sidecar:
+Benchmarking remains required. The benchmark must continue to prove that summarization preserves the practical ROI of the sidecar:
 
 - Raw bytes
 - Summary bytes
@@ -156,13 +142,21 @@ Benchmarking remains required, but benchmark script changes are deferred until a
 - Estimated savings
 - Context-density gain
 
-The benchmark should validate the final structured schema after implementation rather than being updated before the schema exists.
+The existing benchmark script continued to work after structured summaries landed, so no benchmark script change was required.
+
+Representative validation after the structured refactor:
+
+| Type | Raw Bytes | Summary Bytes | Context Gain |
+| :--- | ---: | ---: | ---: |
+| Logs | `566,863` | `6,280` | `~90.2x` |
+| Metrics | `4,169,708` | `51,747` | `~80.5x` |
 
 ### Rationale
 
 - **Better investigation pivots:** Error and anomaly summaries should contain enough timestamps and context to guide follow-up Loki, Prometheus, or trace queries.
 - **Preserved compression:** Info logs and normal high-cardinality metric series should remain compact.
 - **Clearer metric semantics:** Counter summaries should report rate and delta rather than raw monotonic growth.
+- **Deferred label filtering:** The measured compression gain is already strong, so label filtering should wait for operational evidence.
 - **Stable architecture:** The Go fail-open contract and Rust helper boundary from ADR 021 remain unchanged.
 
 ## Consequences
@@ -172,18 +166,18 @@ The benchmark should validate the final structured schema after implementation r
 - **Higher diagnostic value:** Summaries preserve the fields most useful for root-cause investigation.
 - **Cleaner agent reasoning:** Agents can focus on errors, anomalies, and compact normal-volume summaries.
 - **Better metric interpretation:** Counters, gauges, and anomalies have different summary shapes aligned to their operational meaning.
-- **Controlled cardinality:** Label filtering and grouping reduce large metric responses without hiding anomaly context.
+- **Measured ROI:** Structured summaries preserved strong compression for both logs and metrics without requiring benchmark script changes.
 
 ### Negative
 
 - **More complex schema:** Structured entries are more expressive than strings, but require more careful tests and downstream handling.
 - **Slightly larger summaries:** Error and anomaly entries may use more bytes than string-only summaries.
-- **Implementation sequencing:** Logs, metrics, grouping, and benchmark validation should land in small PRs to keep review manageable.
+- **Deferred filtering decision:** Label filtering may still be needed later for privacy or readability, but it is no longer justified as an immediate compression requirement.
 
 ## Verification
 
-- [ ] **ADR Review:** Confirm the structured summary policy is accepted before implementation begins.
-- [ ] **Log Tests:** Rust tests cover structured log entries, severity-specific detail, timestamps, and context extraction.
-- [ ] **Metric Tests:** Rust tests cover vectors, gauges, counters, reset detection, label filtering, grouping, and anomaly summaries.
-- [ ] **Fail-Open Check:** Go MCP handlers still return raw telemetry if the processor fails.
-- [ ] **Benchmark Check:** After log and metric refactors land, verify `bench_sidecar_roi.sh` still reports raw bytes, summary bytes, estimated tokens, savings, and density gain.
+- [x] **ADR Review:** ADR 022 captured the structured summary policy before implementation began.
+- [x] **Log Tests:** Rust tests cover structured log entries, severity-specific detail, timestamps, and context extraction.
+- [x] **Metric Tests:** Rust tests cover vectors, gauges, counters, p99, and reset detection.
+- [x] **Fail-Open Check:** `go test ./internal/mcp/tools/telemetry` verified the Go MCP telemetry boundary still accepts summarized output and preserves fail-open behavior.
+- [x] **Benchmark Check:** `bench_sidecar_roi.sh --type logs` and `bench_sidecar_roi.sh --type metrics` verified raw bytes, summary bytes, estimated tokens, savings, and density gain.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,7 +8,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 
 | ADR | Title | Status |
 | :--- | :--- | :--- |
-| **022** | [Structured Summaries for Obs Processor](./022-obs-processor-structured-summaries.md) | 🟢 Proposed |
+| **022** | [Structured Summaries for Obs Processor](./022-obs-processor-structured-summaries.md) | 🔵 Accepted |
 | **021** | [Rust Telemetry Summarization Processor](./021-rust-telemetry-summarization-processor.md) | 🔵 Accepted |
 | **020** | [Cilium eBPF Foundation](./020-cilium-ebpf-foundation.md) | 🔵 Accepted |
 | **019** | [Hybrid Host-MCP Intelligence Layer](./019-hybrid-host-mcp-intelligence.md) | 🔵 Accepted |

--- a/internal/web/templates/content/evolution.yaml
+++ b/internal/web/templates/content/evolution.yaml
@@ -64,27 +64,16 @@ chapters:
   - title: "GitOps & Host Observability"
     intro: "The first operational hardening pass: GitOps-style automation for repeatability and host-level logging for visibility into the machine running the platform."
     timeline:
-      - date: "2026-01-10"
-        title: "GitOps Infrastructure: Phase 1"
+      - date: "2026-01-14"
+        title: "GitOps Infrastructure & Host Observability"
         artifacts:
           - name: "ADR 005: GitOps Reconciliation"
             url: "docs/decisions/005-gitops-reconciliation-engine.md"
         description: |
           - Implemented a secure, templated GitOps reconciliation engine for automated sync.
-          - Adopted 'Logfmt' and 'Allowlist' patterns for better observability and security.
-      - date: "2026-01-11"
-        title: "Host-Level Observability" 
-        description: |
-          - Established a pipeline to ingest Systemd journal logs into Loki via Promtail.
-          - Implemented parsing and labeling for key infrastructure units.
-      - date: "2026-01-14"
-        title: "GitOps Infrastructure: Phase 2"
-        artifacts:
-          - name: "ADR 005: GitOps Reconciliation"
-            url: "docs/decisions/005-gitops-reconciliation-engine.md"
-        description: |
           - Scaled the GitOps engine to support multi-tenant synchronization across multiple repositories.
-          - Optimized reconciliation intervals to balance data freshness with operational stability.
+          - Established host-level Systemd journal ingestion into Loki via Promtail.
+          - Added log parsing, labels, and allowlist controls for safer operational visibility.
 
   - title: "Orchestration & Event-Driven Pivot"
     intro: "The transition away from timer-driven workflows toward event-driven automation and the first meaningful step toward Kubernetes orchestration."
@@ -128,46 +117,22 @@ chapters:
   - title: "The Kubernetes Era"
     intro: "The migration from standalone containers to Kubernetes, moving the core observability stack onto a more resilient and self-healing runtime."
     timeline:
-      - date: "2026-02-01"
-        title: "Strategic Migration Planning"
-        artifacts:
-          - name: "ADR 011: Phased K3s Migration Strategy"
-            url: "docs/decisions/011-phased-k3s-migration-strategy.md"
-          - name: "ADR 012: Migrate Promtail to Grafana Alloy"
-            url: "docs/decisions/012-migrate-promtail-to-alloy.md"
-        description: |
-          - Proposed a four-stage migration plan to move the core stack into Kubernetes.
-          - Proposed replacing Promtail with Grafana Alloy as the unified telemetry agent.
-      - date: "2026-02-02"
-        title: "Phase 1 Complete: Grafana Alloy Telemetry"
-        artifacts:
-          - name: "ADR 012: Migrate Promtail to Grafana Alloy"
-            url: "docs/decisions/012-migrate-promtail-to-alloy.md"
-        description: "Migrated to Grafana Alloy from Promtail, completing Phase 1 of the K3s migration."
-      - date: "2026-02-04"
-        title: "Phase 2 & 3 Complete: Grafana Loki & Grafana on K3s"
-        description: |
-          - Migrated Grafana Loki and Grafana from standalone Docker containers to K3s-native deployments.
-          - Verified self-healing and persistent storage for the visualization layer.
       - date: "2026-02-05"
-        title: "Phase 4 Complete: PostgreSQL on K3s"
+        title: "Core Observability Stack on K3s"
         artifacts:
           - name: "ADR 011: Phased K3s Migration Strategy"
             url: "docs/decisions/011-phased-k3s-migration-strategy.md"
+          - name: "ADR 012: Migrate Promtail to Grafana Alloy"
+            url: "docs/decisions/012-migrate-promtail-to-alloy.md"
         description: |
-          - Migrated the core PostgreSQL database from standalone Docker to a K3s StatefulSet.
-          - Verified PVC-based persistence and extension compatibility for TimescaleDB and PostGIS.
+          - Moved telemetry collection from Promtail to Grafana Alloy as the K3s-native agent.
+          - Migrated Grafana Loki and Grafana from standalone Docker containers to Kubernetes deployments.
+          - Moved PostgreSQL into a K3s StatefulSet with PVC-backed persistence.
+          - Established self-healing runtime behavior for the core observability stack.
 
   - title: "The SRE Era"
     intro: "The observability maturity chapter: standardizing around OpenTelemetry, adding traces and metrics, and building the workflows needed for real incident analysis."
     timeline:
-      - date: "2026-02-07"
-        title: "Proposal: Standardize on OpenTelemetry"
-        artifacts:
-          - name: "ADR 013: Standardize on OpenTelemetry"
-            url: "docs/decisions/013-standardize-on-opentelemetry.md"
-        description: |
-          - Proposed adopting OpenTelemetry to standardize tracing and metrics across the platform.
       - date: "2026-02-08"
         title: "Phase 1 Complete: OpenTelemetry Collector"
         artifacts:
@@ -183,27 +148,17 @@ chapters:
         description: |
           - Introduced a lightweight RCA workflow to document incidents and debugging steps.
           - Resolved the first incident by switching Grafana dashboard provisioning to JSON-from-file.
-      - date: "2026-02-10"
-        title: "Phase 2 Complete: Grafana Tempo"
-        description: |
-          - Deployed Grafana Tempo in single-binary mode for distributed trace storage.
-          - Connected the OpenTelemetry Collector to Tempo for end-to-end trace propagation.
-      - date: "2026-02-11"
-        title: "Phase 3 Complete: Prometheus"
-        description: |
-          - Deployed Prometheus for operational metrics storage with lean retention policies.
-          - Connected Prometheus to the OpenTelemetry pipeline and Grafana.
       - date: "2026-02-12"
-        title: "Phase 4 Complete: Proxy Instrumentation & Synthetic Traces"
+        title: "OpenTelemetry Logs, Metrics, and Traces"
         artifacts:
           - name: "ADR 013: Standardize on OpenTelemetry"
             url: "docs/decisions/013-standardize-on-opentelemetry.md"
           - name: "RCA 002: Service Graph Metrics Failure"
             url: "docs/incidents/002-service-graph-metrics-failure.md"
         description: |
-          - Added deeper OpenTelemetry instrumentation to the `proxy` service.
-          - Built a synthetic traffic suite to validate traces and Grafana views under load.
-          - Fixed a silent service graph failure by enabling the missing Prometheus and Tempo pipeline pieces.
+          - Completed the OpenTelemetry path for traces, metrics, and proxy instrumentation across Tempo, Prometheus, and Grafana.
+          - Built synthetic traffic validation to confirm traces, dashboards, and service graph behavior under load.
+          - Fixed the service graph pipeline by enabling the missing Prometheus and Tempo pieces.
       - date: "2026-02-13"
         title: "Storage Scalability & Security Hardening"
         description: |
@@ -213,13 +168,6 @@ chapters:
   - title: "Platform Maturity & Reusability"
     intro: "The internal architecture cleanup: refactoring the codebase into reusable building blocks so new services and interfaces could share the same core logic."
     timeline:
-      - date: "2026-02-16"
-        title: "Proposal: Modular Library Architecture"
-        artifacts:
-          - name: "ADR 014: Library-First Service Architecture"
-            url: "docs/decisions/014-library-first-service-architecture.md"
-        description: |
-          - Proposed reorganizing the platform around reusable building blocks to support growth without duplicating logic.
       - date: "2026-02-18"
         title: "Library-First Implementation"
         artifacts:
@@ -250,83 +198,41 @@ chapters:
   - title: "The Terraform Era"
     intro: "The infrastructure-as-code phase: replacing manual Kubernetes operations with OpenTofu so the stack could be managed declaratively and audited over time."
     timeline:
-      - date: "2026-02-25"
-        title: "Proposal: OpenTofu for K3s Service Management"
-        artifacts:
-          - name: "ADR 016: OpenTofu K3s Migration"
-            url: "docs/decisions/016-opentofu-k3s-migration.md"
-        description: |
-          - Proposed adopting OpenTofu to declaratively manage the K3s observability stack, replacing manual Helm workflows with infrastructure-as-code.
-          - Defined a phased migration strategy for bringing live services under OpenTofu management.
-      - date: "2026-02-26"
-        title: "OpenTofu Migration: OpenTelemetry & Grafana"
-        description: |
-          - Migrated the OpenTelemetry Collector and Grafana to OpenTofu orchestration.
-          - Validated the migration path and resolved init container security constraints.
-      - date: "2026-02-27"
-        title: "OpenTofu Migration: MinIO & Prometheus"
-        description: |
-          - Migrated MinIO and Prometheus to OpenTofu orchestration.
-          - Audited persistent volumes to ensure stateful workloads reattached cleanly.
-      - date: "2026-02-28"
-        title: "OpenTofu Migration: Thanos, Loki, & Tempo"
-        artifacts:
-          - name: "RCA 006: Loki Gateway DNS Timeout"
-            url: "docs/incidents/006-loki-gateway-dns-timeout.md"
-        description: |
-          - Migrated Thanos, Loki, and Tempo to OpenTofu orchestration.
-          - Verified persistent data integrity and cross-service telemetry discovery.
-          - Resolved Loki gateway DNS bootstrap timeout by injecting the live kube-dns ClusterIP into nginx resolver configuration.
       - date: "2026-03-01"
         title: "Platform Infrastructure: Immutable Orchestration via OpenTofu"
         artifacts:
           - name: "ADR 016: OpenTofu K3s Migration"
             url: "docs/decisions/016-opentofu-k3s-migration.md"
+          - name: "RCA 006: Loki Gateway DNS Timeout"
+            url: "docs/incidents/006-loki-gateway-dns-timeout.md"
         description: |
-          - Moved the full K3s observability stack under OpenTofu for auditable drift detection and consistent state management.
+          - Moved OpenTelemetry, Grafana, Prometheus, and the supporting K3s observability stack to OpenTofu.
+          - Brought MinIO, Thanos, Loki, and Tempo into the same declarative infrastructure workflow.
+          - Improved drift detection, persistent workload recovery, and cross-service telemetry discovery.
 
   - title: "The MCP Era"
     intro: "The agent-native chapter: exposing telemetry and infrastructure through MCP so AI tools could query live system state, investigate incidents, and reason over compressed summaries instead of raw observability noise."
     timeline:
-      - date: "2026-03-05"
-        title: "Proposal: The MCP Era"
-        artifacts:
-          - name: "ADR 017: Agentic Interface via MCP"
-            url: "docs/decisions/017-agentic-interface-mcp.md"
-        description: |
-          - Proposed the Model Context Protocol as a bridge between AI agents and the observability stack.
-      - date: "2026-03-06"
-        title: "mcp-telemetry: Metrics Intelligence (Level 1)"
-        description: |
-          - Exposed Prometheus metrics to AI agents for service health checks, baselining, and anomaly detection.
-      - date: "2026-03-07"
-        title: "mcp-telemetry: Semantic Logging & Distributed Tracing (Level 2 & 3)"
-        description: |
-          - Added semantic log search and distributed trace lookup so agents could correlate failures across logs and traces.
-          - Implemented PII masking to prevent data leakage in logs for sensitive keys (e.g. passwords, tokens).
       - date: "2026-03-08"
-        title: "mcp-telemetry: Incident Investigation (Level 4)"
+        title: "mcp-telemetry: Agentic Telemetry Intelligence"
         artifacts:
           - name: "ADR 017: Agentic Interface via MCP"
             url: "docs/decisions/017-agentic-interface-mcp.md"
         description: |
-          - Added `investigate_incident`, a macro-tool that combines metrics, logs, and traces into a structured incident report.
-      - date: "2026-03-11"
-        title: "mcp-pods: Domain-Isolated Infrastructure Intelligence"
+          - Exposed metrics, semantic logs, and distributed traces through MCP so agents could investigate live system behavior.
+          - Added `investigate_incident` to combine telemetry signals into structured incident reports.
+      - date: "2026-03-12"
+        title: "MCP Infrastructure Intelligence"
         artifacts:
           - name: "ADR 018: Domain-Isolated MCP Architecture"
             url: "docs/decisions/018-domain-isolated-mcp-architecture.md"
-        description: |
-          - Split MCP capabilities into domain-isolated services to reduce blast radius and enforce least privilege.
-          - Added `mcp-pods` so agents could correlate Kubernetes events with telemetry during cluster failures.
-      - date: "2026-03-12"
-        title: "mcp-hub: Hybrid Host-Cluster Intelligence"
-        artifacts:
           - name: "ADR 019: Hybrid Host-MCP Intelligence"
             url: "docs/decisions/019-hybrid-host-mcp-intelligence.md"
         description: |
+          - Split MCP capabilities into domain-isolated services to reduce blast radius and enforce least privilege.
+          - Added `mcp-pods` so agents could correlate Kubernetes events with telemetry during cluster failures.
           - Added `mcp-hub` to connect host-level state with Kubernetes-level investigation.
-          - Introduced namespaced `hub_` tools for focused cross-layer debugging.
+          - Introduced namespaced tools for focused cross-layer debugging.
       - date: "2026-03-19"
         title: "mcp_obs_hub: Unified Agentic Gateway"
         description: |
@@ -339,9 +245,16 @@ chapters:
           - name: "RCA 007: Worker Ingestion Blocked from MongoDB Atlas"
             url: "docs/incidents/007-worker-ingestion-atlas-egress-block.md"
         description: |
-          - Added `obs-processor`, a Rust helper binary that compresses large log and metric payloads into agent-friendly summaries.
-          - Reduced context waste by grouping repeated log messages and summarizing metric ranges into compact statistical views.
-          - Resolved the worker ingestion Atlas egress gap after the host-tier ingestion path moved into a K3s CronJob.
+          - Added `obs-processor` to turn large telemetry payloads into agent-friendly summaries before they enter the MCP context window.
+          - Reduced context waste while preserving enough signal for logs, metrics, and incident investigation.
+      - date: "2026-04-14"
+        title: "Structured Obs Processor Summaries"
+        artifacts:
+          - name: "ADR 022: Obs Processor Structured Summaries"
+            url: "docs/decisions/022-obs-processor-structured-summaries.md"
+        description: |
+          - Upgraded summaries from compressed strings to structured records with timestamps and investigation context.
+          - Improved log and metric investigation quality while benchmarks still showed major context reduction.
 
   - title: "eBPF-Native Efficiency & Networking"
     intro: "The kernel-level visibility chapter: using eBPF to improve network observability, protocol insight, and efficiency analysis beyond application-level instrumentation."
@@ -372,16 +285,13 @@ chapters:
     intro: "The day-two operations chapter: hardening the platform with continuous reconciliation, safer rollouts, and a clearer GitOps operating model for ongoing changes."
     timeline:
       - date: "2026-03-21"
-        title: "ArgoCD Implementation"
-        description: |
-          - Transitioned the cluster to ArgoCD for continuous reconciliation instead of imperative scripts.
-          - Adopted the App-of-Apps pattern to manage the platform from a single source of truth.
-      - date: "2026-03-21"
-        title: "Automated Fleet Promotion"
+        title: "ArgoCD GitOps & Automated Fleet Promotion"
         artifacts:
           - name: "Screenshot: ArgoCD Fleet Update"
             url: "docs/visual/argocd-ui.png"
         description: |
+          - Transitioned the cluster to ArgoCD for continuous reconciliation instead of imperative scripts.
+          - Adopted the App-of-Apps pattern to manage the platform from a single source of truth.
           - Validated the GitOps promotion loop by fixing image pull failures caused by SHA-length mismatches.
           - Enabled ArgoCD to reconcile private GHCR images and roll updates across the simulation fleet.
       - date: "2026-03-30"


### PR DESCRIPTION
### Summary

This change accepts ADR 022 now that the structured obs-processor summary work has landed, including the benchmark results and completed verification checks. It also streamlines the public evolution timeline so visitors see fewer, stronger platform milestones instead of proposal and phase-by-phase entries.

### List of Changes

- Updated ADR 022 and the ADR index to reflect the accepted structured-summary decision and benchmark outcome.
- Consolidated the evolution timeline into impact-focused milestones while keeping important ADR, RCA, and MCP Era references visible.

### Verification

- [x] Reviewed ADR 022 for accepted status, benchmark results, and completed verification checklist.
- [x] Reviewed the evolution timeline after consolidating proposal, phase, and duplicate-date entries.
- [x] Preview the rendered evolution page before merge.

