### PR TITLE
fix(n8n): add writable cache volume

### DIFF
--- a/k3s/base/hub-apps/automation.yaml
+++ b/k3s/base/hub-apps/automation.yaml
@@ -80,6 +80,8 @@ spec:
         volumeMounts:
         - name: n8n-data
           mountPath: /home/node/.n8n
+        - name: node-cache
+          mountPath: /home/node/.cache
         - name: tmp
           mountPath: /tmp
         livenessProbe:
@@ -109,6 +111,8 @@ spec:
       - name: n8n-data
         persistentVolumeClaim:
           claimName: n8n-data
+      - name: node-cache
+        emptyDir: {}
       - name: tmp
         emptyDir: {}
 ---


### PR DESCRIPTION
### Summary

This follow-up fixes the n8n rollout regression introduced by enabling a read-only root filesystem. n8n still needs a writable cache directory at runtime, so the manifest now provides that path with an ephemeral volume while preserving the security hardening.

### List of Changes

- Restored n8n startup compatibility by giving the container a writable `/home/node/.cache` path without reopening the root filesystem.
- Preserved the Trivy-compliant security posture while allowing ArgoCD to reconcile a healthy replacement pod.

### Verification

- [x] Ran `kubectl kustomize k3s/base/hub-apps`
- [x] Ran `git diff --check -- k3s/base/hub-apps/automation.yaml`
- [x] Ran `nix-shell --run 'trivy config --severity HIGH,CRITICAL k3s/base/hub-apps/automation.yaml'`

