### PR TITLE
feat(hardware-sim): add voltage sag telemetry

### DIFF
--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -14,7 +14,7 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - **Role**: Simulates an individual hardware device emitting real-time telemetry.
 - **Logic**:
   - **Boot Sequence**: Emits serial-style logs to Loki mimicking a hardware bootloader.
-  - **Telemetry**: Generates synthetic `temperature` and `power_usage` data.
+  - **Telemetry**: Generates synthetic `temperature`, `voltage`, `current`, and `power_usage` data.
   - **Identity**: Uses the stable StatefulSet pod name as `device_id`, while `sensor_id` remains the runtime sensor identity.
   - **Firmware Metadata**: Publishes `firmware_version` with every telemetry payload.
   - **Hardware Integration**: If available, reads the physical host temperature via `hostPath` mount (`/sys/class/thermal`).
@@ -23,10 +23,10 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 
 ### Current Baseline
 
-- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `power_usage`, and `timestamp`.
+- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, and `timestamp`.
 - Uses `sensors/thermal` as the configured thermal telemetry topic.
 - Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
-- Supports the current `spike` chaos command for temporary thermal and power changes.
+- Supports the current `spike` chaos command for temporary thermal load, current draw, power increase, and voltage sag.
 - Does not yet publish explicit lifecycle state in telemetry.
 
 ### Device Lifecycle Model
@@ -86,11 +86,3 @@ The simulation uses the platform's observability stack as a learning surface:
 - **Metrics**: EMQX stats are scraped by Prometheus, providing visibility into the message throughput and client connectivity of the simulation fleet.
 - **Visualization**: Grafana dashboards track the relationship between simulated sensor behavior, pod health, network traffic, and resource consumption.
 - **Agentic Audit**: AI agents (via MCP) can use pod, log, metric, and network tools to inspect what happened during an experiment.
-
-## Future Roadmap
-
-As outlined in `plan-hardware-sim.md`, the simulation will evolve to include:
-
-- **Voltage Sag**: Emulating battery drops during high-throughput MQTT bursts.
-- **Signal Multi-path**: Simulating radio interference through RSSI and SNR fluctuations.
-- **Link Quality**: Correlating network latency with simulated weak-signal or obstacle scenarios.

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -28,6 +28,8 @@ type SensorData struct {
 	FirmwareVersion string  `json:"firmware_version"`
 	TelemetryTopic  string  `json:"telemetry_topic"`
 	Temperature     float64 `json:"temperature"`
+	Voltage         float64 `json:"voltage"`
+	Current         float64 `json:"current"`
 	PowerUsage      float64 `json:"power_usage"`
 	Timestamp       string  `json:"timestamp"`
 }
@@ -43,6 +45,9 @@ type ChaosCommand struct {
 type ChaosController struct {
 	MqttBroker string
 	Namespace  string
+
+	randMu     sync.Mutex
+	randSource *rand.Rand
 }
 
 // Run starts the chaos injection loop.
@@ -70,7 +75,7 @@ func (c *ChaosController) Run(ctx context.Context) error {
 
 	for {
 		// Randomize interval between 15s and 45s (Average 30s)
-		interval := time.Duration(15+rand.Intn(31)) * time.Second
+		interval := time.Duration(15+c.randIntn(31)) * time.Second
 		timer := time.NewTimer(interval)
 
 		select {
@@ -98,11 +103,11 @@ func (c *ChaosController) injectChaos(ctx context.Context, k8s kubernetes.Interf
 	}
 
 	// Target a random pod
-	targetPod := pods.Items[rand.Intn(len(pods.Items))]
+	targetPod := pods.Items[c.randIntn(len(pods.Items))]
 
 	// Randomize Spike Parameters
-	durationSec := 10 + rand.Intn(21) // 10s to 30s
-	intensity := []string{"low", "medium", "high"}[rand.Intn(3)]
+	durationSec := 10 + c.randIntn(21) // 10s to 30s
+	intensity := []string{"low", "medium", "high"}[c.randIntn(3)]
 
 	log.Printf("Injecting Chaos into %s: Intensity=%s, Duration=%ds", targetPod.Name, intensity, durationSec)
 
@@ -127,6 +132,8 @@ type Sensor struct {
 	mu             sync.Mutex
 	isSpiking      bool
 	spikeIntensity string
+	randMu         sync.Mutex
+	randSource     *rand.Rand
 }
 
 // Run starts the sensor data generation and chaos subscription loop.
@@ -219,28 +226,34 @@ func (s *Sensor) generateData() SensorData {
 	s.mu.Unlock()
 
 	// Base Simulation (Healthy state)
-	temp := 35.0 + rand.Float64()*5.0
-	power := 2.0 + rand.Float64()*2.0
+	temp := 35.0 + s.randFloat64()*5.0
+	voltage := 5.0 - s.randFloat64()*0.1
+	current := 0.4 + s.randFloat64()*0.4
 
 	// Apply Dynamic Spike Logic
 	if spiking {
-		var tempAdd, powerAdd float64
+		var tempAdd, currentAdd, voltageSag float64
 		switch intensity {
 		case "low":
-			tempAdd = 5.0 + rand.Float64()*5.0
-			powerAdd = 2.0 + rand.Float64()*3.0
+			tempAdd = 5.0 + s.randFloat64()*5.0
+			currentAdd = 0.6 + s.randFloat64()*0.6
+			voltageSag = 0.2 + s.randFloat64()*0.2
 		case "medium":
-			tempAdd = 15.0 + rand.Float64()*10.0
-			powerAdd = 10.0 + rand.Float64()*10.0
+			tempAdd = 15.0 + s.randFloat64()*10.0
+			currentAdd = 3.0 + s.randFloat64()*2.0
+			voltageSag = 0.6 + s.randFloat64()*0.4
 		case "high":
-			tempAdd = 30.0 + rand.Float64()*20.0
-			powerAdd = 25.0 + rand.Float64()*20.0
+			tempAdd = 30.0 + s.randFloat64()*20.0
+			currentAdd = 8.0 + s.randFloat64()*4.0
+			voltageSag = 1.1 + s.randFloat64()*0.7
 		default:
 			tempAdd = 10.0
-			powerAdd = 5.0
+			currentAdd = 1.0
+			voltageSag = 0.4
 		}
 		temp += tempAdd
-		power += powerAdd
+		current += currentAdd
+		voltage -= voltageSag
 	}
 
 	// Try to read actual temperature if available (HostPath mount)
@@ -261,7 +274,9 @@ func (s *Sensor) generateData() SensorData {
 		FirmwareVersion: s.firmwareVersion(),
 		TelemetryTopic:  s.telemetryTopic(),
 		Temperature:     temp,
-		PowerUsage:      power,
+		Voltage:         voltage,
+		Current:         current,
+		PowerUsage:      voltage * current,
 		Timestamp:       time.Now().Format(time.RFC3339),
 	}
 }
@@ -285,4 +300,22 @@ func (s *Sensor) telemetryTopic() string {
 		return s.TelemetryTopic
 	}
 	return DefaultThermalTelemetryTopic
+}
+
+func (c *ChaosController) randIntn(n int) int {
+	c.randMu.Lock()
+	defer c.randMu.Unlock()
+	if c.randSource != nil {
+		return c.randSource.Intn(n)
+	}
+	return rand.Intn(n)
+}
+
+func (s *Sensor) randFloat64() float64 {
+	s.randMu.Lock()
+	defer s.randMu.Unlock()
+	if s.randSource != nil {
+		return s.randSource.Float64()
+	}
+	return rand.Float64()
 }

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -92,15 +92,15 @@ func (m *fakeMessage) MessageID() uint16 { return 0 }
 func (m *fakeMessage) Payload() []byte   { return m.payload }
 func (m *fakeMessage) Ack()              {}
 
-func TestSensor_generateData_SpikeIncreasesPower(t *testing.T) {
+func TestSensor_generateData_SpikeIncreasesPowerAndSagsVoltage(t *testing.T) {
 	s := &Sensor{
 		ID:              "sensor-1",
 		DeviceID:        "device-1",
 		FirmwareVersion: "2026.04.0",
 		TelemetryTopic:  "sensors/thermal",
+		randSource:      rand.New(rand.NewSource(123)),
 	}
 
-	rand.Seed(123)
 	base := s.generateData()
 
 	s.mu.Lock()
@@ -108,12 +108,18 @@ func TestSensor_generateData_SpikeIncreasesPower(t *testing.T) {
 	s.spikeIntensity = "high"
 	s.mu.Unlock()
 
-	rand.Seed(123)
+	s.randSource = rand.New(rand.NewSource(123))
 	spike := s.generateData()
 
 	// High intensity adds at least 25W, regardless of host temperature override logic.
 	if spike.PowerUsage <= base.PowerUsage+20 {
 		t.Fatalf("expected spike power to be significantly higher, base=%v spike=%v", base.PowerUsage, spike.PowerUsage)
+	}
+	if spike.Current <= base.Current {
+		t.Fatalf("expected spike current to increase, base=%v spike=%v", base.Current, spike.Current)
+	}
+	if spike.Voltage >= base.Voltage {
+		t.Fatalf("expected spike voltage to sag, base=%v spike=%v", base.Voltage, spike.Voltage)
 	}
 	if spike.SensorID != "sensor-1" {
 		t.Fatalf("expected sensor_id to be set, got %q", spike.SensorID)
@@ -126,6 +132,12 @@ func TestSensor_generateData_SpikeIncreasesPower(t *testing.T) {
 	}
 	if spike.TelemetryTopic != "sensors/thermal" {
 		t.Fatalf("expected telemetry_topic to be set, got %q", spike.TelemetryTopic)
+	}
+	if spike.Voltage <= 0 {
+		t.Fatalf("expected voltage to be positive, got %v", spike.Voltage)
+	}
+	if spike.Current <= 0 {
+		t.Fatalf("expected current to be positive, got %v", spike.Current)
 	}
 	if spike.Timestamp == "" {
 		t.Fatal("expected timestamp to be set")
@@ -145,6 +157,15 @@ func TestSensor_generateData_DefaultsDeviceMetadata(t *testing.T) {
 	}
 	if data.TelemetryTopic != DefaultThermalTelemetryTopic {
 		t.Fatalf("expected default telemetry topic %q, got %q", DefaultThermalTelemetryTopic, data.TelemetryTopic)
+	}
+	if data.Voltage <= 0 {
+		t.Fatalf("expected default voltage to be positive, got %v", data.Voltage)
+	}
+	if data.Current <= 0 {
+		t.Fatalf("expected default current to be positive, got %v", data.Current)
+	}
+	if data.PowerUsage <= 0 {
+		t.Fatalf("expected default power_usage to be positive, got %v", data.PowerUsage)
 	}
 }
 
@@ -189,9 +210,11 @@ func TestChaosController_injectChaos_NoPods_NoPublish(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
 
 	mq := &fakeMQTTClient{}
-	c := &ChaosController{Namespace: "default"}
+	c := &ChaosController{
+		Namespace:  "default",
+		randSource: rand.New(rand.NewSource(1)),
+	}
 
-	rand.Seed(1)
 	c.injectChaos(ctx, k8s, mq)
 
 	if got := len(mq.Publishes()); got != 0 {
@@ -219,9 +242,11 @@ func TestChaosController_injectChaos_PublishesToSensorTopic(t *testing.T) {
 	k8s := fake.NewSimpleClientset(p1, p2)
 
 	mq := &fakeMQTTClient{}
-	c := &ChaosController{Namespace: "default"}
+	c := &ChaosController{
+		Namespace:  "default",
+		randSource: rand.New(rand.NewSource(2)),
+	}
 
-	rand.Seed(2)
 	c.injectChaos(ctx, k8s, mq)
 
 	pubs := mq.Publishes()


### PR DESCRIPTION
### Summary

This change implements Phase 3 of the hardware simulator by adding explicit voltage and current telemetry to each sensor payload. Spike chaos now models a load event where current and power rise while voltage sags.

### List of Changes

- Expanded sensor telemetry so power behavior can be monitored through voltage, current, and derived power usage.
- Made spike chaos easier to interpret by modeling load as rising current and sagging voltage.

### Verification

- [x] Ran `go test ./internal/hardware-sim ./cmd/sensor`
- [x] Ran `make lint`

