### PR TITLE
docs(platform): reframe infra observability narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 ## What is this?
 
-Observability Hub is a closed-loop platform ownership system for a self-hosted Kubernetes environment.
+Observability Hub is an end-to-end infrastructure platform for a self-hosted Kubernetes environment.
 
-It is built to show end-to-end ownership, not just tool installation: infrastructure definition, deployment automation, runtime observability, incident diagnosis, safe remediation, and operational memory.
+The project is designed from source of truth to runtime operations: infrastructure definition, deployment automation, runtime observability, incident diagnosis, safe remediation, and operational memory.
 
 Git and infrastructure definitions describe the intended state. Host and cluster runtimes execute that state. Telemetry systems expose behavior. MCP tools and dashboards support diagnosis. Remediation flows apply controlled fixes. ADRs, RCAs, and notes preserve what was learned.
-
-It demonstrates how a platform engineering team owns a system end to end:
 
 - provision infrastructure declaratively
 - deploy services through GitOps
 - collect logs, metrics, traces, and network signals
 - diagnose failures with dashboards, runbooks, and MCP tools
+- analyze resource utilization, capacity pressure, and efficiency trends
 - remediate safely through bounded operational paths
 - preserve decisions and incidents as operational memory
 
@@ -37,13 +36,11 @@ flowchart TB
     Memory --> Source
 ```
 
-The goal is to make the ownership loop visible first, so the project reads as a complete platform engineering system rather than a collection of DevOps tools.
-
 - 🌐 [Project Portal](https://victoriacheng15.github.io/observability-hub/)  
 
 ---
 
-## 🔍 What I Built (Quick Proof)
+## 🔍 What This Builds (Quick Proof)
 
 - Kubernetes (K3s) homelab running 10+ platform components
 - GitOps deployment using Argo CD (App-of-Apps pattern)
@@ -53,6 +50,7 @@ The goal is to make the ownership loop visible first, so the project reads as a 
 - Centralized dashboards for monitoring and debugging
 - Secrets management without hardcoding credentials
 - Infrastructure as Code using OpenTofu (layered architecture)
+- Resource and capacity analysis using Kubernetes, host, and telemetry signals
 - Data ingestion pipeline with worker-based processing
 - eBPF-based networking and visibility using Cilium
 - Backup and storage integration with Azure Blob Storage + MinIO
@@ -74,11 +72,12 @@ This platform is built as connected ownership domains:
 | Networking | Cilium eBPF visibility, policy control, and flow debugging |
 | CI/CD | GitHub Actions, image publication, and GitOps reconciliation |
 | Incident Response | Diagnostics, bounded repair actions, RCAs, and runbooks |
+| Resource Efficiency | Kubernetes and host telemetry used for capacity and cost-aware analysis |
 | Data Ingestion | Worker-based batch processing and analytics jobs |
 
 ---
 
-## 🧠 Problems I Solved
+## 🧠 Problems Solved
 
 | Problem | Solution |
 | :--- | :--- |
@@ -88,6 +87,7 @@ This platform is built as connected ownership domains:
 | Single point of failure | High-availability PostgreSQL and backup paths |
 | Hard-to-debug issues | MCP diagnostics, dashboards, runbooks, and incident reports |
 | Infrastructure drift | Declarative source of truth with OpenTofu, Kustomize, and GitOps |
+| Unclear resource pressure | Kubernetes, host, and workload telemetry correlated for capacity decisions |
 | Operational knowledge loss | Versioned ADRs, RCAs, notes, and workflow docs |
 
 ---
@@ -216,6 +216,7 @@ This project demonstrates how to build a production-like DevOps platform using:
 - Full observability (logs, metrics, traces)  
 - Infrastructure as Code  
 - High availability systems  
+- Capacity and cost-aware infrastructure analysis  
 - Real-world debugging and failure handling  
 
-It reflects how modern platform teams operate in real environments.
+It reflects practical infrastructure ownership: designing the system, running it, observing it, debugging it, and using telemetry to make better operational and cost-aware decisions.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,7 +4,7 @@ This directory contains the architectural blueprints for the Observability Hub. 
 
 ## Architecture At A Glance
 
-The Observability Hub is a self-hosted platform that provisions infrastructure, deploys workloads, collects telemetry, supports diagnosis, applies bounded remediation, and records operational memory.
+The Observability Hub is a self-hosted platform that provisions infrastructure, deploys workloads, collects telemetry, supports diagnosis, applies bounded remediation, and records operational memory. It uses observability data to reason about reliability, capacity, and cost-aware infrastructure decisions as part of the same operating loop.
 
 For a fast mental model, the main system story is:
 
@@ -34,6 +34,7 @@ The surrounding platform supports that flow:
 - **OpenTelemetry Collector**: Central intake and routing point for logs, metrics, and traces
 - **LGTM Stack**: Loki, Tempo, and Prometheus as the main observability backends
 - **Grafana**: Unified visualization layer for operators
+- **Resource Analytics**: Kubernetes, host, and workload signals for capacity and efficiency analysis
 - **MCP Gateway**: Agent-readable diagnostic and operational interface
 - **ArgoCD + OpenTofu**: Deployment and reconciliation control plane
 

--- a/docs/architecture/core-concepts/automation.md
+++ b/docs/architecture/core-concepts/automation.md
@@ -1,16 +1,16 @@
 # Automation & GitOps Architecture
 
-The Observability Hub leverages a **Dual-Tier GitOps Model** to manage both cluster infrastructure and host-level automation. By combining **ArgoCD** for Kubernetes reconciliation with **Systemd** for process management, we ensure full-stack reliability and self-healing.
+The Observability Hub leverages a **Dual-Tier GitOps Model** to manage both cluster infrastructure and host-level automation. ArgoCD handles Kubernetes reconciliation, while Systemd manages native host processes that need direct machine access.
 
 This page explains how the platform stays synchronized and recoverable. Instead of treating automation as a single deployment layer, the system separates cluster reconciliation from host synchronization so each environment can be managed with the tools that fit it best.
 
-For a recruiter or hiring manager, the important point is that this project is not just running services. It also demonstrates a deliberate operating model for keeping infrastructure, host automation, and observability aligned.
+This keeps infrastructure, host automation, and observability aligned without forcing every responsibility into one orchestration layer.
 
 ## Core Philosophy
 
 - **Declarative Kubernetes (Tier 1)**: All cluster resources are managed via **ArgoCD**. This ensures that the "Intent" defined in Git is continuously reconciled, providing automated recovery from configuration drift.
 - **Resilient Host-Sync (Tier 2)**: Critical host-tier components (Proxy, Tailscale Gate) are synchronized via native Systemd services and custom scripts. This ensures the host's physical filesystem and systemd units stay in sync with the remote repository independently of the Kubernetes runtime.
-- **Event-Driven Reconciliation**: We prioritize webhooks over polling. Push events from GitHub trigger a simultaneous loop: ArgoCD updates the cluster, and the Proxy-Webhook triggers a fast-forward sync of the local host directory.
+- **Event-Driven Reconciliation**: Webhooks are preferred over polling. Push events from GitHub trigger a simultaneous loop: ArgoCD updates the cluster, and the Proxy-Webhook triggers a fast-forward sync of the local host directory.
 
 ## GitOps Implementation
 
@@ -56,7 +56,7 @@ The system consists of several main service families, each with a `.service` uni
 
 ## Operational Excellence
 
-Our automation employs several production-grade patterns:
+The automation layer uses several production-grade patterns:
 
 - **Symmetric Configuration**: Both ArgoCD and OpenTofu inherit global resource and security policies from a centralized `_standards.yaml`.
 - **Security Gating**: The `tailscale-gate` service ensures the public entry point (Funnel) is automatically closed if the underlying `proxy` service stops.

--- a/docs/architecture/core-concepts/observability.md
+++ b/docs/architecture/core-concepts/observability.md
@@ -6,13 +6,13 @@ The Observability Hub implements a high-fidelity logging, tracing, and metrics p
 
 At the highest level, this platform answers a simple question:
 
-How does telemetry move from the services I run to the dashboards I use?
+How does telemetry move from running services to operator dashboards?
 
 The short answer is:
 
 `Apps and services -> OpenTelemetry Collector -> Loki / Tempo / Prometheus -> Grafana`
 
-This is the most important mental model for first-time readers. It captures the core portfolio story of the platform without requiring the reader to understand every supporting subsystem on the first pass.
+This model keeps the telemetry path clear before introducing the supporting subsystems. The same telemetry also supports capacity planning and cost-aware infrastructure analysis because resource usage is tied back to the workloads and systems that produced it.
 
 ```mermaid
 flowchart LR
@@ -139,12 +139,12 @@ The platform implements a dual-path logging strategy: structured application log
 
 ## 📊 Metrics
 
-The platform aggregates infrastructure metrics through Prometheus scraping, application-level metrics via OpenTelemetry, and specialized analytical data.
+The platform aggregates infrastructure metrics through Prometheus scraping, application-level metrics via OpenTelemetry, and specialized analytical data. These metrics are used for reliability diagnosis first, then extended into capacity and efficiency analysis so cost becomes one operational signal among CPU, memory, storage, network, and workload behavior.
 
 - **Collection Strategy**:
   - **Infrastructure Scrapes**: **Prometheus** actively pulls metrics from the Kubernetes API, nodes (cAdvisor), pods, service endpoints, and internal exporters (`kube-state-metrics`, `node-exporter`).
   - **Telemetry Ingestion**: The **OpenTelemetry Collector** exports OTLP metrics (including derived span-metrics from Tempo) to **Prometheus**, which is configured with the `remote-write-receiver` enabled to ingest these metrics.
-  - **Host Resource Metrics**: Host-level metrics (e.g., CPU, RAM, disk, network) are first collected by **Prometheus**. The **Unified Worker (Analytics Mode)** then retrieves this data from **Prometheus** via **Thanos**, forwards it via the **OpenTelemetry Collector**, and exports it to **PostgreSQL** for long-term analytical reporting.
+  - **Host Resource Metrics**: Host-level metrics (e.g., CPU, RAM, disk, network) are first collected by **Prometheus**. The **Unified Worker (Analytics Mode)** then retrieves this data from **Prometheus** via **Thanos**, forwards it via the **OpenTelemetry Collector**, and exports it to **PostgreSQL** for long-term resource, capacity, and cost-aware analytical reporting.
   - **Network Metrics (eBPF)**: Cilium and Hubble export eBPF-level network metrics (e.g., packet drops, connection latency, and L7 protocol stats) directly to Prometheus via dedicated exporters.
 - **Persistence**:
   - **Local Storage**: Prometheus maintains a high-resolution 24-hour local TSDB on `local-path` persistent volumes.
@@ -155,7 +155,7 @@ The platform aggregates infrastructure metrics through Prometheus scraping, appl
 Distributed tracing is powered by OpenTelemetry for correlation and performance profiling across high-throughput pipelines.
 
 - **Collection Pipeline**:
-  - **Instrumentation**: Services use the **OpenTelemetry SDK** to generate spans in OTLP format. We follow a **Pure Wrapper** philosophy where shared libraries (`internal/db`) provide standardized infrastructure spans (e.g., `db.postgres.record_metric`), while services own the root spans (`job.*` or `handler.*`).
+  - **Instrumentation**: Services use the **OpenTelemetry SDK** to generate spans in OTLP format. The platform follows a **Pure Wrapper** pattern where shared libraries (`internal/db`) provide standardized infrastructure spans (e.g., `db.postgres.record_metric`), while services own the root spans (`job.*` or `handler.*`).
   - **Ingestion**: Spans are sent to the **OpenTelemetry Collector** via gRPC (NodePort `30317`) or HTTP (NodePort `30318`), which batches and exports them to **Grafana Tempo**.
   - **Processing**: Tempo analyzes raw spans to generate derived **Service Graphs** and **Span Metrics**, which are pushed to Prometheus via `remote_write` for operational correlation.
 - **Persistence**:
@@ -168,7 +168,7 @@ The platform leverages **Cilium** and **Hubble** for deep, kernel-level network 
 - **L7 Visibility (MQTT)**: Cilium's eBPF-native datapath enables sidecar-less inspection of application-level protocols. This allows the platform to attribute network traffic to specific MQTT topics without requiring modifications to the application code.
 - **Autonomous Flow Analysis**: Beyond the Hubble UI, the platform exposes raw flow data directly to AI agents via the MCP `observe_network_flows` tool. This enables instantaneous, packet-level auditing of `FORWARDED`, `DROPPED`, and `DENIED` traffic across the entire cluster.
 - **Service Mapping**: Hubble provides a real-time service map and detailed flow logs, enabling engineers to visualize and troubleshoot network connectivity and performance between pods and host services.
-- **Metrics Correlation**: Network-level signals (like connection latency or throughput) are correlated with application-level traces and hardware-level energy metrics (Kepler) to provide a complete view of system efficiency.
+- **Metrics Correlation**: Network-level signals (like connection latency or throughput) are correlated with application-level traces and hardware-level energy metrics (Kepler) to provide a complete view of system efficiency and infrastructure cost drivers.
 
 ## 🗄️ Shared Data Stores
 

--- a/docs/architecture/infrastructure/deployment.md
+++ b/docs/architecture/infrastructure/deployment.md
@@ -2,9 +2,9 @@
 
 The infrastructure layer follows a **hybrid model**: core data services (Storage, Logs, Viz) are orchestrated via **OpenTofu** on **Kubernetes (k3s)**, while application logic and automation agents run as native host-level Systemd services for direct hardware and filesystem access.
 
-This split is one of the key design choices in the project. It keeps scalable observability services inside the cluster while preserving direct host access for the components that need low-level control, local filesystem access, or hardware awareness.
+This split is one of the key design choices in the project. It keeps scalable observability services inside the cluster while preserving direct host access for the components that need low-level control, local filesystem access, or hardware awareness. That boundary also makes resource analysis more accurate: cluster workloads, host services, storage, and network paths can be measured in the tier where they actually run.
 
-For a portfolio reader, the main takeaway is simple: the platform is intentionally divided between cluster-native data systems and host-native control systems, rather than forcing every responsibility into Kubernetes.
+The platform is intentionally divided between cluster-native data systems and host-native control systems, rather than forcing every responsibility into Kubernetes.
 
 ## Component Details
 
@@ -15,7 +15,7 @@ Managed via **OpenTofu (IaC)** and **ArgoCD (GitOps)**.
 | Component | Role | Details |
 | :--- | :--- | :--- |
 | **ArgoCD** | GitOps Orchestrator | Controller for declarative cluster state management and automated self-healing. |
-| **Unified Worker** | Batch Task Engine | CronJobs for collecting host telemetry (Analytics) and synchronizing data sources (Ingestion). |
+| **Unified Worker** | Batch Task Engine | CronJobs for collecting host and Kubernetes telemetry for resource analysis, plus synchronizing data sources. |
 | **Cilium & Hubble** | eBPF Networking | CNI with eBPF-native datapath for L7 visibility (MQTT) and network-level observability. |
 | **Grafana** | Visualization | Deployment for unified dashboarding UI. |
 | **Loki** | Log Aggregation | StatefulSet for indexing metadata-tagged logs. |

--- a/docs/architecture/infrastructure/security.md
+++ b/docs/architecture/infrastructure/security.md
@@ -4,7 +4,7 @@ The Observability Hub employs a multi-layered security model to protect the data
 
 ## 📡 External Ingress (Tailscale Funnel)
 
-To receive webhooks from GitHub without exposing the entire server to the public internet, we use **Tailscale Funnel**.
+GitHub webhooks are received through **Tailscale Funnel** without exposing the entire server to the public internet.
 
 - **Scoped Exposure**: Only port `8443` (HTTPS) is exposed to the public.
 - **Termination**: TLS is terminated at the Tailscale edge; traffic is forwarded to the local Proxy service over the secure Tailscale mesh.

--- a/docs/architecture/ownership.md
+++ b/docs/architecture/ownership.md
@@ -8,11 +8,11 @@ The operating model is:
 Source of Truth -> Runtime -> Signals -> Decisions -> Actions -> Memory
 ```
 
-This page explains how the repo connects infrastructure definition, deployment, observability, diagnosis, remediation, and institutional memory into one system.
+This page explains how the project connects infrastructure definition, deployment, observability, diagnosis, remediation, resource analysis, and institutional memory into one system.
 
 ## Ownership Loop
 
-| Stage | Purpose | Repo Surface |
+| Stage | Purpose | Project Surface |
 | :--- | :--- | :--- |
 | Source of Truth | Defines the intended platform state | `tofu/`, `k3s/`, `systemd/`, `.github/workflows/`, `Makefile` |
 | Runtime | Runs the platform services | K3s workloads, host systemd services, databases, storage |
@@ -29,6 +29,7 @@ This page explains how the repo connects infrastructure definition, deployment, 
 | Cluster Tier | `k3s/`, `tofu/` | K3s workloads and namespaces | pod status, events, kube metrics | pod MCP tools, kube events | GitOps sync, rollout, pod deletion | `docs/workflows.md`, incident reports |
 | Delivery | `.github/workflows/`, image tags, ArgoCD manifests | GitHub Actions, GHCR, ArgoCD | workflow status, image tags, sync state | workflow logs, proxy logs, ArgoCD state | PR fix, image retag, reconciliation | `docs/workflows.md` |
 | Observability | `k3s/base/infra/`, telemetry config | OpenTelemetry, Loki, Tempo, Prometheus, Grafana | logs, metrics, traces, dashboards | telemetry MCP tools, Grafana queries | config patch, collector restart, datasource fix | observability docs, RCAs |
+| Resource Efficiency | `k3s/`, `tofu/`, worker schedules | K3s workloads, host resources, storage systems | CPU, memory, disk, network, energy, workload metrics | Prometheus/Thanos queries, Grafana dashboards, worker analytics | resource limit patch, workload tuning, capacity plan | notes, RCAs, architecture docs |
 | Data | `tofu/`, database manifests, backup config | Postgres, MinIO, object storage backups | DB health, PVC state, backup status | DB logs, dashboard panels, pod tools | failover, restore, storage fix | `docs/notes/postgres.md`, incidents |
 | Networking | Cilium policies, network docs | Cilium, Hubble, service networking | flows, drops, DNS behavior | network MCP tools, flow baseline | policy patch, DNS/service correction | `docs/notes/network-flow-baseline.md` |
 | Security | `config/openbao/`, secrets manifests | OpenBao, Kubernetes secrets, service accounts | auth failures, service logs, policy errors | host logs, pod logs, security docs | rotate secret, patch policy, tighten RBAC | security docs, ADRs |
@@ -43,6 +44,7 @@ Every platform component should be explainable with the same ownership questions
 - Where is its desired state defined?
 - How is it deployed or reconciled?
 - What logs, metrics, traces, or flows prove it is healthy?
+- What resource signals show capacity pressure, waste, or cost risk?
 - Which tool or runbook diagnoses it?
 - What is the safe remediation path?
 - Where are decisions and incidents recorded?

--- a/docs/architecture/services/mcp-servers.md
+++ b/docs/architecture/services/mcp-servers.md
@@ -6,11 +6,11 @@ This is an advanced capability of the platform, not a prerequisite for understan
 
 In plain language, this component turns the platform into something an agent can inspect and reason about directly. Instead of opening multiple UIs and manually correlating logs, metrics, traces, pod state, and network flows, an agent can access those capabilities through one gateway.
 
-## Why This Is Interesting
+## Operational Role
 
 - It extends the platform beyond dashboards into AI-assisted operations
 - It unifies telemetry, Kubernetes state, network visibility, and host intelligence behind one interface
-- It demonstrates platform engineering work that connects observability data to autonomous tooling, not just human-facing dashboards
+- It connects observability data to autonomous tooling, not just human-facing dashboards
 
 ## Example Workflow
 

--- a/docs/architecture/services/worker.md
+++ b/docs/architecture/services/worker.md
@@ -4,7 +4,7 @@ The Unified Worker (`cmd/worker`, `internal/worker`) is a cluster-native executi
 
 This service represents the platform's batch-processing layer. It handles scheduled analytical and ingestion workloads without introducing multiple one-off services, which keeps the runtime model simpler and makes the telemetry story easier to follow.
 
-For a quick mental model: the Worker is the system's scheduled execution engine for tasks that do not need to run continuously but still need strong observability, repeatability, and operational discipline.
+For a quick mental model: the Worker is the system's scheduled execution engine for tasks that do not need to run continuously but still need strong observability, repeatability, and operational discipline. Its analytics mode turns infrastructure telemetry into capacity, efficiency, and cost-aware operating data.
 
 ## 🎯 Objective
 
@@ -16,11 +16,11 @@ The worker operates in two primary modes, triggered via the `--mode` CLI flag:
 
 ### 1. Analytics Mode (`--mode analytics`)
 
-- **Mission**: Correlates infrastructure resource consumption (Energy, Cost) with platform outcomes.
+- **Mission**: Correlates infrastructure resource usage with platform outcomes so operators can reason about capacity, efficiency, and cost drivers from real telemetry.
 - **Sources**:
-  - **Thanos**: Retrieves energy (Kepler) and host utilization metrics.
+  - **Thanos**: Retrieves energy (Kepler), Kubernetes, and host utilization metrics.
   - **Tailscale**: Inspects Funnel and mesh connectivity status.
-- **Persistence**: Records high-fidelity resource samples into the PostgreSQL `analytics_metrics` table.
+- **Persistence**: Records high-fidelity resource samples into the PostgreSQL `analytics_metrics` table for trend analysis and operational reporting.
 - **Scheduling**: Every 15 minutes via Kubernetes `CronJob`.
 
 ### 2. Ingestion Mode (`--mode ingestion`)

--- a/docs/decisions/002-cloud-to-local-bridge.md
+++ b/docs/decisions/002-cloud-to-local-bridge.md
@@ -8,7 +8,7 @@
 
 Telemetry generated in Azure Functions (Cover Craft / Reading App) needs to be visualized in the local Grafana instance.
 
-**Constraint:** The local environment is behind a residential firewall (NAT). Inbound HTTP connections from Azure are restricted for security reasons. The goal is to avoid the complexity of maintaining a VPN for a single-purpose logging use case.
+**Constraint:** The local environment is behind a residential firewall (NAT). Inbound HTTP connections from Azure are restricted for security reasons. The design avoids the complexity of maintaining a VPN for a single-purpose logging use case.
 
 ## Decision Outcome
 

--- a/docs/decisions/004-spatial-telemetry-keyboard.md
+++ b/docs/decisions/004-spatial-telemetry-keyboard.md
@@ -6,9 +6,9 @@
 
 ## Context and Problem Statement
 
-Standard input monitoring (keyloggers or counters) lacks the physical context of *where* interactions happen. For ergonomic analysis, heatmapping, and advanced hardware telemetry, we need a way to map raw Linux input events to physical coordinates on a 2D plane.
+Standard input monitoring (keyloggers or counters) lacks the physical context of *where* interactions happen. Ergonomic analysis, heatmapping, and advanced hardware telemetry require a way to map raw Linux input events to physical coordinates on a 2D plane.
 
-Existing solutions are either platform-specific (Windows-only), high-latency (Python-based), or closed-source. We need a low-level, high-performance bridge that can ship this data from an "Edge" device (Desktop) to a "Control Plane" (Laptop) without impacting system performance.
+Existing solutions are either platform-specific (Windows-only), high-latency (Python-based), or closed-source. The platform needs a low-level, high-performance bridge that can ship this data from an "Edge" device (Desktop) to a "Control Plane" (Laptop) without impacting system performance.
 
 ## Decision Outcome
 
@@ -22,7 +22,7 @@ A distributed IoT pipeline consisting of three tiers:
 
 - **C++ for Performance:** Direct kernel access and zero Garbage Collection (GC) ensures that even high-speed typing (150+ WPM) doesn't cause telemetry lag or CPU spikes.
 - **Distributed Architecture:** Decouples the data collection (Desktop) from the visualization (Laptop), allowing the observability hub to remain centralized.
-- **Spatial Focus:** By using PostGIS, we can perform advanced spatial queries (e.g., "distance traveled between keypresses") that are impossible in standard time-series databases.
+- **Spatial Focus:** PostGIS enables advanced spatial queries (e.g., "distance traveled between keypresses") that are impossible in standard time-series databases.
 
 ## Consequences
 

--- a/docs/decisions/005-gitops-reconciliation-engine.md
+++ b/docs/decisions/005-gitops-reconciliation-engine.md
@@ -12,7 +12,7 @@ While merging via `gh pr merge -s -d` handles local synchronization, web-based m
 
 ## Decision Outcome
 
-We implemented a **"Pull-based" synchronization agent managed by Templated Systemd Timers**. This approach prioritizes security, scalability, and observability.
+A **"Pull-based" synchronization agent managed by Templated Systemd Timers** was implemented. This approach prioritizes security, scalability, and observability.
 
 ### The Controller (Bash Agent)
 
@@ -20,7 +20,7 @@ The core logic is contained in [scripts/gitops_sync.sh](../../scripts/gitops_syn
 
 ### Scalability (Systemd Templates)
 
-We use the `@` symbol to create a single template that can service multiple repositories.
+The `@` symbol creates a single template that can service multiple repositories.
 
 - **Unit:** `gitops-sync@.service`
 - **Timer:** `gitops-sync@.timer`

--- a/docs/decisions/008-gitops-via-proxy-webhook.md
+++ b/docs/decisions/008-gitops-via-proxy-webhook.md
@@ -6,7 +6,11 @@
 
 ## Context and Problem Statement
 
-Currently, we leverage `systemd` timers to periodically trigger GitOps synchronizations. While effective for a small number of services, this approach is becoming an operational bottleneck due to management overhead, latency (polling), and process sprawl.
+The platform previously used `systemd` timers to periodically trigger GitOps synchronizations. While simple, timer-based polling caused the machine to wake up and check for work even when no repository had changed. That behavior wasted CPU cycles and power, added avoidable background activity, and made synchronization depend on a fixed schedule instead of actual change events.
+
+Polling also weakened the source-of-truth loop: Git changes could sit unapplied until the next timer interval, and each additional synchronized service required another timer surface to manage, monitor, and debug.
+
+The webhook path makes reconciliation event-driven. When GitHub sends a webhook, the Proxy receives the event, authenticates it, maps it to an allowlisted repository, executes the sync script, and emits structured logs for the result. If no Git event occurs, no sync work is triggered.
 
 ## Decision Outcome
 
@@ -15,18 +19,22 @@ Shift the trigger mechanism to an **Event-Driven Model** using the existing Go P
 - **New Endpoint:** `/api/webhook/gitops` acts as a universal receiver.
 - **Dynamic Execution:** Parses repo name from payload and executes `gitops_sync.sh`.
 - **Security:** HMAC SHA-256 signature verification.
+- **Observability:** Proxy logs provide one place to trace webhook receipt, validation, and sync execution.
+- **Bounded Execution:** Repository names are resolved through the existing sync script controls instead of accepting arbitrary shell input.
 
 ## Consequences
 
 ### Positive
 
 - **Real-time:** Updates happen immediately on push (vs. 15min polling).
-- **Simplicity:** Single configuration point (Github Webhook) vs. multiple systemd timers.
+- **Simplicity:** Single configuration point (GitHub Webhook) vs. multiple systemd timers.
 - **Toil Reduction:** No need to SSH and create new timer units for new repos.
+- **Auditability:** Each sync attempt has a request path, validation result, and execution log.
 
 ### Negative
 
 - **Dependency:** Relies on Proxy availability (unlike systemd timers which are independent).
+- **Blast Radius:** A malformed webhook handler could affect multiple synchronization paths, so signature checks and allowlisted repo execution are required.
 
 ## Verification
 

--- a/docs/decisions/009-standardized-db-connection-methods.md
+++ b/docs/decisions/009-standardized-db-connection-methods.md
@@ -6,14 +6,20 @@
 
 ## Context and Problem Statement
 
-`internal/db` currently only centralizes configuration (DSN). The actual connection logic (`sql.Open`, `Ping`) is duplicated across services, leading to inconsistent reliability and scattered dependency management.
+`internal/db` currently only centralizes configuration by returning the database connection string (DSN). The actual connection logic still lives inside individual services, with each service deciding how to call `sql.Open`, when to run `Ping`, how to handle startup failures, and which driver dependency to import.
+
+This creates a weak abstraction: the DSN is shared, but the behavior around database connections is not. As more services depend on PostgreSQL and MongoDB, duplicated connection code increases the chance of inconsistent timeout handling, missing health checks, and scattered dependency updates.
+
+The connection layer also needs to match the platform's internal-first architecture. Database setup is infrastructure behavior, not application business logic, so it belongs in one reusable package where lifecycle decisions, driver imports, and validation standards can be reviewed and tested once.
 
 ## Decision Outcome
 
-Expand `internal/db` to be a **Connection Factory**.
+Expand `internal/db` from a configuration helper into a **Connection Factory** that owns database initialization behavior.
 
 - **Functionality:** `ConnectPostgres` and `ConnectMongo` handle initialization and verification (Ping).
 - **Dependency Management:** Drivers are centralized in `internal/db/go.mod`.
+- **Service Contract:** Callers receive a verified database handle instead of assembling connection behavior locally.
+- **Boundary:** Services own queries and domain behavior; `internal/db` owns connection lifecycle and driver setup.
 
 ## Consequences
 
@@ -22,12 +28,15 @@ Expand `internal/db` to be a **Connection Factory**.
 - **Boilerplate Reduction:** One function call vs. 10+ lines of code per service.
 - **Consistency:** Best practices (Ping on startup) applied universally.
 - **Dependency Management:** Centralized driver updates.
+- **Operational Reliability:** Startup failures become easier to diagnose because connection validation follows one shared path.
+- **Testability:** Connection behavior can be covered in `internal/db` without duplicating test scaffolding across every service.
 
 ### Negative
 
 - **Module Size:** `internal/db` pulls in multiple drivers (Postgres + Mongo).
+- **Abstraction Scope:** Shared connection logic must stay generic enough to support multiple services without hiding service-specific query behavior.
 
 ## Verification
 
 - [x] **Manual Check:** Verify services start without connection errors.
-- [x] **Automated Tests:** `proxy/utils/dbConnection_test.go` verifies initialization logic.
+- [x] **Automated Tests:** `internal/db/postgres/client_test.go` and `internal/db/mongodb/client_test.go` verify initialization logic.

--- a/docs/decisions/011-phased-k3s-migration-strategy.md
+++ b/docs/decisions/011-phased-k3s-migration-strategy.md
@@ -18,19 +18,19 @@ Adopt a **Risk-Based Phased Migration Strategy**, moving components from "Lowest
 
 - **Phase 1: The Agent (Alloy)**
   - **Risk:** Low. If a failure occurs, only live logs are lost; historical data remains safe.
-  - **Goal:** Establish the telemetry pipeline in k3s by deploying Grafana Alloy to take over systemd journal log collection from Promtail.
+  - **Objective:** Establish the telemetry pipeline in k3s by deploying Grafana Alloy to take over systemd journal log collection from Promtail.
   - **Status:** Completed on 2026-02-02. Alloy is successfully collecting systemd journal logs and forwarding them to Docker-Loki.
 - **Phase 2: The Log Store (Loki)**
   - **Risk:** Medium. Requires moving log data.
-  - **Goal:** Establish persistent storage (PVCs) in k3s. Verify K3s networking.
+  - **Objective:** Establish persistent storage (PVCs) in k3s. Verify K3s networking.
   - **Status:** Completed on 2026-02-03. Loki is running in k3s with 10Gi persistence. Historical data migrated from Docker. Alloy updated to use internal K3s-Loki.
 - **Phase 3: The UI (Grafana)**
   - **Risk:** Low/Medium. No critical state (dashboards can be re-imported).
-  - **Goal:** Switch the "Pane of Glass" to run natively in the cluster.
+  - **Objective:** Switch the "Pane of Glass" to run natively in the cluster.
   - **Status:** Completed on 2026-02-04. Grafana is running in k3s with 10Gi persistence. Dashboards, users, and plugins migrated from Docker.
 - **Phase 4: The Core Data (PostgreSQL)**
   - **Risk:** Critical. The "Heart" of the system.
-  - **Goal:** Migrate the relational database using the "StatefulSet & Volume Sync" pattern once Phases 1-3 are stable.
+  - **Objective:** Migrate the relational database using the "StatefulSet & Volume Sync" pattern once Phases 1-3 are stable.
   - **Status:** Completed on 2026-02-05. PostgreSQL is running in k3s with 10Gi persistence and custom extensions (TimescaleDB/PostGIS). All services updated to connect via the k3s NodePort.
 
 ## Consequences

--- a/docs/decisions/013-standardize-on-opentelemetry.md
+++ b/docs/decisions/013-standardize-on-opentelemetry.md
@@ -8,14 +8,14 @@
 
 This decision initiates the **SRE Era** of the platform—a phase dedicated to mastering Site Reliability Engineering principles through the implementation of industry-standard telemetry.
 
-While the current custom Go collectors (e.g., `system-metrics`) and PostgreSQL storage are functional and effective for their original scope, they represent a "pre-standardized" phase of development. To evolve the platform into a true SRE learning hub, we need to bridge the gap between "working code" and "industry-standard observability."
+While the current custom Go collectors (e.g., `system-metrics`) and PostgreSQL storage are functional and effective for their original scope, they represent a "pre-standardized" phase of development. The platform needs to bridge the gap between "working code" and "industry-standard observability."
 
-The goal is not to "fix" the custom collectors, but to use the platform as a sandbox to understand:
+The decision is not to "fix" the custom collectors, but to use the platform as a sandbox to understand:
 
 - **Distributed Tracing**: How request flows are reconstructed across services.
 - **OTel Specification**: Mastering the semantic conventions for metrics, logs, and traces.
 - **Advanced Backend Management**: Operating specialized stores like Prometheus and Tempo.
-- **FinOps & Sustainability**: Leveraging standardized metadata for granular cost and carbon analysis.
+- **Resource Efficiency & Sustainability**: Leveraging standardized metadata for granular resource, cost, and carbon analysis.
 
 ## Decision Outcome
 
@@ -27,7 +27,7 @@ Standardize the platform on **OpenTelemetry (OTel)** as the primary telemetry fr
 - **Specialized Backends**: Move toward purpose-built storage engines:
   - **Prometheus**: For real-time operational metrics.
   - **Grafana Tempo**: For distributed trace storage.
-  - **PostgreSQL**: Retained for long-term analytical and FinOps-specific data via OTel Collector aggregation.
+  - **PostgreSQL**: Retained for long-term resource and cost-aware analytical data via OTel Collector aggregation.
 - **Standardized Instrumentation**: All platform services will be updated to use OpenTelemetry SDKs (Go, Python, etc.) to emit telemetry.
 
 ### Rationale
@@ -35,8 +35,8 @@ Standardize the platform on **OpenTelemetry (OTel)** as the primary telemetry fr
 - **Vendor-Agnostic**: OTel ensures the platform is not locked into a specific observability vendor.
 - **Industry Standard**: Aligns the platform with modern SRE and DevOps practices, improving the "Developer Experience" and scalability.
 - **Observability Trinity**: Completes the "Trinity" (Logs, Metrics, Traces) by adding distributed tracing capabilities.
-- **FinOps Foundation**: Provides the standardized metadata (labels/attributes) required for granular resource and cost analysis.
-- **Managed Resource Footprint**: By utilizing OTel's specialized backends and Kubernetes resource limits, we can maintain a lean cluster footprint while gaining advanced capabilities.
+- **Resource Analysis Foundation**: Provides the standardized metadata (labels/attributes) required for granular resource and cost analysis.
+- **Managed Resource Footprint**: OTel's specialized backends and Kubernetes resource limits maintain a lean cluster footprint while adding advanced capabilities.
 
 ## Consequences
 

--- a/docs/decisions/014-library-first-service-architecture.md
+++ b/docs/decisions/014-library-first-service-architecture.md
@@ -6,7 +6,7 @@
 
 ## Context and Problem Statement
 
-As the Observability Hub matures, it is transitioning from a collection of isolated services into a multi-interface platform. We now face the need to support multiple execution triggers for the same business logic, such as automated background ingestion (systemd/k3s) and real-time requests via the `proxy`.
+As the Observability Hub matures, it is transitioning from a collection of isolated services into a multi-interface platform. The system now needs to support multiple execution triggers for the same business logic, such as automated background ingestion (systemd/k3s) and real-time requests via the `proxy`.
 
 The current architecture tightly couples business logic (e.g., metric collection, "Second Brain" ingestion) within the `main` packages of individual services. This makes it difficult to reuse logic across different interfaces without duplication or fragile dependencies.
 

--- a/docs/decisions/015-unified-host-telemetry-collectors.md
+++ b/docs/decisions/015-unified-host-telemetry-collectors.md
@@ -39,8 +39,8 @@ Consolidate all host-level observability responsibilities into a single, re-arch
   | **Net Savings**        | **~8m / 40Mi** | **10m / 74Mi**     |
   | **% Reduction**        | **80% / 80%**  | **50% / 65%**      |
 
-- **Data Parity & Schema Consistency:** By utilizing PromQL `query_range` with a `step=1m`, we maintain the high-resolution data (1-minute granularity) required for accurate FinOps analysis while gaining the operational benefits of batch processing.
-- **Surgical Consolidation:** This approach allows us to integrate specialized collection (Tailscale, hardware temperatures) into a single path, eliminating the need for three separate management domains (Alloy, systemd, and legacy Go services).
+- **Data Parity & Schema Consistency:** PromQL `query_range` with a `step=1m` maintains the high-resolution data (1-minute granularity) required for accurate resource and cost-aware analysis while gaining the operational benefits of batch processing.
+- **Surgical Consolidation:** This approach integrates specialized collection (Tailscale, hardware temperatures) into a single path, eliminating the need for three separate management domains (Alloy, systemd, and legacy Go services).
 
 ## Consequences
 
@@ -48,13 +48,13 @@ Consolidate all host-level observability responsibilities into a single, re-arch
 
 - **Significant Resource Savings**: Frees up approximately 8m CPU and 74Mi RAM in reserved resources per node, based on the difference between Alloy's prior requests (20m CPU / 114Mi RAM) and Analytics' new requests (10m CPU / 40Mi RAM), with even larger savings in actual idle usage.
 - **Operational Simplicity**: Replaces three legacy components (Alloy, old `system-metrics`, `systemd` units) with one unified Go binary.
-- **FinOps Readiness**: Provides a curated, efficient historical data source in PostgreSQL for electricity cost analysis.
+- **Resource Analysis Readiness**: Provides a curated, efficient historical data source in PostgreSQL for capacity, efficiency, and electricity cost analysis.
 - **Architectural Alignment**: Standardizes on Go and the "library-first" pattern.
 
 ### Negative
 
 - **Increased Development Effort**: Requires custom Go code for Tailscale and PromQL parsing rather than using off-the-shelf Alloy modules.
-- **Dependency on Thanos**: Data collection for FinOps now depends on the availability of the Thanos Query service.
+- **Dependency on Thanos**: Resource analytics depends on the availability of the Thanos Query service.
 
 ## Verification
 

--- a/docs/decisions/023-benchmark-rust-obs-processor.md
+++ b/docs/decisions/023-benchmark-rust-obs-processor.md
@@ -1,0 +1,81 @@
+# ADR 023: Benchmark-Validated Rust Obs Processor
+
+- **Status:** Accepted
+- **Date:** 2026-04-17
+- **Author:** Victoria Cheng
+
+## Context and Problem Statement
+
+ADR 021 selected Rust for the `obs-processor` sidecar that summarizes logs and metrics before telemetry responses are returned to MCP agents. ADR 022 refined the summary format so the processor preserves investigation pivots while still reducing raw payload size.
+
+The remaining question is whether Rust should stay as the long-term implementation choice for this processing path instead of moving the summarization logic back into Go. The platform is Go-first for service orchestration, but log and metric reduction has a different performance profile: it reads large JSON payloads, groups repeated log lines, computes metric statistics, and reduces output before the data becomes agent context.
+
+This matters because raw Loki and Prometheus responses can become expensive in two ways:
+
+- **Runtime cost:** Large payloads require CPU and memory to parse, group, and summarize.
+- **Token cost:** Large responses consume context window budget and increase the cost of agent-assisted investigations.
+- **Operator cost:** Noisy responses make it harder to identify the signal that actually matters.
+
+The decision needs benchmark evidence, not only a language preference.
+
+## Decision Outcome
+
+Keep the production telemetry reducer in Rust and maintain a dedicated benchmark harness that compares equivalent Go and Rust processors against the same live API payload.
+
+- **Benchmark Harness:** `scripts/benchmark_obs_processor.sh` fetches either a Loki or Prometheus payload, builds both standalone processors, runs repeated iterations, and reports average, minimum, and maximum runtime.
+- **Go Baseline:** `scripts/bench/obs_processor.go` provides a comparable Go implementation of the same summarization behavior.
+- **Rust Candidate:** `scripts/bench/obs_processor.rs` provides the Rust implementation used to validate the performance characteristics of the sidecar approach.
+- **Payload Parity:** Both binaries process the same captured payload from stdin, which keeps the comparison focused on parsing and summarization rather than network timing.
+- **Token-Cost Link:** Runtime benchmarks validate processor efficiency, while the ROI benchmark from ADR 021 and ADR 022 validates byte, token, and cost reduction from raw telemetry to summaries.
+
+### Rationale
+
+- **Rust is appropriate for the hot path:** The processor performs bounded, CPU-sensitive transformation over large structured telemetry payloads.
+- **Go remains the control plane:** MCP handlers still own provider calls, validation, timeouts, and fail-open behavior.
+- **Benchmarks prevent hand-waving:** The language decision is tied to repeatable measurements under `scripts/bench` rather than preference.
+- **Token reduction is the product outcome:** Faster parsing is useful, but the operational value is reducing context waste while preserving enough diagnostic structure for investigations.
+- **The boundary stays narrow:** Rust is used for telemetry reduction only, avoiding a broad polyglot rewrite of platform services.
+
+## Consequences
+
+### Positive
+
+- **Measured implementation choice:** Rust remains justified by a benchmarkable processing workload.
+- **Lower agent context waste:** Logs and metrics are summarized before they become expensive prompt context.
+- **Clear regression guard:** Future changes can rerun the benchmark to catch slower parsing or less efficient summaries.
+- **Separation of concerns:** Go handles orchestration and safety; Rust handles high-volume payload transformation.
+
+### Negative
+
+- **Additional benchmark maintenance:** Go and Rust benchmark implementations must stay behaviorally comparable.
+- **Toolchain complexity:** Benchmarking requires both Go and Cargo to be available.
+- **Representative payload dependency:** Benchmark quality depends on querying realistic Loki and Prometheus data.
+
+## Verification
+
+- [x] **Benchmark Script:** `scripts/benchmark_obs_processor.sh` added for Go vs Rust processor comparison.
+- [x] **Go Benchmark Processor:** `scripts/bench/obs_processor.go` added as the Go baseline.
+- [x] **Rust Benchmark Processor:** `scripts/bench/obs_processor.rs` added as the Rust comparison target.
+- [x] **ROI Linkage:** ADR 021 and ADR 022 continue to document raw-to-summary byte, token, and cost reduction.
+
+## Benchmark Result
+
+Representative 24-hour logs and metrics benchmarks used the same API payload for both processors and ran 20 iterations per telemetry type.
+
+### Logs
+
+| Processor | Average | Minimum | Maximum | Iterations |
+| :--- | ---: | ---: | ---: | ---: |
+| Go | `4.782ms` | `4.108ms` | `6.316ms` | `20` |
+| Rust | `2.608ms` | `2.125ms` | `3.029ms` | `20` |
+
+Rust completed the same log-processing workload about `1.83x` faster on average for this benchmark run.
+
+### Metrics
+
+| Processor | Average | Minimum | Maximum | Iterations |
+| :--- | ---: | ---: | ---: | ---: |
+| Go | `18.460ms` | `16.665ms` | `20.062ms` | `20` |
+| Rust | `4.943ms` | `4.328ms` | `6.224ms` | `20` |
+
+Rust completed the same metric-processing workload about `3.73x` faster on average for this benchmark run.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 
 | ADR | Title | Status |
 | :--- | :--- | :--- |
+| **023** | [Benchmark-Validated Rust Obs Processor](./023-benchmark-rust-obs-processor.md) | 🔵 Accepted |
 | **022** | [Structured Summaries for Obs Processor](./022-obs-processor-structured-summaries.md) | 🔵 Accepted |
 | **021** | [Rust Telemetry Summarization Processor](./021-rust-telemetry-summarization-processor.md) | 🔵 Accepted |
 | **020** | [Cilium eBPF Foundation](./020-cilium-ebpf-foundation.md) | 🔵 Accepted |
@@ -35,7 +36,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 
 ## 🛠️ Process & Standards
 
-This section defines how we propose, evaluate, and document architectural changes.
+This section defines how architectural changes are proposed, evaluated, and documented.
 
 ### Decision Lifecycle
 

--- a/docs/incidents/002-service-graph-metrics-failure.md
+++ b/docs/incidents/002-service-graph-metrics-failure.md
@@ -24,7 +24,7 @@ The primary cause was a **Disconnected Telemetry Pipeline** due to a disabled re
 
 1. **Disabled Sink**: The Prometheus instance was running with default settings, which do not allow external services to "push" metrics via Remote Write.
 2. **Inactive Processors**: Tempo's `metrics_generator` was defined in the configuration but was not explicitly activated via the `overrides` section, meaning it was not actually analyzing traces for structural data.
-3. **Strict Semantic Requirements**: The OTel Collector's `servicegraph` implementation was too strict for our current testing methodology (direct `curl` calls), whereas Tempo's implementation was better suited for this "single-node" hybrid environment.
+3. **Strict Semantic Requirements**: The OTel Collector's `servicegraph` implementation was too strict for the current testing methodology (direct `curl` calls), whereas Tempo's implementation was better suited for this "single-node" hybrid environment.
 
 ## Lessons Learned
 

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -78,7 +78,7 @@ Detailed explanation of why the incident happened (The "Why").
 
 ## Lessons Learned (Optional)
 
-What went well? What went wrong? What did we get lucky with?
+What went well? What went wrong? What reduced the impact?
 
 ## Action Items
 

--- a/internal/web/templates/content/evolution.yaml
+++ b/internal/web/templates/content/evolution.yaml
@@ -1,8 +1,8 @@
 page_title: "System Logs & Milestones"
-intro_text: "A chronological view of how the Observability Hub evolved from a local lab into a layered platform for telemetry, automation, and operations."
+intro_text: "A chronological view of how the Observability Hub evolved from a local lab into an infrastructure, Kubernetes, and observability platform with automation, incident response, and cost-aware telemetry analysis."
 chapters:
   - title: "The Genesis"
-    intro: "The starting point: a reliable local lab, an initial Go telemetry path, and the first bridge between cloud-generated events and self-hosted storage."
+    intro: "The foundation chapter: building a reliable local lab, choosing PostgreSQL for durable telemetry storage, and bridging cloud-generated events into a self-hosted observability path."
     timeline:
       - date: "2025-11-20"
         title: "Reliable Local Lab"
@@ -27,7 +27,7 @@ chapters:
           - Decoupled stateless analytics from persistent storage to enable independent scaling.
 
   - title: "The Platform Core"
-    intro: "The phase where the project stopped being a loose collection of experiments and became a more structured platform with shared libraries, automation, and a visible system story."
+    intro: "The platform-structure chapter: turning early services into a coherent system with shared libraries, structured logging, automated ingestion, and documented architecture decisions."
     timeline:
       - date: "2026-01-01"
         title: "Project Portal Launch"
@@ -62,7 +62,7 @@ chapters:
           - Eliminated configuration drift by refactoring services to use the shared configuration module.
 
   - title: "GitOps & Host Observability"
-    intro: "The first operational hardening pass: GitOps-style automation for repeatability and host-level logging for visibility into the machine running the platform."
+    intro: "The host-operations chapter: using GitOps-style synchronization and systemd journal ingestion to make host services repeatable, observable, and easier to recover."
     timeline:
       - date: "2026-01-14"
         title: "GitOps Infrastructure & Host Observability"
@@ -76,7 +76,7 @@ chapters:
           - Added log parsing, labels, and allowlist controls for safer operational visibility.
 
   - title: "Orchestration & Event-Driven Pivot"
-    intro: "The transition away from timer-driven workflows toward event-driven automation and the first meaningful step toward Kubernetes orchestration."
+    intro: "The orchestration chapter: moving from timer-driven background work to event-driven webhooks, reducing wasted wakeups while preparing the platform for Kubernetes."
     timeline:
       - date: "2026-01-19"
         title: "Orchestration Spike: k3s"
@@ -98,7 +98,7 @@ chapters:
           - Proposed 'Paved Road' philosophy by centralizing database connection logic to streamline service development and enforce architectural consistency.
 
   - title: "Vault via OpenBao"
-    intro: "The security chapter: replacing scattered static environment variables with a centralized, more production-like secret management model."
+    intro: "The security chapter: replacing scattered static environment variables with OpenBao-backed secrets, central policy, and safer credential access for services."
     timeline:
       - date: "2026-01-22"
         title: "The Security Blueprint"
@@ -115,7 +115,7 @@ chapters:
           - Migrated 'system-metrics' and 'proxy' services to dynamic credential retrieval.
 
   - title: "The Kubernetes Era"
-    intro: "The migration from standalone containers to Kubernetes, moving the core observability stack onto a more resilient and self-healing runtime."
+    intro: "The Kubernetes chapter: moving the observability stack, PostgreSQL, and persistent workloads from standalone containers into K3s for resilient, self-healing operations."
     timeline:
       - date: "2026-02-05"
         title: "Core Observability Stack on K3s"
@@ -131,7 +131,7 @@ chapters:
           - Established self-healing runtime behavior for the core observability stack.
 
   - title: "The SRE Era"
-    intro: "The observability maturity chapter: standardizing around OpenTelemetry, adding traces and metrics, and building the workflows needed for real incident analysis."
+    intro: "The observability maturity chapter: standardizing on OpenTelemetry, connecting logs, metrics, and traces, and using RCAs to turn incidents into durable operational knowledge."
     timeline:
       - date: "2026-02-08"
         title: "Phase 1 Complete: OpenTelemetry Collector"
@@ -166,7 +166,7 @@ chapters:
           - Established a safer default baseline across the core platform services.
 
   - title: "Platform Maturity & Reusability"
-    intro: "The internal architecture cleanup: refactoring the codebase into reusable building blocks so new services and interfaces could share the same core logic."
+    intro: "The software-architecture chapter: refactoring the Go codebase into reusable internal packages so services, workers, and interfaces share tested platform logic."
     timeline:
       - date: "2026-02-18"
         title: "Library-First Implementation"
@@ -196,7 +196,7 @@ chapters:
           - Completed a more consistent OpenTelemetry-native observability stack for logs, metrics, and traces.
 
   - title: "The Terraform Era"
-    intro: "The infrastructure-as-code phase: replacing manual Kubernetes operations with OpenTofu so the stack could be managed declaratively and audited over time."
+    intro: "The infrastructure-as-code chapter: moving Kubernetes platform services into OpenTofu so infrastructure state is declarative, reviewable, and easier to audit over time."
     timeline:
       - date: "2026-03-01"
         title: "Platform Infrastructure: Immutable Orchestration via OpenTofu"
@@ -211,28 +211,22 @@ chapters:
           - Improved drift detection, persistent workload recovery, and cross-service telemetry discovery.
 
   - title: "The MCP Era"
-    intro: "The agent-native chapter: exposing telemetry and infrastructure through MCP so AI tools could query live system state, investigate incidents, and reason over compressed summaries instead of raw observability noise."
+    intro: "The agent-native operations chapter: building an MCP gateway for live telemetry, Kubernetes, and host state; reducing noisy observability payloads with Rust; and proving the design with Go-vs-Rust benchmarks for faster, lower-cost investigations."
     timeline:
       - date: "2026-03-08"
-        title: "mcp-telemetry: Agentic Telemetry Intelligence"
+        title: "MCP Telemetry and Infrastructure Intelligence"
         artifacts:
           - name: "ADR 017: Agentic Interface via MCP"
             url: "docs/decisions/017-agentic-interface-mcp.md"
-        description: |
-          - Exposed metrics, semantic logs, and distributed traces through MCP so agents could investigate live system behavior.
-          - Added `investigate_incident` to combine telemetry signals into structured incident reports.
-      - date: "2026-03-12"
-        title: "MCP Infrastructure Intelligence"
-        artifacts:
           - name: "ADR 018: Domain-Isolated MCP Architecture"
             url: "docs/decisions/018-domain-isolated-mcp-architecture.md"
           - name: "ADR 019: Hybrid Host-MCP Intelligence"
             url: "docs/decisions/019-hybrid-host-mcp-intelligence.md"
         description: |
-          - Split MCP capabilities into domain-isolated services to reduce blast radius and enforce least privilege.
-          - Added `mcp-pods` so agents could correlate Kubernetes events with telemetry during cluster failures.
-          - Added `mcp-hub` to connect host-level state with Kubernetes-level investigation.
-          - Introduced namespaced tools for focused cross-layer debugging.
+          - Exposed metrics, semantic logs, distributed traces, Kubernetes events, and host state through MCP.
+          - Split capabilities into domain-isolated services to reduce blast radius and enforce least privilege.
+          - Connected telemetry, pod state, and host-level signals for focused cross-layer debugging.
+          - Introduced `investigate_incident` for structured incident reports from live platform signals.
       - date: "2026-03-19"
         title: "mcp_obs_hub: Unified Agentic Gateway"
         description: |
@@ -255,9 +249,17 @@ chapters:
         description: |
           - Upgraded summaries from compressed strings to structured records with timestamps and investigation context.
           - Improved log and metric investigation quality while benchmarks still showed major context reduction.
+      - date: "2026-04-17"
+        title: "Rust Telemetry Processing Benchmarks"
+        artifacts:
+          - name: "ADR 023: Benchmark-Validated Rust Obs Processor"
+            url: "docs/decisions/023-benchmark-rust-obs-processor.md"
+        description: |
+          - Benchmarked Go and Rust telemetry processors against the same 24-hour Loki and Prometheus payloads.
+          - Established Rust as the faster reduction path, especially for metric summarization where numeric parsing and statistical aggregation dominate.
 
   - title: "eBPF-Native Efficiency & Networking"
-    intro: "The kernel-level visibility chapter: using eBPF to improve network observability, protocol insight, and efficiency analysis beyond application-level instrumentation."
+    intro: "The kernel-visibility chapter: using Cilium, Hubble, and Kepler to inspect network flows, protocol behavior, and infrastructure efficiency below the application layer."
     timeline:
       - date: "2026-03-11"
         title: "Kepler Integration & Energy Dashboards"
@@ -282,7 +284,7 @@ chapters:
           - Resolved a critical SSH lockout during migration and formalized a recovery protocol.
 
   - title: "GitOps & Operational Maturity"
-    intro: "The day-two operations chapter: hardening the platform with continuous reconciliation, safer rollouts, and a clearer GitOps operating model for ongoing changes."
+    intro: "The day-two operations chapter: hardening the platform with ArgoCD reconciliation, deterministic Kustomize rendering, safer rollouts, and a clearer GitOps operating model."
     timeline:
       - date: "2026-03-21"
         title: "ArgoCD GitOps & Automated Fleet Promotion"


### PR DESCRIPTION
### Summary

This change reframes the project documentation around infrastructure, Kubernetes, observability, and resource-aware platform ownership. It also adds benchmark-backed ADR coverage for the Rust obs processor and updates the evolution timeline so the public project story is easier to skim and stronger for platform engineering roles.

### List of Changes

- Improved the documentation narrative so cost analysis is presented as an outcome of infrastructure and observability work, not as the primary identity of the project.
- Added ADR and evolution timeline updates that connect MCP, Rust telemetry reduction, and benchmark evidence to faster, lower-cost operational investigations.

### Verification

- [x] Ran `make lint` successfully after Podman approval.
- [x] Ran `make web-build`

