### PR TITLE
feat(benchmark): add obs processor language benchmark

### DIFF
--- a/scripts/bench/obs_processor.go
+++ b/scripts/bench/obs_processor.go
@@ -1,0 +1,551 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"os"
+	"sort"
+	"strings"
+)
+
+type LokiResponse struct {
+	Status string   `json:"status"`
+	Data   LokiData `json:"data"`
+}
+
+type LokiData struct {
+	ResultType string       `json:"resultType"`
+	Result     []LokiStream `json:"result"`
+}
+
+type LokiStream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string        `json:"values"`
+}
+
+type MetricResponse struct {
+	Status string     `json:"status"`
+	Data   MetricData `json:"data"`
+}
+
+type MetricData struct {
+	ResultType string         `json:"resultType"`
+	Result     []MetricResult `json:"result"`
+}
+
+type MetricResult struct {
+	Metric map[string]string `json:"metric"`
+	Value  []any             `json:"value,omitempty"`
+	Values [][]any           `json:"values,omitempty"`
+}
+
+type LogSummaryResult struct {
+	TotalRawLines   int               `json:"total_raw_lines"`
+	SummarizedCount int               `json:"summarized_count"`
+	Entries         []LogSummaryEntry `json:"entries"`
+}
+
+type LogSummaryEntry struct {
+	Level            string            `json:"level"`
+	Message          string            `json:"message"`
+	Count            int               `json:"count"`
+	FirstTimestampNS string            `json:"first_timestamp_ns"`
+	LastTimestampNS  string            `json:"last_timestamp_ns"`
+	Context          map[string]string `json:"context,omitempty"`
+}
+
+type logAggregate struct {
+	count            int
+	firstTimestampNS string
+	lastTimestampNS  string
+	context          map[string]string
+}
+
+type MetricSummaryResult struct {
+	ResultType      string               `json:"result_type"`
+	TotalRawLines   int                  `json:"total_raw_lines"`
+	SummarizedCount int                  `json:"summarized_count"`
+	Entries         []MetricSummaryEntry `json:"entries"`
+}
+
+type MetricSummaryEntry struct {
+	Metric               string            `json:"metric"`
+	Kind                 string            `json:"kind"`
+	Status               string            `json:"status"`
+	Labels               map[string]string `json:"labels"`
+	SampleCount          int               `json:"sample_count"`
+	Timestamp            *float64          `json:"timestamp,omitempty"`
+	Current              *float64          `json:"current,omitempty"`
+	Min                  *float64          `json:"min,omitempty"`
+	Max                  *float64          `json:"max,omitempty"`
+	Avg                  *float64          `json:"avg,omitempty"`
+	P95                  *float64          `json:"p95,omitempty"`
+	P99                  *float64          `json:"p99,omitempty"`
+	First                *float64          `json:"first,omitempty"`
+	Last                 *float64          `json:"last,omitempty"`
+	TrendDelta           *float64          `json:"trend_delta,omitempty"`
+	Delta                *float64          `json:"delta,omitempty"`
+	AverageRatePerSecond *float64          `json:"average_rate_per_second,omitempty"`
+	ResetsDetected       *int              `json:"resets_detected,omitempty"`
+	FirstTimestamp       *float64          `json:"first_timestamp,omitempty"`
+	LastTimestamp        *float64          `json:"last_timestamp,omitempty"`
+}
+
+func processLokiResponse(response LokiResponse) LogSummaryResult {
+	infoEntries := make(map[string]*logAggregate)
+	warnEntries := make(map[string]*logAggregate)
+	errorEntries := make(map[string]*logAggregate)
+	totalLines := 0
+
+	for _, stream := range response.Data.Result {
+		level := stream.Stream["level"]
+		if level == "" {
+			level = stream.Stream["detected_level"]
+		}
+		if level == "" {
+			level = stream.Stream["severity_text"]
+		}
+		if level == "" {
+			level = "info"
+		}
+		normalized := normalizeLogLevel(strings.ToLower(level))
+
+		for _, entry := range stream.Values {
+			totalLines++
+			if len(entry) < 2 {
+				continue
+			}
+			timestampNS := entry[0]
+			message := entry[1]
+
+			switch normalized {
+			case "error":
+				recordLogEntry(errorEntries, message, timestampNS, extractLogContext(stream.Stream, "error"))
+			case "warn":
+				recordLogEntry(warnEntries, message, timestampNS, extractLogContext(stream.Stream, "warn"))
+			default:
+				recordLogEntry(infoEntries, message, timestampNS, nil)
+			}
+		}
+	}
+
+	finalEntries := make([]LogSummaryEntry, 0)
+	appendLogEntries(&finalEntries, "error", errorEntries)
+	appendLogEntries(&finalEntries, "warn", warnEntries)
+	appendLogEntries(&finalEntries, "info", infoEntries)
+
+	return LogSummaryResult{
+		TotalRawLines:   totalLines,
+		SummarizedCount: len(finalEntries),
+		Entries:         finalEntries,
+	}
+}
+
+func normalizeLogLevel(level string) string {
+	switch level {
+	case "error", "err", "fatal", "panic":
+		return "error"
+	case "warn", "warning":
+		return "warn"
+	default:
+		return "info"
+	}
+}
+
+func recordLogEntry(entries map[string]*logAggregate, message, timestampNS string, context map[string]string) {
+	existing, ok := entries[message]
+	if !ok {
+		entries[message] = &logAggregate{
+			count:            1,
+			firstTimestampNS: timestampNS,
+			lastTimestampNS:  timestampNS,
+			context:          context,
+		}
+		return
+	}
+
+	existing.count++
+	if timestampBefore(timestampNS, existing.firstTimestampNS) {
+		existing.firstTimestampNS = timestampNS
+	}
+	if timestampAfter(timestampNS, existing.lastTimestampNS) {
+		existing.lastTimestampNS = timestampNS
+	}
+	mergeLogContext(&existing.context, context)
+}
+
+func timestampBefore(left, right string) bool {
+	lb, lok := new(big.Int).SetString(left, 10)
+	rb, rok := new(big.Int).SetString(right, 10)
+	if lok && rok {
+		return lb.Cmp(rb) < 0
+	}
+	return left < right
+}
+
+func timestampAfter(left, right string) bool {
+	lb, lok := new(big.Int).SetString(left, 10)
+	rb, rok := new(big.Int).SetString(right, 10)
+	if lok && rok {
+		return lb.Cmp(rb) > 0
+	}
+	return left > right
+}
+
+func appendLogEntries(finalEntries *[]LogSummaryEntry, level string, entries map[string]*logAggregate) {
+	type pair struct {
+		message string
+		entry   *logAggregate
+	}
+
+	pairs := make([]pair, 0, len(entries))
+	for msg, ent := range entries {
+		pairs = append(pairs, pair{message: msg, entry: ent})
+	}
+
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].entry.count == pairs[j].entry.count {
+			return pairs[i].message < pairs[j].message
+		}
+		return pairs[i].entry.count > pairs[j].entry.count
+	})
+
+	for _, p := range pairs {
+		*finalEntries = append(*finalEntries, LogSummaryEntry{
+			Level:            level,
+			Message:          p.message,
+			Count:            p.entry.count,
+			FirstTimestampNS: p.entry.firstTimestampNS,
+			LastTimestampNS:  p.entry.lastTimestampNS,
+			Context:          p.entry.context,
+		})
+	}
+}
+
+func extractLogContext(stream map[string]string, scope string) map[string]string {
+	var allowed []string
+	if scope == "error" {
+		allowed = []string{"service_name", "repo", "error", "status", "path", "ref", "action"}
+	} else {
+		allowed = []string{"service_name", "status", "path", "action", "error"}
+	}
+
+	context := make(map[string]string)
+	for _, key := range allowed {
+		if value, ok := stream[key]; ok && strings.TrimSpace(value) != "" {
+			context[key] = trimContextValue(value)
+		}
+	}
+
+	if scope == "error" {
+		if output, ok := stream["output"]; ok {
+			if preview := previewOutput(output); preview != "" {
+				context["output_preview"] = preview
+			}
+		}
+	}
+
+	if len(context) == 0 {
+		return nil
+	}
+	return context
+}
+
+func trimContextValue(value string) string {
+	const maxLen = 160
+	trimmed := strings.TrimSpace(value)
+	runes := []rune(trimmed)
+	if len(runes) <= maxLen {
+		return trimmed
+	}
+	return string(runes[:maxLen]) + "..."
+}
+
+func previewOutput(output string) string {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return ""
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &obj); err == nil {
+		if msg, ok := obj["msg"].(string); ok {
+			return trimContextValue(msg)
+		}
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) > 0 {
+		return trimContextValue(lines[0])
+	}
+	return ""
+}
+
+func mergeLogContext(existingContext *map[string]string, newContext map[string]string) {
+	if newContext == nil {
+		return
+	}
+	if *existingContext == nil {
+		*existingContext = make(map[string]string)
+	}
+	for key, value := range newContext {
+		if existingValue, ok := (*existingContext)[key]; ok {
+			if existingValue != value {
+				(*existingContext)[key] = "<multiple>"
+			}
+		} else {
+			(*existingContext)[key] = value
+		}
+	}
+}
+
+func processMetricsResponse(response MetricResponse) MetricSummaryResult {
+	finalEntries := make([]MetricSummaryEntry, 0)
+	seriesCount := len(response.Data.Result)
+	resultType := response.Data.ResultType
+
+	for _, series := range response.Data.Result {
+		name := series.Metric["__name__"]
+		if name == "" {
+			name = "unknown"
+		}
+		labels := metricLabels(series.Metric)
+
+		switch resultType {
+		case "vector":
+			timestamp, current, ok := parseSample(series.Value)
+			if !ok {
+				continue
+			}
+			kind := metricKind(name)
+			finalEntries = append(finalEntries, MetricSummaryEntry{
+				Metric:      name,
+				Kind:        kind,
+				Status:      "normal",
+				Labels:      labels,
+				SampleCount: 1,
+				Timestamp:   ptrFloat(timestamp),
+				Current:     ptrFloat(current),
+			})
+		case "matrix":
+			samples := make([][2]float64, 0, len(series.Values))
+			for _, raw := range series.Values {
+				ts, val, ok := parseSample(raw)
+				if ok {
+					samples = append(samples, [2]float64{ts, val})
+				}
+			}
+			if len(samples) == 0 {
+				continue
+			}
+
+			firstTimestamp := samples[0][0]
+			first := samples[0][1]
+			lastTimestamp := samples[len(samples)-1][0]
+			last := samples[len(samples)-1][1]
+			kind := metricKind(name)
+
+			if kind == "counter" {
+				delta, resets := counterDeltaAndResets(samples)
+				var avgRate *float64
+				elapsed := lastTimestamp - firstTimestamp
+				if elapsed > 0 {
+					avgRate = ptrFloat(delta / elapsed)
+				}
+				finalEntries = append(finalEntries, MetricSummaryEntry{
+					Metric:               name,
+					Kind:                 kind,
+					Status:               "normal",
+					Labels:               labels,
+					SampleCount:          len(samples),
+					First:                ptrFloat(first),
+					Last:                 ptrFloat(last),
+					Delta:                ptrFloat(delta),
+					AverageRatePerSecond: avgRate,
+					ResetsDetected:       ptrInt(resets),
+					FirstTimestamp:       ptrFloat(firstTimestamp),
+					LastTimestamp:        ptrFloat(lastTimestamp),
+				})
+				continue
+			}
+
+			floats := make([]float64, len(samples))
+			for i, sample := range samples {
+				floats[i] = sample[1]
+			}
+			sort.Float64s(floats)
+
+			minV := floats[0]
+			maxV := floats[len(floats)-1]
+			sum := 0.0
+			for _, v := range floats {
+				sum += v
+			}
+			avg := sum / float64(len(floats))
+			p95idx := int(math.Floor(float64(len(floats)) * 0.95))
+			if p95idx >= len(floats) {
+				p95idx = len(floats) - 1
+			}
+			p99idx := int(math.Floor(float64(len(floats)) * 0.99))
+			if p99idx >= len(floats) {
+				p99idx = len(floats) - 1
+			}
+			p95 := floats[p95idx]
+			p99 := floats[p99idx]
+			trendDelta := last - first
+
+			finalEntries = append(finalEntries, MetricSummaryEntry{
+				Metric:         name,
+				Kind:           "gauge",
+				Status:         "normal",
+				Labels:         labels,
+				SampleCount:    len(samples),
+				Min:            ptrFloat(minV),
+				Max:            ptrFloat(maxV),
+				Avg:            ptrFloat(avg),
+				P95:            ptrFloat(p95),
+				P99:            ptrFloat(p99),
+				First:          ptrFloat(first),
+				Last:           ptrFloat(last),
+				TrendDelta:     ptrFloat(trendDelta),
+				FirstTimestamp: ptrFloat(firstTimestamp),
+				LastTimestamp:  ptrFloat(lastTimestamp),
+			})
+		}
+	}
+
+	return MetricSummaryResult{
+		ResultType:      resultType,
+		TotalRawLines:   seriesCount,
+		SummarizedCount: len(finalEntries),
+		Entries:         finalEntries,
+	}
+}
+
+func parseSample(sample []any) (float64, float64, bool) {
+	if len(sample) < 2 {
+		return 0, 0, false
+	}
+
+	timestamp, ok := anyToFloat(sample[0])
+	if !ok {
+		return 0, 0, false
+	}
+	value, ok := anyToFloat(sample[1])
+	if !ok {
+		return 0, 0, false
+	}
+	return timestamp, value, true
+}
+
+func anyToFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case string:
+		var f float64
+		_, err := fmt.Sscanf(x, "%f", &f)
+		return f, err == nil
+	case json.Number:
+		f, err := x.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func metricLabels(metric map[string]string) map[string]string {
+	labels := make(map[string]string)
+	for key, value := range metric {
+		if key == "__name__" {
+			continue
+		}
+		labels[key] = value
+	}
+	return labels
+}
+
+func metricKind(name string) string {
+	if strings.HasSuffix(name, "_total") || strings.HasSuffix(name, "_count") || strings.HasSuffix(name, "_sum") {
+		return "counter"
+	}
+	return "gauge"
+}
+
+func counterDeltaAndResets(samples [][2]float64) (float64, int) {
+	if len(samples) < 2 {
+		return 0, 0
+	}
+	delta := 0.0
+	resets := 0
+	for i := 1; i < len(samples); i++ {
+		previous := samples[i-1][1]
+		current := samples[i][1]
+		if current >= previous {
+			delta += current - previous
+		} else {
+			resets++
+			delta += current
+		}
+	}
+	return delta, resets
+}
+
+func ptrFloat(v float64) *float64 { return &v }
+func ptrInt(v int) *int           { return &v }
+
+func main() {
+	typeLong := flag.String("type", "logs", "telemetry type: logs or metrics")
+	typeShort := flag.String("t", "", "telemetry type: logs or metrics")
+	flag.Parse()
+
+	telemetryType := strings.ToLower(*typeLong)
+	if *typeShort != "" {
+		telemetryType = strings.ToLower(*typeShort)
+	}
+	if telemetryType != "logs" && telemetryType != "metrics" {
+		telemetryType = "logs"
+	}
+
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(string(input)) == "" {
+		return
+	}
+
+	if telemetryType == "logs" {
+		var response LokiResponse
+		if err := json.Unmarshal(input, &response); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing Loki JSON: %v\n", err)
+			os.Exit(1)
+		}
+		result := processLokiResponse(response)
+		out, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println(string(out))
+		return
+	}
+
+	var response MetricResponse
+	if err := json.Unmarshal(input, &response); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing Prometheus JSON: %v\n", err)
+		os.Exit(1)
+	}
+	result := processMetricsResponse(response)
+	out, err := json.Marshal(result)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
+}

--- a/scripts/bench/obs_processor.rs
+++ b/scripts/bench/obs_processor.rs
@@ -1,0 +1,576 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap, hash_map::Entry};
+use std::env;
+use std::io::{self, Read};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum TelemetryType {
+    Logs,
+    Metrics,
+}
+
+impl TelemetryType {
+    fn from_args() -> Self {
+        let mut telemetry_type = TelemetryType::Logs;
+        let args: Vec<String> = env::args().collect();
+        let mut i = 1usize;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--type" | "-t" if i + 1 < args.len() => {
+                    telemetry_type = match args[i + 1].as_str() {
+                        "metrics" => TelemetryType::Metrics,
+                        _ => TelemetryType::Logs,
+                    };
+                    i += 1;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        telemetry_type
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LokiResponse {
+    pub status: String,
+    pub data: LokiData,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LokiData {
+    #[serde(rename = "resultType")]
+    pub result_type: String,
+    pub result: Vec<LokiStream>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LokiStream {
+    pub stream: HashMap<String, String>,
+    pub values: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MetricResponse {
+    pub status: String,
+    pub data: MetricData,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MetricData {
+    #[serde(rename = "resultType")]
+    pub result_type: String,
+    pub result: Vec<MetricResult>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MetricResult {
+    pub metric: HashMap<String, String>,
+    pub value: Option<(f64, String)>,
+    pub values: Option<Vec<(f64, String)>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct LogSummaryResult {
+    pub total_raw_lines: usize,
+    pub summarized_count: usize,
+    pub entries: Vec<LogSummaryEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct LogSummaryEntry {
+    pub level: String,
+    pub message: String,
+    pub count: usize,
+    pub first_timestamp_ns: String,
+    pub last_timestamp_ns: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug)]
+struct LogAggregate {
+    count: usize,
+    first_timestamp_ns: String,
+    last_timestamp_ns: String,
+    context: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct MetricSummaryResult {
+    pub result_type: String,
+    pub total_raw_lines: usize,
+    pub summarized_count: usize,
+    pub entries: Vec<MetricSummaryEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct MetricSummaryEntry {
+    pub metric: String,
+    pub kind: String,
+    pub status: String,
+    pub labels: BTreeMap<String, String>,
+    pub sample_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p95: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p99: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trend_delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average_rate_per_second: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resets_detected: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_timestamp: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_timestamp: Option<f64>,
+}
+
+pub fn process_loki_response(response: LokiResponse) -> LogSummaryResult {
+    let mut info_entries: HashMap<String, LogAggregate> = HashMap::new();
+    let mut warn_entries: HashMap<String, LogAggregate> = HashMap::new();
+    let mut error_entries: HashMap<String, LogAggregate> = HashMap::new();
+    let mut total_lines = 0;
+
+    for stream in response.data.result {
+        let level = stream
+            .stream
+            .get("level")
+            .or_else(|| stream.stream.get("detected_level"))
+            .or_else(|| stream.stream.get("severity_text"))
+            .map(|l| l.to_lowercase())
+            .unwrap_or_else(|| "info".to_string());
+        let normalized_level = normalize_log_level(&level);
+
+        for entry in stream.values {
+            total_lines += 1;
+            if entry.len() < 2 {
+                continue;
+            }
+            let timestamp_ns = &entry[0];
+            let message = &entry[1];
+
+            match normalized_level {
+                "error" => {
+                    let context = extract_log_context(&stream.stream, ContextScope::Error);
+                    record_log_entry(&mut error_entries, message, timestamp_ns, context);
+                }
+                "warn" => {
+                    let context = extract_log_context(&stream.stream, ContextScope::Warn);
+                    record_log_entry(&mut warn_entries, message, timestamp_ns, context);
+                }
+                _ => {
+                    record_log_entry(&mut info_entries, message, timestamp_ns, None);
+                }
+            }
+        }
+    }
+
+    let mut final_entries = Vec::new();
+    append_log_entries(&mut final_entries, "error", error_entries);
+    append_log_entries(&mut final_entries, "warn", warn_entries);
+    append_log_entries(&mut final_entries, "info", info_entries);
+
+    LogSummaryResult {
+        total_raw_lines: total_lines,
+        summarized_count: final_entries.len(),
+        entries: final_entries,
+    }
+}
+
+fn normalize_log_level(level: &str) -> &'static str {
+    match level {
+        "error" | "err" | "fatal" | "panic" => "error",
+        "warn" | "warning" => "warn",
+        _ => "info",
+    }
+}
+
+fn record_log_entry(
+    entries: &mut HashMap<String, LogAggregate>,
+    message: &str,
+    timestamp_ns: &str,
+    context: Option<HashMap<String, String>>,
+) {
+    match entries.entry(message.to_string()) {
+        Entry::Occupied(mut occupied) => {
+            let entry = occupied.get_mut();
+            entry.count += 1;
+            if timestamp_before(timestamp_ns, &entry.first_timestamp_ns) {
+                entry.first_timestamp_ns = timestamp_ns.to_string();
+            }
+            if timestamp_after(timestamp_ns, &entry.last_timestamp_ns) {
+                entry.last_timestamp_ns = timestamp_ns.to_string();
+            }
+            merge_log_context(&mut entry.context, context);
+        }
+        Entry::Vacant(vacant) => {
+            vacant.insert(LogAggregate {
+                count: 1,
+                first_timestamp_ns: timestamp_ns.to_string(),
+                last_timestamp_ns: timestamp_ns.to_string(),
+                context,
+            });
+        }
+    }
+}
+
+fn timestamp_before(left: &str, right: &str) -> bool {
+    match (left.parse::<u128>(), right.parse::<u128>()) {
+        (Ok(left), Ok(right)) => left < right,
+        _ => left < right,
+    }
+}
+
+fn timestamp_after(left: &str, right: &str) -> bool {
+    match (left.parse::<u128>(), right.parse::<u128>()) {
+        (Ok(left), Ok(right)) => left > right,
+        _ => left > right,
+    }
+}
+
+fn append_log_entries(
+    final_entries: &mut Vec<LogSummaryEntry>,
+    level: &str,
+    entries: HashMap<String, LogAggregate>,
+) {
+    let mut sorted_entries: Vec<_> = entries.into_iter().collect();
+    sorted_entries.sort_by(|a, b| b.1.count.cmp(&a.1.count).then_with(|| a.0.cmp(&b.0)));
+
+    for (message, entry) in sorted_entries {
+        final_entries.push(LogSummaryEntry {
+            level: level.to_string(),
+            message,
+            count: entry.count,
+            first_timestamp_ns: entry.first_timestamp_ns,
+            last_timestamp_ns: entry.last_timestamp_ns,
+            context: entry.context,
+        });
+    }
+}
+
+#[derive(Copy, Clone)]
+enum ContextScope {
+    Error,
+    Warn,
+}
+
+fn extract_log_context(
+    stream: &HashMap<String, String>,
+    scope: ContextScope,
+) -> Option<HashMap<String, String>> {
+    let allowed_keys = match scope {
+        ContextScope::Error => [
+            "service_name",
+            "repo",
+            "error",
+            "status",
+            "path",
+            "ref",
+            "action",
+        ]
+        .as_slice(),
+        ContextScope::Warn => ["service_name", "status", "path", "action", "error"].as_slice(),
+    };
+
+    let mut context = HashMap::new();
+    for key in allowed_keys {
+        if let Some(value) = stream.get(*key).filter(|value| !value.trim().is_empty()) {
+            context.insert((*key).to_string(), trim_context_value(value));
+        }
+    }
+
+    if matches!(scope, ContextScope::Error) {
+        if let Some(output) = stream.get("output").and_then(|value| preview_output(value)) {
+            context.insert("output_preview".to_string(), output);
+        }
+    }
+
+    if context.is_empty() {
+        None
+    } else {
+        Some(context)
+    }
+}
+
+fn trim_context_value(value: &str) -> String {
+    const MAX_CONTEXT_VALUE_LEN: usize = 160;
+    let trimmed = value.trim();
+    if trimmed.chars().count() <= MAX_CONTEXT_VALUE_LEN {
+        return trimmed.to_string();
+    }
+
+    let mut truncated: String = trimmed.chars().take(MAX_CONTEXT_VALUE_LEN).collect();
+    truncated.push_str("...");
+    truncated
+}
+
+fn preview_output(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if let Some(message) = value.get("msg").and_then(|msg| msg.as_str()) {
+            return Some(trim_context_value(message));
+        }
+    }
+
+    trimmed.lines().next().map(trim_context_value)
+}
+
+fn merge_log_context(
+    existing_context: &mut Option<HashMap<String, String>>,
+    new_context: Option<HashMap<String, String>>,
+) {
+    let Some(new_context) = new_context else {
+        return;
+    };
+
+    let existing_context = existing_context.get_or_insert_with(HashMap::new);
+    for (key, value) in new_context {
+        existing_context
+            .entry(key)
+            .and_modify(|existing_value| {
+                if existing_value != &value {
+                    *existing_value = "<multiple>".to_string();
+                }
+            })
+            .or_insert(value);
+    }
+}
+
+pub fn process_metrics_response(response: MetricResponse) -> MetricSummaryResult {
+    let mut final_entries = Vec::new();
+    let series_count = response.data.result.len();
+    let result_type = response.data.result_type.clone();
+
+    for series in response.data.result {
+        let name = series
+            .metric
+            .get("__name__")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let labels = metric_labels(&series.metric);
+
+        match result_type.as_str() {
+            "vector" => {
+                if let Some((timestamp, val_str)) = series.value {
+                    if let Ok(current) = val_str.parse::<f64>() {
+                        let kind = metric_kind(&name);
+                        final_entries.push(MetricSummaryEntry {
+                            metric: name,
+                            kind: kind.to_string(),
+                            status: "normal".to_string(),
+                            labels,
+                            sample_count: 1,
+                            timestamp: Some(timestamp),
+                            current: Some(current),
+                            min: None,
+                            max: None,
+                            avg: None,
+                            p95: None,
+                            p99: None,
+                            first: None,
+                            last: None,
+                            trend_delta: None,
+                            delta: None,
+                            average_rate_per_second: None,
+                            resets_detected: None,
+                            first_timestamp: None,
+                            last_timestamp: None,
+                        });
+                    }
+                }
+            }
+            "matrix" => {
+                if let Some(values) = series.values {
+                    let samples: Vec<(f64, f64)> = values
+                        .iter()
+                        .filter_map(|(timestamp, value)| {
+                            value.parse::<f64>().ok().map(|value| (*timestamp, value))
+                        })
+                        .collect();
+
+                    if !samples.is_empty() {
+                        let first_timestamp = samples[0].0;
+                        let first = samples[0].1;
+                        let last_timestamp = samples[samples.len() - 1].0;
+                        let last = samples[samples.len() - 1].1;
+                        let kind = metric_kind(&name);
+
+                        if kind == "counter" {
+                            let (delta, resets_detected) = counter_delta_and_resets(&samples);
+                            let elapsed_seconds = last_timestamp - first_timestamp;
+                            let average_rate_per_second = if elapsed_seconds > 0.0 {
+                                Some(delta / elapsed_seconds)
+                            } else {
+                                None
+                            };
+
+                            final_entries.push(MetricSummaryEntry {
+                                metric: name,
+                                kind: kind.to_string(),
+                                status: "normal".to_string(),
+                                labels,
+                                sample_count: samples.len(),
+                                timestamp: None,
+                                current: None,
+                                min: None,
+                                max: None,
+                                avg: None,
+                                p95: None,
+                                p99: None,
+                                first: Some(first),
+                                last: Some(last),
+                                trend_delta: None,
+                                delta: Some(delta),
+                                average_rate_per_second,
+                                resets_detected: Some(resets_detected),
+                                first_timestamp: Some(first_timestamp),
+                                last_timestamp: Some(last_timestamp),
+                            });
+                            continue;
+                        }
+
+                        let trend_delta = last - first;
+                        let mut floats: Vec<f64> = samples.iter().map(|(_, value)| *value).collect();
+                        floats.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                        let min = floats[0];
+                        let max = floats[floats.len() - 1];
+                        let sum: f64 = floats.iter().sum();
+                        let avg = sum / floats.len() as f64;
+                        let p95_idx = (floats.len() as f64 * 0.95).floor() as usize;
+                        let p95 = floats[p95_idx.min(floats.len() - 1)];
+                        let p99_idx = (floats.len() as f64 * 0.99).floor() as usize;
+                        let p99 = floats[p99_idx.min(floats.len() - 1)];
+
+                        final_entries.push(MetricSummaryEntry {
+                            metric: name,
+                            kind: "gauge".to_string(),
+                            status: "normal".to_string(),
+                            labels,
+                            sample_count: samples.len(),
+                            timestamp: None,
+                            current: None,
+                            min: Some(min),
+                            max: Some(max),
+                            avg: Some(avg),
+                            p95: Some(p95),
+                            p99: Some(p99),
+                            first: Some(first),
+                            last: Some(last),
+                            trend_delta: Some(trend_delta),
+                            delta: None,
+                            average_rate_per_second: None,
+                            resets_detected: None,
+                            first_timestamp: Some(first_timestamp),
+                            last_timestamp: Some(last_timestamp),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    MetricSummaryResult {
+        result_type,
+        total_raw_lines: series_count,
+        summarized_count: final_entries.len(),
+        entries: final_entries,
+    }
+}
+
+fn metric_labels(metric: &HashMap<String, String>) -> BTreeMap<String, String> {
+    metric
+        .iter()
+        .filter(|(key, _)| key.as_str() != "__name__")
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn metric_kind(name: &str) -> &'static str {
+    if name.ends_with("_total") || name.ends_with("_count") || name.ends_with("_sum") {
+        "counter"
+    } else {
+        "gauge"
+    }
+}
+
+fn counter_delta_and_resets(samples: &[(f64, f64)]) -> (f64, usize) {
+    if samples.len() < 2 {
+        return (0.0, 0);
+    }
+
+    let mut delta = 0.0;
+    let mut resets = 0;
+
+    for window in samples.windows(2) {
+        let previous = window[0].1;
+        let current = window[1].1;
+        if current >= previous {
+            delta += current - previous;
+        } else {
+            resets += 1;
+            delta += current;
+        }
+    }
+
+    (delta, resets)
+}
+
+fn main() -> io::Result<()> {
+    let telemetry_type = TelemetryType::from_args();
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+
+    if buffer.trim().is_empty() {
+        return Ok(());
+    }
+
+    match telemetry_type {
+        TelemetryType::Logs => {
+            let response: LokiResponse = match serde_json::from_str(&buffer) {
+                Ok(res) => res,
+                Err(e) => {
+                    eprintln!("Error parsing Loki JSON: {}", e);
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, e));
+                }
+            };
+            let result = process_loki_response(response);
+            println!("{}", serde_json::to_string(&result).unwrap());
+        }
+        TelemetryType::Metrics => {
+            let response: MetricResponse = match serde_json::from_str(&buffer) {
+                Ok(res) => res,
+                Err(e) => {
+                    eprintln!("Error parsing Prometheus JSON: {}", e);
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, e));
+                }
+            };
+            let result = process_metrics_response(response);
+            println!("{}", serde_json::to_string(&result).unwrap());
+        }
+    }
+
+    Ok(())
+}

--- a/scripts/benchmark_obs_processor.sh
+++ b/scripts/benchmark_obs_processor.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Benchmarks Go vs Rust obs processors using the same API payload.
+#
+# Default usage:
+#   ./scripts/benchmark_obs_processor.sh
+#
+# Example usage:
+#   ./scripts/benchmark_obs_processor.sh \
+#     --type metrics \
+#     --iterations 30
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GO_FILE="${ROOT_DIR}/bench/obs_processor.go"
+RUST_FILE="${ROOT_DIR}/bench/obs_processor.rs"
+
+LOGS_URL="${LOKI_URL:-http://localhost:30100}"
+METRICS_URL="${PROMETHEUS_URL:-http://localhost:30090}"
+LOGS_QUERY='{service_name="proxy"}'
+METRICS_QUERY='up'
+ITERATIONS=20
+TYPE="logs"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --iterations) ITERATIONS="$2"; shift 2 ;;
+    --type) TYPE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '1,40p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$TYPE" != "logs" && "$TYPE" != "metrics" ]]; then
+  echo "--type must be logs or metrics" >&2
+  exit 1
+fi
+
+if [[ ! -f "$GO_FILE" ]]; then
+  echo "Missing file: $GO_FILE" >&2
+  exit 1
+fi
+if [[ ! -f "$RUST_FILE" ]]; then
+  echo "Missing file: $RUST_FILE" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 1
+fi
+if ! command -v go >/dev/null 2>&1; then
+  echo "go is required" >&2
+  exit 1
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo is required" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+PAYLOAD_FILE="${TMP_DIR}/payload.json"
+GO_BIN="${TMP_DIR}/obs-go"
+RUST_PROJ="${TMP_DIR}/rust-proj"
+RUST_BIN="${RUST_PROJ}/target/release/obs-processor-rust-standalone"
+
+END_NS="$(date +%s)000000000"
+START_NS="$(( $(date +%s) - 86400 ))000000000"
+
+if [[ "$TYPE" == "logs" ]]; then
+  echo "Fetching Loki logs payload (24h)..."
+  curl -fsS -G "${LOGS_URL%/}/loki/api/v1/query_range" \
+    --data-urlencode "query=${LOGS_QUERY}" \
+    --data-urlencode "start=${START_NS}" \
+    --data-urlencode "end=${END_NS}" \
+    > "$PAYLOAD_FILE"
+else
+  echo "Fetching Prometheus metrics payload (24h)..."
+  START_S="${START_NS:0:-9}"
+  END_S="${END_NS:0:-9}"
+  curl -fsS -G "${METRICS_URL%/}/api/v1/query_range" \
+    --data-urlencode "query=${METRICS_QUERY}" \
+    --data-urlencode "start=${START_S}" \
+    --data-urlencode "end=${END_S}" \
+    --data-urlencode "step=60s" \
+    > "$PAYLOAD_FILE"
+fi
+
+if [[ ! -s "$PAYLOAD_FILE" ]]; then
+  echo "API payload is empty." >&2
+  exit 1
+fi
+
+echo "Building Go binary..."
+go build -o "$GO_BIN" "$GO_FILE"
+
+echo "Building Rust binary..."
+mkdir -p "${RUST_PROJ}/src"
+cat > "${RUST_PROJ}/Cargo.toml" <<'EOF'
+[package]
+name = "obs-processor-rust-standalone"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+EOF
+cp "$RUST_FILE" "${RUST_PROJ}/src/main.rs"
+cargo build --release --manifest-path "${RUST_PROJ}/Cargo.toml" --quiet
+
+run_once_ms() {
+  local cmd="$1"
+  local start_ns end_ns elapsed_ns
+  start_ns="$(date +%s%N)"
+  eval "$cmd" < "$PAYLOAD_FILE" > /dev/null
+  end_ns="$(date +%s%N)"
+  elapsed_ns=$((end_ns - start_ns))
+  awk "BEGIN { printf \"%.3f\", ${elapsed_ns}/1000000 }"
+}
+
+summarize_times() {
+  local label="$1"
+  shift
+  local times=("$@")
+
+  local min max sum avg
+  min="${times[0]}"
+  max="${times[0]}"
+  sum=0
+
+  for t in "${times[@]}"; do
+    awk "BEGIN { if (${t} < ${min}) print \"${t}\"; else print \"${min}\" }" >/tmp/.bench_min.$$
+    min="$(cat /tmp/.bench_min.$$)"
+    awk "BEGIN { if (${t} > ${max}) print \"${t}\"; else print \"${max}\" }" >/tmp/.bench_max.$$
+    max="$(cat /tmp/.bench_max.$$)"
+    sum="$(awk "BEGIN { printf \"%.6f\", ${sum} + ${t} }")"
+  done
+
+  avg="$(awk "BEGIN { printf \"%.3f\", ${sum} / ${#times[@]} }")"
+  rm -f /tmp/.bench_min.$$ /tmp/.bench_max.$$
+
+  printf "%-8s avg=%8sms min=%8sms max=%8sms (n=%s)\n" "$label" "$avg" "$min" "$max" "${#times[@]}"
+}
+
+echo "Running benchmark (${ITERATIONS} iterations, type=${TYPE})..."
+go_times=()
+rust_times=()
+
+# Warm-up
+"$GO_BIN" --type "$TYPE" < "$PAYLOAD_FILE" > /dev/null
+"$RUST_BIN" --type "$TYPE" < "$PAYLOAD_FILE" > /dev/null
+
+for ((i=1; i<=ITERATIONS; i++)); do
+  go_ms="$(run_once_ms "\"$GO_BIN\" --type \"$TYPE\"")"
+  rust_ms="$(run_once_ms "\"$RUST_BIN\" --type \"$TYPE\"")"
+  go_times+=("$go_ms")
+  rust_times+=("$rust_ms")
+done
+
+echo
+echo "Benchmark result (same API payload):"
+summarize_times "Go" "${go_times[@]}"
+summarize_times "Rust" "${rust_times[@]}"


### PR DESCRIPTION
### Summary
This change adds a standalone benchmark harness for the obs processor so Rust and Go can be compared on the same fetched telemetry payload. It also organizes the benchmark assets under `scripts/` for easier reuse and portability. The result is a repeatable basis for language performance decisions in log/metric summarization.

### List of Changes
- Established a repeatable Rust-vs-Go benchmark workflow for the obs processor so performance decisions are grounded in consistent measurements.
- Improved long-term reviewability by standardizing benchmark inputs and keeping the benchmark assets organized in one predictable location.

### Verification
- [x] Ran `bash -n scripts/benchmark_obs_processor.sh` successfully.
- [x] Run `./scripts/benchmark_obs_processor.sh --type logs --iterations 20` and `--type metrics --iterations 20` on target host and record baseline numbers.

