### PR TITLE
chore(ci): add trivy security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,12 +7,22 @@ on:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/**'
+      - 'config/**'
+      - 'docker/**'
+      - 'k3s/**'
+      - 'tofu/**'
   pull_request:
     branches: [main]
     paths:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/**'
+      - 'config/**'
+      - 'docker/**'
+      - 'k3s/**'
+      - 'tofu/**'
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sundays
 
@@ -31,3 +41,21 @@ jobs:
 
       - name: Run vuln-scan
         run: make vuln-scan
+
+  trivy-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '0'
+          format: table

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,19 @@ This document is the **Primary Heuristic** for AI agents. It defines the systemi
 
 ## 1. Systemic Architecture & Mental Model
 
-Agents must distinguish between the two primary orchestration tiers to avoid "circular dependencies" and resource contention.
+Observability Hub is an end-to-end platform engineering system. Agents should reason about changes through the platform ownership loop:
+
+```text
+Source of Truth -> Runtime -> Signals -> Decisions -> Actions -> Memory
+```
+
+Every meaningful change should fit into that loop: declarative state, running service, telemetry, diagnosis, remediation, or documentation.
+
+Agents must also distinguish between the two primary orchestration tiers to avoid circular dependencies and resource contention.
 
 ### 🌌 Hybrid Orchestration Layers
 
-- **Host Tier (Systemd)**: Reserved for hardware-level telemetry, security gates, and GitOps reconciliation. Reliability here is critical for cluster recovery. Core logic is strictly encapsulated in `internal/` to ensure reusability and enforce project boundaries.
+- **Host Tier (Systemd)**: Reserved for local control, security gates, GitOps reconciliation, and services that need direct host access. Reliability here is critical for cluster recovery. Core logic is strictly encapsulated in `internal/` to ensure reusability and enforce project boundaries.
 - **Cluster Tier (K3s)**: Handles scalable data services (Postgres, Loki, Prometheus, Grafana, Tempo, MinIO). Orchestrated via **OpenTofu (IaC)** in `tofu/`.
 
 ### 🏗️ Directory Map (Consolidated Monorepo)
@@ -18,11 +26,13 @@ Agents must distinguish between the two primary orchestration tiers to avoid "ci
   - **`cmd/proxy/`**: API Gateway and GitOps webhook listener entry point.
   - **`cmd/worker/`**: Unified one-shot execution engine for Analytics and Ingestion tasks.
 - **`internal/`**: Private Implementation Layer. Enforces Go's internal package visibility rules.
+- **`config/`**: Runtime configuration source of truth. OpenBao config lives under `config/openbao/`.
+- **`docker/`**: Per-image Dockerfiles for published service images.
 - **`k3s/`**: Kubernetes manifests and Helm values for the data platform.
 - **`makefiles/`**: Modular logic for the root automation layer.
 - **`systemd/`**: Host-tier unit files for production service management.
 - **`scripts/`**: Operational utilities (Traffic gen, ADR creation, Tailscale gate).
-- **`docs/`**: Institutional memory. ADRs, Architecture, Incidents, and Notes.
+- **`docs/`**: Institutional memory. ADRs, Architecture, Incidents, Notes, Workflows, and the Ownership Model.
 
 ## 2. Staff-Level Automation (`Makefile`)
 
@@ -34,9 +44,11 @@ The project uses a unified automation layer. **Always prefer `make` commands** a
 | :--- | :--- | :--- |
 | **Governance** | `make adr` | Creates a new Architecture Decision Record. |
 | **IaC** | `tofu plan` / `apply` | Manages K3s data services and infrastructure state. |
-| **Quality** | `make lint` | Lints markdown and configuration files. |
+| **Quality** | `make lint` | Lints markdown files. |
+| **Config Quality** | `make lint-configs` | Formats OpenBao policies and validates GitHub Actions workflows. |
 | **Go Dev** | `make test` | Runs full test suite across the monorepo. |
-| **Security** | `make vuln-scan` | Executes `govulncheck` for dependency auditing. |
+| **Go Coverage** | `make test-cov` | Runs Go tests with coverage reporting. |
+| **Security** | `make vuln-scan` | Executes `govulncheck` for Go dependency auditing. |
 | **K3s Ops** | `make build-postgres` | Builds and imports the custom PG image into K3s. |
 | **Host Ops** | `make proxy-build` | Builds proxy server to `bin/` and restarts the service. |
 
@@ -49,16 +61,18 @@ The project uses a unified automation layer. **Always prefer `make` commands** a
 - **Environment Loading**: Always use `internal/env` for standardized `.env` discovery.
 - **Observability**: Every service must emit structured JSON logs using `internal/telemetry`.
 - **Telemetry**: All instrumentation must be handled through the centralized `internal/telemetry` library.
-- **Testing**: Table-driven tests are the standard. Run `make go-cov` to verify coverage.
+- **Testing**: Table-driven tests are the standard. Run `make test-cov` to verify coverage.
 
 ### 📝 Institutional Memory (Documentation)
 
 - **ADRs (`docs/decisions/`)**: Mandatory for any architectural pivot.
 - **RCA (`docs/incidents/`)**: Document every failure to prevent regression.
 - **Golden Path**: Maintain `docs/workflows.md` to reflect the CI/CD reality.
+- **Ownership Model**: Maintain `docs/architecture/ownership.md` when ownership domains, diagnostic paths, or remediation paths change.
 
 ## 4. Operational Excellence & Safety
 
 - **Secrets**: NEVER commit secrets. Use `.env` for local dev and OpenBao for production.
+- **OpenBao Config**: Keep OpenBao server and policy configuration under `config/openbao/`.
 - **GitOps**: Host-tier changes are applied via `gitops_sync.sh` (triggered by Proxy webhooks).
-- **Security**: All Kubernetes manifests must pass `kube-lint`. All Go code must pass `go-vuln-scan`.
+- **Security**: Kubernetes manifests must pass `kube-lint`. Go code must pass `make vuln-scan`. CI runs Trivy across repository files for vulnerabilities, secrets, and misconfigurations.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -79,11 +79,11 @@ Enforces documentation standards and protects the "Institutional Memory."
 
 ### 🛡️ [Security Scan](../.github/workflows/security.yml)
 
-Proactively identifies vulnerabilities in the Go codebase and dependencies.
+Proactively identifies vulnerabilities, exposed secrets, and infrastructure misconfigurations.
 
-- **Trigger**: Pushes or Pull Requests affecting Go code, and weekly scheduled runs.
-- **Responsibility**: Executes `govulncheck` to scan for known security vulnerabilities.
-- **Key Feature**: Multi-layered protection through both event-driven and periodic security auditing.
+- **Trigger**: Pushes or Pull Requests affecting Go code, workflows, config, Dockerfiles, K3s manifests, or OpenTofu files, plus weekly scheduled runs.
+- **Responsibility**: Executes `govulncheck` for Go dependencies and Trivy filesystem scans for vulnerabilities, secrets, and misconfigurations.
+- **Key Feature**: Multi-layered protection across application code, infrastructure-as-code, container definitions, and repository content.
 
 ---
 


### PR DESCRIPTION
### Summary
This change adds Trivy-backed repository scanning to the security workflow. It extends CI beyond Go dependency checks so platform files, container definitions, infrastructure manifests, and repository content are checked for vulnerabilities, secrets, and misconfigurations.

### List of Changes
- Added a Trivy filesystem scan to the security workflow so CI covers security risks across application, infrastructure, and configuration files.
- Updated workflow and agent documentation so the security ownership model reflects both `govulncheck` and Trivy scanning.

### Verification
- [x] Ran `nix-shell --run "action-validator .github/workflows/security.yml"` successfully.

