### PR TITLE
chore(security): enforce trivy workload baseline

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,5 +57,5 @@ jobs:
           scanners: vuln,secret,misconfig
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: '0'
+          exit-code: '1'
           format: table

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ flowchart TB
 - High-availability PostgreSQL with automated failover (CloudNativePG)
 - Centralized dashboards for monitoring and debugging
 - Secrets management without hardcoding credentials
+- Trivy-backed container and Kubernetes manifest hardening
 - Infrastructure as Code using OpenTofu (layered architecture)
 - Resource and capacity analysis using Kubernetes, host, and telemetry signals
 - Data ingestion pipeline with worker-based processing
@@ -68,6 +69,7 @@ This platform is built as connected ownership domains:
 | Telemetry Pipeline | OpenTelemetry logs, metrics, and traces across services |
 | High Availability Database | PostgreSQL failover with Azure Blob Storage backups |
 | Secrets Management | Dynamic secrets and policy management with OpenBao |
+| Workload Security | Trivy-scanned Dockerfiles and Kubernetes security contexts |
 | Infrastructure as Code | Layered OpenTofu architecture for infrastructure ownership |
 | Networking | Cilium eBPF visibility, policy control, and flow debugging |
 | CI/CD | GitHub Actions, image publication, and GitOps reconciliation |
@@ -84,6 +86,7 @@ This platform is built as connected ownership domains:
 | Manual deployments | GitOps automation with Argo CD and webhook-triggered reconciliation |
 | No visibility into systems | Logs, metrics, traces, network flows, and Grafana dashboards |
 | Secrets stored in code | Dynamic secret management with OpenBao |
+| Containers running with weak defaults | Non-root images, read-only root filesystems, dropped capabilities, and Trivy scans |
 | Single point of failure | High-availability PostgreSQL and backup paths |
 | Hard-to-debug issues | MCP diagnostics, dashboards, runbooks, and incident reports |
 | Infrastructure drift | Declarative source of truth with OpenTofu, Kustomize, and GitOps |
@@ -132,6 +135,7 @@ This platform is built as connected ownership domains:
 - Cilium (eBPF networking)
 - OpenBao (Secrets Management)
 - Tailscale
+- Trivy (container and Kubernetes misconfiguration scanning)
 
 ### Languages
 
@@ -215,6 +219,7 @@ This project demonstrates how to build a production-like DevOps platform using:
 - Kubernetes + GitOps  
 - Full observability (logs, metrics, traces)  
 - Infrastructure as Code  
+- Trivy-verified workload hardening
 - High availability systems  
 - Capacity and cost-aware infrastructure analysis  
 - Real-world debugging and failure handling  

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -35,6 +35,7 @@ The surrounding platform supports that flow:
 - **LGTM Stack**: Loki, Tempo, and Prometheus as the main observability backends
 - **Grafana**: Unified visualization layer for operators
 - **Resource Analytics**: Kubernetes, host, and workload signals for capacity and efficiency analysis
+- **Workload Security**: Trivy-scanned Dockerfiles and Kubernetes manifests with non-root, read-only-root filesystem hardening
 - **MCP Gateway**: Agent-readable diagnostic and operational interface
 - **ArgoCD + OpenTofu**: Deployment and reconciliation control plane
 
@@ -64,7 +65,7 @@ Fundamental patterns and cross-cutting concerns that define how the system opera
 The runtime environment and foundational deployment strategies.
 
 - **[Deployment Model](./infrastructure/deployment.md)**: Details on the hybrid Kubernetes/Systemd orchestration.
-- **[Security](./infrastructure/security.md)**: Tailscale Funnel gating, HMAC authentication, and isolation boundaries.
+- **[Security](./infrastructure/security.md)**: Tailscale Funnel gating, HMAC authentication, workload hardening, and isolation boundaries.
 
 ### ⚙️ [Services](./services/)
 

--- a/docs/architecture/infrastructure/security.md
+++ b/docs/architecture/infrastructure/security.md
@@ -25,6 +25,15 @@ All incoming requests to `/api/webhook/gitops` must be authenticated using **HMA
 - **Service Boundaries**: The Proxy (running as a native systemd service) acts as the primary "bridge" between the public funnel and the internal cluster data tier.
 - **Environment Variables**: Sensitive credentials (passwords, URIs) are managed via **Kubernetes Secrets** or retrieved from OpenBao, ensuring they never appear in plain text in process lists.
 
+## 🧰 Workload Hardening
+
+Cluster workloads are hardened at the image and manifest layers before ArgoCD reconciles them into the runtime.
+
+- **Non-Root Containers**: Project-built images for the chaos controller, sensor fleet, and worker create and run as a non-root UID/GID instead of relying on root defaults.
+- **Pod and Container Security Contexts**: Kubernetes manifests define `runAsNonRoot`, explicit user and group IDs, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, and `capabilities.drop: ["ALL"]` where supported.
+- **Read-Only Root Filesystems**: Hardened workloads set `readOnlyRootFilesystem: true`. Required write paths are modeled explicitly with PVCs or `emptyDir` mounts, such as n8n state, cache, and temporary directories.
+- **Service Account Boundaries**: Workloads that do not need Kubernetes API access disable token automounting. Workloads that do need API access, such as the chaos controller, keep a scoped service account and RBAC role.
+
 ## 🧱 Repository Integrity
 
 The GitOps agent (`gitops_sync.sh`) uses **Fast-Forward Only (`--ff-only`)** merges to prevent accidental merge commits on the host and ensure the local environment stays strictly in sync with the remote "Source of Truth."
@@ -35,5 +44,6 @@ To maintain a "Secure by Default" posture, the repository employs automated CI/C
 
 - **GitOps Desired State**: **ArgoCD** continuously enforces the desired state defined in Git, automatically reverting any unauthorized manual modifications to Kubernetes resources.
 - **Infrastructure Linting**: Every change to the `k3s/` directory is automatically scanned by `kube-linter` to identify misconfigurations and security violations in Kubernetes manifests.
+- **Misconfiguration Scanning**: **Trivy** scans Dockerfiles and Kubernetes manifests for HIGH and CRITICAL configuration risks, including root containers, missing security contexts, and mutable root filesystems.
 - **Vulnerability Scanning**: The Go codebase and its dependencies are continuously audited using `govulncheck` (triggered on pushes and weekly schedules) to proactively identify and remediate known vulnerabilities.
 - **Policy Enforcement**: Markdown and HCL configurations are linted to ensure consistent adherence to operational and security standards across all documentation and policies.

--- a/docs/decisions/024-trivy-verified-workload-hardening.md
+++ b/docs/decisions/024-trivy-verified-workload-hardening.md
@@ -1,0 +1,63 @@
+# ADR 024: Trivy-Verified Workload Hardening
+
+- **Status:** Accepted
+- **Date:** 2026-04-17
+- **Author:** Victoria Cheng
+
+## Context and Problem Statement
+
+The platform already used GitOps, OpenBao, Cilium policies, kube-linter, and dependency scanning as security controls. The remaining gap was workload-level hardening across project Dockerfiles and Kubernetes manifests.
+
+Trivy reported HIGH configuration findings for several workloads:
+
+- Dockerfiles did not explicitly switch to non-root users.
+- Kubernetes workloads relied on default pod and container security contexts.
+- Containers did not consistently set read-only root filesystems.
+
+These findings matter because the platform runs long-lived automation and observability workloads in a shared homelab Kubernetes environment. A compromised container should have the smallest practical filesystem, privilege, and identity surface. The control also needs to remain operable under GitOps: security settings should live in source control and be verified before ArgoCD reconciles them.
+
+## Decision Outcome
+
+Adopt Trivy-verified workload hardening as the baseline for project-managed Dockerfiles and Kubernetes workloads.
+
+- **Docker Runtime Users:** Project-built images must create and run as a non-root UID/GID instead of relying on root defaults.
+- **Pod Security Contexts:** Kubernetes manifests must set `runAsNonRoot`, explicit user and group IDs, `fsGroup` when writable volumes need group ownership, and `seccompProfile: RuntimeDefault`.
+- **Container Security Contexts:** Containers must set `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and `capabilities.drop: ["ALL"]` unless a documented workload exception requires otherwise.
+- **Explicit Writable Paths:** Workloads with read-only root filesystems must model required write paths with PVCs or `emptyDir` volumes instead of reopening the root filesystem.
+- **Service Account Boundaries:** Workloads that do not need Kubernetes API access should disable token automounting. Workloads that do need API access should keep scoped service accounts and RBAC.
+- **Local Reproducibility:** Trivy is included in `shell.nix` so the same misconfiguration checks can be run from the development shell.
+
+The first implementation applies this baseline to the chaos controller, sensor fleet, unified worker CronJobs, and n8n automation deployment.
+
+### Rationale
+
+- **Scanner findings become engineering standards:** Trivy findings are translated into source-controlled workload defaults rather than treated as one-off cleanup.
+- **GitOps remains the source of truth:** ArgoCD reconciles hardened manifests from `k3s/`, so runtime drift does not become the control mechanism.
+- **Read-only filesystems need explicit design:** n8n showed that hardening can expose hidden write paths. The correct fix is a targeted writable mount, not disabling the security control.
+- **API access stays intentional:** The sensor fleet can disable service account tokens, while the chaos controller keeps a scoped token because it lists sensor pods.
+- **Reviewers get repeatable evidence:** Local Trivy scans, Kustomize renders, and markdown documentation make the control easy to verify.
+
+## Consequences
+
+### Positive
+
+- **Reduced container blast radius:** Workloads run without root defaults, unnecessary Linux capabilities, or mutable root filesystems.
+- **Clearer security posture:** README and architecture docs now describe workload hardening as an implemented platform control.
+- **Reproducible validation:** Developers can run Trivy from the Nix shell before pushing changes.
+- **Better operational discipline:** Required write paths are visible in manifests as PVCs or `emptyDir` volumes.
+
+### Negative
+
+- **More manifest detail:** Security contexts and writable mounts add YAML verbosity.
+- **Runtime compatibility checks are required:** Some third-party images, such as n8n, may need additional writable directories after `readOnlyRootFilesystem` is enabled.
+- **Exceptions need documentation:** Any workload that cannot support the baseline must explain why and define a compensating control.
+
+## Verification
+
+- [x] **Kustomize Render:** `kubectl kustomize k3s/base/hardware-sim` completed successfully.
+- [x] **Kustomize Render:** `kubectl kustomize k3s/base/worker` completed successfully.
+- [x] **Kustomize Render:** `kubectl kustomize k3s/base/hub-apps` completed successfully.
+- [x] **Trivy Docker Scan:** `nix-shell --run 'trivy config --severity HIGH,CRITICAL docker'` reported zero misconfigurations.
+- [x] **Trivy K3s Scan:** `nix-shell --run 'trivy config --severity HIGH,CRITICAL k3s/base'` reported zero misconfigurations.
+- [x] **Runtime Follow-Up:** n8n CrashLoopBackOff was traced to `/home/node/.cache` under a read-only root filesystem and fixed with an explicit `emptyDir` cache mount.
+- [x] **Documentation:** README and security architecture docs were updated to describe the implemented workload hardening baseline.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 
 | ADR | Title | Status |
 | :--- | :--- | :--- |
+| **024** | [Trivy-Verified Workload Hardening](./024-trivy-verified-workload-hardening.md) | 🔵 Accepted |
 | **023** | [Benchmark-Validated Rust Obs Processor](./023-benchmark-rust-obs-processor.md) | 🔵 Accepted |
 | **022** | [Structured Summaries for Obs Processor](./022-obs-processor-structured-summaries.md) | 🔵 Accepted |
 | **021** | [Rust Telemetry Summarization Processor](./021-rust-telemetry-summarization-processor.md) | 🔵 Accepted |

--- a/internal/web/templates/content/evolution.yaml
+++ b/internal/web/templates/content/evolution.yaml
@@ -284,7 +284,7 @@ chapters:
           - Resolved a critical SSH lockout during migration and formalized a recovery protocol.
 
   - title: "GitOps & Operational Maturity"
-    intro: "The day-two operations chapter: hardening the platform with ArgoCD reconciliation, deterministic Kustomize rendering, safer rollouts, and a clearer GitOps operating model."
+    intro: "The day-two operations chapter: hardening the platform with ArgoCD reconciliation, deterministic Kustomize rendering, Trivy-backed workload security, safer rollouts, and a clearer GitOps operating model."
     timeline:
       - date: "2026-03-21"
         title: "ArgoCD GitOps & Automated Fleet Promotion"
@@ -304,3 +304,11 @@ chapters:
         description: |
           - Resolved duplicate resource and namespace collision failures in the tiered Kustomize tree.
           - Split cross-namespace RBAC from overlay-scoped resources so GitOps rendering stayed deterministic.
+      - date: "2026-04-17"
+        title: "Trivy-Verified Workload Hardening"
+        artifacts:
+          - name: "ADR 024: Trivy-Verified Workload Hardening"
+            url: "docs/decisions/024-trivy-verified-workload-hardening.md"
+        description: |
+          - Established a Trivy-verified workload hardening baseline for platform-managed containers and Kubernetes manifests.
+          - Strengthened the GitOps security posture by making container runtime controls part of the source of truth.


### PR DESCRIPTION
### Summary

This change documents the new Trivy-verified workload hardening baseline and makes the security scan enforce HIGH and CRITICAL findings in CI. It also adds ADR 024 and updates the public evolution timeline so the security governance work is visible as part of the platform's GitOps maturity.

### List of Changes

- Improved security documentation by recording Trivy-backed workload hardening across the README, architecture docs, ADR log, and evolution timeline.
- Strengthened review gates by changing the security workflow so Trivy findings fail CI instead of only reporting results.

### Verification

- [x] Ran `git diff --check` for the changed workflow, docs, ADR, and evolution content
- [x] Ran `make lint`
- [x] Ran `make lint-configs`
- [x] Ran `make web-build`

