### PR TITLE
feat(hardware-sim): add device telemetry identity

### DIFF
--- a/cmd/sensor/main.go
+++ b/cmd/sensor/main.go
@@ -23,9 +23,20 @@ func main() {
 		sensorID = fmt.Sprintf("sensor-%d", rand.Intn(1000))
 	}
 
+	deviceID := os.Getenv("DEVICE_ID")
+	if deviceID == "" {
+		deviceID = sensorID
+	}
+
+	firmwareVersion := os.Getenv("FIRMWARE_VERSION")
+	telemetryTopic := os.Getenv("TELEMETRY_TOPIC")
+
 	s := &hardwaresim.Sensor{
-		ID:         sensorID,
-		MqttBroker: mqttBroker,
+		ID:              sensorID,
+		DeviceID:        deviceID,
+		FirmwareVersion: firmwareVersion,
+		MqttBroker:      mqttBroker,
+		TelemetryTopic:  telemetryTopic,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -10,19 +10,21 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 
 ### Sensor Fleet (`sensor`)
 
-- **Type**: Kubernetes Deployment (`hardware-sim` namespace).
+- **Type**: Kubernetes StatefulSet (`hardware-sim` namespace).
 - **Role**: Simulates an individual hardware device emitting real-time telemetry.
 - **Logic**:
   - **Boot Sequence**: Emits serial-style logs to Loki mimicking a hardware bootloader.
   - **Telemetry**: Generates synthetic `temperature` and `power_usage` data.
+  - **Identity**: Uses the stable StatefulSet pod name as `device_id`, while `sensor_id` remains the runtime sensor identity.
+  - **Firmware Metadata**: Publishes `firmware_version` with every telemetry payload.
   - **Hardware Integration**: If available, reads the physical host temperature via `hostPath` mount (`/sys/class/thermal`).
-  - **Communication**: Publishes JSON payloads to the `sensors/thermal` topic on the EMQX broker.
+  - **Communication**: Publishes JSON payloads to the configured telemetry topic, currently `sensors/thermal`, on the EMQX broker.
 - **Failure Hooks**: Subscribes to its own chaos topic (`sensors/<pod-name>/chaos`) to receive simulated failure instructions.
 
 ### Current Baseline
 
-- Publishes sensor telemetry with `sensor_id`, `temperature`, `power_usage`, and `timestamp`.
-- Uses `sensors/thermal` as the telemetry topic.
+- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `power_usage`, and `timestamp`.
+- Uses `sensors/thermal` as the configured thermal telemetry topic.
 - Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
 - Supports the current `spike` chaos command for temporary thermal and power changes.
 - Does not yet publish explicit lifecycle state in telemetry.
@@ -71,7 +73,7 @@ sequenceDiagram
     Sensor->>Sensor: Enter "Spiking" State
 
     loop Every 2s
-        Sensor->>Broker: Publish Telemetry (sensors/thermal)
+        Sensor->>Broker: Publish Telemetry (configured topic)
         Broker->>Viz: Real-time Visualization
     end
 ```

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -16,12 +16,20 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	DefaultThermalTelemetryTopic = "sensors/thermal"
+	DefaultFirmwareVersion       = "dev"
+)
+
 // SensorData represents the synthetic sensor payload.
 type SensorData struct {
-	SensorID    string  `json:"sensor_id"`
-	Temperature float64 `json:"temperature"`
-	PowerUsage  float64 `json:"power_usage"`
-	Timestamp   string  `json:"timestamp"`
+	SensorID        string  `json:"sensor_id"`
+	DeviceID        string  `json:"device_id"`
+	FirmwareVersion string  `json:"firmware_version"`
+	TelemetryTopic  string  `json:"telemetry_topic"`
+	Temperature     float64 `json:"temperature"`
+	PowerUsage      float64 `json:"power_usage"`
+	Timestamp       string  `json:"timestamp"`
 }
 
 // ChaosCommand represents the instruction sent to a sensor to simulate a failure.
@@ -110,8 +118,11 @@ func (c *ChaosController) injectChaos(ctx context.Context, k8s kubernetes.Interf
 
 // Sensor represents a synthetic hardware sensor.
 type Sensor struct {
-	ID         string
-	MqttBroker string
+	ID              string
+	DeviceID        string
+	FirmwareVersion string
+	MqttBroker      string
+	TelemetryTopic  string
 
 	mu             sync.Mutex
 	isSpiking      bool
@@ -148,7 +159,8 @@ func (s *Sensor) Run(ctx context.Context) error {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
-	log.Printf("Sensor %s started publishing to sensors/thermal...", s.ID)
+	telemetryTopic := s.telemetryTopic()
+	log.Printf("Sensor %s started publishing to %s...", s.ID, telemetryTopic)
 
 	for {
 		select {
@@ -162,7 +174,7 @@ func (s *Sensor) Run(ctx context.Context) error {
 				continue
 			}
 
-			token := client.Publish("sensors/thermal", 1, false, payload)
+			token := client.Publish(telemetryTopic, 1, false, payload)
 			token.Wait()
 			if token.Error() != nil {
 				log.Printf("Error publishing to MQTT: %v", token.Error())
@@ -244,9 +256,33 @@ func (s *Sensor) generateData() SensorData {
 	}
 
 	return SensorData{
-		SensorID:    s.ID,
-		Temperature: temp,
-		PowerUsage:  power,
-		Timestamp:   time.Now().Format(time.RFC3339),
+		SensorID:        s.ID,
+		DeviceID:        s.deviceID(),
+		FirmwareVersion: s.firmwareVersion(),
+		TelemetryTopic:  s.telemetryTopic(),
+		Temperature:     temp,
+		PowerUsage:      power,
+		Timestamp:       time.Now().Format(time.RFC3339),
 	}
+}
+
+func (s *Sensor) deviceID() string {
+	if s.DeviceID != "" {
+		return s.DeviceID
+	}
+	return s.ID
+}
+
+func (s *Sensor) firmwareVersion() string {
+	if s.FirmwareVersion != "" {
+		return s.FirmwareVersion
+	}
+	return DefaultFirmwareVersion
+}
+
+func (s *Sensor) telemetryTopic() string {
+	if s.TelemetryTopic != "" {
+		return s.TelemetryTopic
+	}
+	return DefaultThermalTelemetryTopic
 }

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -93,7 +93,12 @@ func (m *fakeMessage) Payload() []byte   { return m.payload }
 func (m *fakeMessage) Ack()              {}
 
 func TestSensor_generateData_SpikeIncreasesPower(t *testing.T) {
-	s := &Sensor{ID: "sensor-1"}
+	s := &Sensor{
+		ID:              "sensor-1",
+		DeviceID:        "device-1",
+		FirmwareVersion: "2026.04.0",
+		TelemetryTopic:  "sensors/thermal",
+	}
 
 	rand.Seed(123)
 	base := s.generateData()
@@ -113,8 +118,33 @@ func TestSensor_generateData_SpikeIncreasesPower(t *testing.T) {
 	if spike.SensorID != "sensor-1" {
 		t.Fatalf("expected sensor_id to be set, got %q", spike.SensorID)
 	}
+	if spike.DeviceID != "device-1" {
+		t.Fatalf("expected device_id to be set, got %q", spike.DeviceID)
+	}
+	if spike.FirmwareVersion != "2026.04.0" {
+		t.Fatalf("expected firmware_version to be set, got %q", spike.FirmwareVersion)
+	}
+	if spike.TelemetryTopic != "sensors/thermal" {
+		t.Fatalf("expected telemetry_topic to be set, got %q", spike.TelemetryTopic)
+	}
 	if spike.Timestamp == "" {
 		t.Fatal("expected timestamp to be set")
+	}
+}
+
+func TestSensor_generateData_DefaultsDeviceMetadata(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	data := s.generateData()
+
+	if data.DeviceID != "sensor-1" {
+		t.Fatalf("expected device_id to default to sensor id, got %q", data.DeviceID)
+	}
+	if data.FirmwareVersion != DefaultFirmwareVersion {
+		t.Fatalf("expected default firmware version %q, got %q", DefaultFirmwareVersion, data.FirmwareVersion)
+	}
+	if data.TelemetryTopic != DefaultThermalTelemetryTopic {
+		t.Fatalf("expected default telemetry topic %q, got %q", DefaultThermalTelemetryTopic, data.TelemetryTopic)
 	}
 }
 

--- a/k3s/base/hardware-sim/sensor-fleet.yaml
+++ b/k3s/base/hardware-sim/sensor-fleet.yaml
@@ -1,5 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sensor-fleet
+  namespace: hardware-sim
+  labels:
+    app: sensor-fleet
+spec:
+  clusterIP: None
+  selector:
+    app: sensor-fleet
+---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: sensor-fleet
   namespace: hardware-sim
@@ -7,6 +19,7 @@ metadata:
     app: sensor-fleet
     feature: simulation
 spec:
+  serviceName: sensor-fleet
   replicas: 5
   selector:
     matchLabels:
@@ -57,6 +70,14 @@ spec:
           value: "tcp://emqx.observability.svc.cluster.local:1883"
         - name: TARGET_NAMESPACE
           value: "hardware-sim"
+        - name: DEVICE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: FIRMWARE_VERSION
+          value: "learning-lab-0.1.0"
+        - name: TELEMETRY_TOPIC
+          value: "sensors/thermal"
         resources:
           requests:
             cpu: "20m"

--- a/k3s/overlays/dev/kustomization.yaml
+++ b/k3s/overlays/dev/kustomization.yaml
@@ -26,12 +26,19 @@ patches:
         path: /spec/template/spec/containers/0/env/1/value
         value: "dev-hardware-sim"
   - target:
-      kind: Deployment
+      kind: StatefulSet
       name: sensor-fleet
     patch: |-
       - op: replace
         path: /spec/replicas
         value: 1
+  - target:
+      kind: Service
+      name: sensor-fleet
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: dev-hardware-sim
   # --- Simulation RBAC (dev-hardware-sim) ---
   - target:
       name: hw-.*

--- a/k3s/overlays/prod/kustomization.yaml
+++ b/k3s/overlays/prod/kustomization.yaml
@@ -26,12 +26,19 @@ patches:
         path: /spec/template/spec/containers/0/env/1/value
         value: "hardware-sim"
   - target:
-      kind: Deployment
+      kind: StatefulSet
       name: sensor-fleet
     patch: |-
       - op: replace
         path: /spec/replicas
         value: 3
+  - target:
+      kind: Service
+      name: sensor-fleet
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: hardware-sim
   # --- Simulation RBAC (hardware-sim) ---
   - target:
       name: hw-.*


### PR DESCRIPTION
### Summary

This change implements Phase 2 of the hardware simulator plan by giving each simulated sensor a stable device identity, firmware metadata, and an explicit telemetry topic. The sensor fleet now uses a StatefulSet so pod names can act as durable learning-lab device IDs across normal pod restarts.

### List of Changes

- Added `device_id`, `firmware_version`, and `telemetry_topic` fields to hardware simulator telemetry payloads.
- Wired sensor runtime configuration through `DEVICE_ID`, `FIRMWARE_VERSION`, and `TELEMETRY_TOPIC`, with defaults for local runs.
- Converted the sensor fleet workload to a StatefulSet with a headless Service so Kubernetes gives each simulated device a stable name.
- Updated dev and prod overlays to target the StatefulSet and keep the headless Service in the correct namespace.
- Updated the hardware simulator architecture page to document the Phase 2 telemetry baseline.

### Verification

- [x] Ran `go test ./...`
- [x] Ran `make lint`
- [x] Ran `make kube-lint`
- [x] Rendered `kubectl kustomize k3s/overlays/dev`
- [x] Rendered `kubectl kustomize k3s/overlays/prod`

