### PR TITLE
feat(hardware-sim): add link quality chaos

### DIFF
--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -14,7 +14,7 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - **Role**: Simulates an individual hardware device emitting real-time telemetry.
 - **Logic**:
   - **Boot Sequence**: Emits serial-style logs to Loki mimicking a hardware bootloader.
-  - **Telemetry**: Generates synthetic `temperature`, `voltage`, `current`, and `power_usage` data.
+  - **Telemetry**: Generates synthetic `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, and `packet_loss_percent` data.
   - **Identity**: Uses the stable StatefulSet pod name as `device_id`, while `sensor_id` remains the runtime sensor identity.
   - **Firmware Metadata**: Publishes `firmware_version` with every telemetry payload.
   - **Hardware Integration**: If available, reads the physical host temperature via `hostPath` mount (`/sys/class/thermal`).
@@ -23,10 +23,11 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 
 ### Current Baseline
 
-- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, and `timestamp`.
+- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, `packet_loss_percent`, and `timestamp`.
 - Uses `sensors/thermal` as the configured thermal telemetry topic.
 - Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
 - Supports the current `spike` chaos command for temporary thermal load, current draw, power increase, and voltage sag.
+- Supports the current `signal_loss` chaos command for temporary RSSI, SNR, and packet-loss degradation.
 - Does not yet publish explicit lifecycle state in telemetry.
 
 ### Device Lifecycle Model
@@ -43,7 +44,7 @@ The lifecycle model is the shared vocabulary for future sensor state reporting:
 | `rebooting` | Device is restarting because of a planned reset or simulated hardware-style fault. |
 | `failed` | Device cannot continue normal operation without an external restart or intervention. |
 
-In the current implementation, `running` is implied during normal telemetry publishing, and `degraded` is implied while a spike command is active.
+In the current implementation, `running` is implied during normal telemetry publishing, and `degraded` is implied while a spike or signal-loss command is active.
 
 ### Chaos Controller (`chaos-controller`)
 
@@ -51,7 +52,7 @@ In the current implementation, `running` is implied during normal telemetry publ
 - **Role**: A small experiment driver that injects periodic failure modes into the sensor fleet.
 - **Logic**:
   - **Discovery**: Queries the Kubernetes API to identify active `sensor-fleet` pods.
-  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike") via MQTT.
+  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike" or "signal_loss") via MQTT.
   - **Parameters**: Randomizes the duration (10s-30s) and intensity (low, medium, high) of the failure.
 
 ## Data Flow & Orchestration
@@ -68,9 +69,9 @@ sequenceDiagram
     K8s-->>Chaos: [sensor-01, sensor-02, ...]
     
     Note over Chaos, Sensor: Chaos Injection Loop
-    Chaos->>Broker: Publish Chaos (Target: sensor-01, Command: Spike)
+    Chaos->>Broker: Publish Chaos (Target: sensor-01, Command: Spike or Signal Loss)
     Broker->>Sensor: Deliver Command
-    Sensor->>Sensor: Enter "Spiking" State
+    Sensor->>Sensor: Enter degraded behavior
 
     loop Every 2s
         Sensor->>Broker: Publish Telemetry (configured topic)

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -31,6 +31,9 @@ type SensorData struct {
 	Voltage         float64 `json:"voltage"`
 	Current         float64 `json:"current"`
 	PowerUsage      float64 `json:"power_usage"`
+	RSSI            float64 `json:"rssi"`
+	SNR             float64 `json:"snr"`
+	PacketLoss      float64 `json:"packet_loss_percent"`
 	Timestamp       string  `json:"timestamp"`
 }
 
@@ -105,14 +108,15 @@ func (c *ChaosController) injectChaos(ctx context.Context, k8s kubernetes.Interf
 	// Target a random pod
 	targetPod := pods.Items[c.randIntn(len(pods.Items))]
 
-	// Randomize Spike Parameters
+	// Randomize chaos parameters
+	command := []string{"spike", "signal_loss"}[c.randIntn(2)]
 	durationSec := 10 + c.randIntn(21) // 10s to 30s
 	intensity := []string{"low", "medium", "high"}[c.randIntn(3)]
 
-	log.Printf("Injecting Chaos into %s: Intensity=%s, Duration=%ds", targetPod.Name, intensity, durationSec)
+	log.Printf("Injecting Chaos into %s: Command=%s, Intensity=%s, Duration=%ds", targetPod.Name, command, intensity, durationSec)
 
 	topic := fmt.Sprintf("sensors/%s/chaos", targetPod.Name)
-	payload := fmt.Sprintf(`{"command": "spike", "duration": "%ds", "intensity": "%s"}`, durationSec, intensity)
+	payload := fmt.Sprintf(`{"command": "%s", "duration": "%ds", "intensity": "%s"}`, command, durationSec, intensity)
 
 	token := mqttClient.Publish(topic, 1, false, payload)
 	token.Wait()
@@ -129,11 +133,13 @@ type Sensor struct {
 	MqttBroker      string
 	TelemetryTopic  string
 
-	mu             sync.Mutex
-	isSpiking      bool
-	spikeIntensity string
-	randMu         sync.Mutex
-	randSource     *rand.Rand
+	mu              sync.Mutex
+	isSpiking       bool
+	spikeIntensity  string
+	signalLoss      bool
+	signalIntensity string
+	randMu          sync.Mutex
+	randSource      *rand.Rand
 }
 
 // Run starts the sensor data generation and chaos subscription loop.
@@ -197,7 +203,8 @@ func (s *Sensor) handleChaos(client mqtt.Client, msg mqtt.Message) {
 		return
 	}
 
-	if cmd.Command == "spike" {
+	switch cmd.Command {
+	case "spike":
 		duration, _ := time.ParseDuration(cmd.Duration)
 		if duration == 0 {
 			duration = 10 * time.Second
@@ -216,6 +223,25 @@ func (s *Sensor) handleChaos(client mqtt.Client, msg mqtt.Message) {
 			s.mu.Unlock()
 			log.Println("Chaos Spike Ended.")
 		})
+	case "signal_loss":
+		duration, _ := time.ParseDuration(cmd.Duration)
+		if duration == 0 {
+			duration = 10 * time.Second
+		}
+
+		log.Printf("!!! Signal Loss Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
+		s.mu.Lock()
+		s.signalLoss = true
+		s.signalIntensity = cmd.Intensity
+		s.mu.Unlock()
+
+		time.AfterFunc(duration, func() {
+			s.mu.Lock()
+			s.signalLoss = false
+			s.signalIntensity = ""
+			s.mu.Unlock()
+			log.Println("Signal Loss Ended.")
+		})
 	}
 }
 
@@ -223,12 +249,17 @@ func (s *Sensor) generateData() SensorData {
 	s.mu.Lock()
 	spiking := s.isSpiking
 	intensity := s.spikeIntensity
+	signalLoss := s.signalLoss
+	signalIntensity := s.signalIntensity
 	s.mu.Unlock()
 
 	// Base Simulation (Healthy state)
 	temp := 35.0 + s.randFloat64()*5.0
 	voltage := 5.0 - s.randFloat64()*0.1
 	current := 0.4 + s.randFloat64()*0.4
+	rssi := -45.0 - s.randFloat64()*10.0
+	snr := 22.0 + s.randFloat64()*8.0
+	packetLoss := s.randFloat64() * 2.0
 
 	// Apply Dynamic Spike Logic
 	if spiking {
@@ -256,6 +287,31 @@ func (s *Sensor) generateData() SensorData {
 		voltage -= voltageSag
 	}
 
+	if signalLoss {
+		var rssiDrop, snrDrop, packetLossAdd float64
+		switch signalIntensity {
+		case "low":
+			rssiDrop = 8.0 + s.randFloat64()*6.0
+			snrDrop = 4.0 + s.randFloat64()*3.0
+			packetLossAdd = 5.0 + s.randFloat64()*5.0
+		case "medium":
+			rssiDrop = 18.0 + s.randFloat64()*8.0
+			snrDrop = 10.0 + s.randFloat64()*5.0
+			packetLossAdd = 18.0 + s.randFloat64()*12.0
+		case "high":
+			rssiDrop = 30.0 + s.randFloat64()*10.0
+			snrDrop = 18.0 + s.randFloat64()*8.0
+			packetLossAdd = 45.0 + s.randFloat64()*25.0
+		default:
+			rssiDrop = 12.0
+			snrDrop = 8.0
+			packetLossAdd = 12.0
+		}
+		rssi -= rssiDrop
+		snr -= snrDrop
+		packetLoss += packetLossAdd
+	}
+
 	// Try to read actual temperature if available (HostPath mount)
 	if b, err := os.ReadFile("/sys/class/thermal/thermal_zone0/temp"); err == nil {
 		var t int
@@ -277,6 +333,9 @@ func (s *Sensor) generateData() SensorData {
 		Voltage:         voltage,
 		Current:         current,
 		PowerUsage:      voltage * current,
+		RSSI:            rssi,
+		SNR:             snr,
+		PacketLoss:      packetLoss,
 		Timestamp:       time.Now().Format(time.RFC3339),
 	}
 }

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -167,6 +167,42 @@ func TestSensor_generateData_DefaultsDeviceMetadata(t *testing.T) {
 	if data.PowerUsage <= 0 {
 		t.Fatalf("expected default power_usage to be positive, got %v", data.PowerUsage)
 	}
+	if data.RSSI >= 0 {
+		t.Fatalf("expected default rssi to be negative dBm, got %v", data.RSSI)
+	}
+	if data.SNR <= 0 {
+		t.Fatalf("expected default snr to be positive, got %v", data.SNR)
+	}
+	if data.PacketLoss < 0 {
+		t.Fatalf("expected default packet loss to be non-negative, got %v", data.PacketLoss)
+	}
+}
+
+func TestSensor_generateData_SignalLossDegradesLinkQuality(t *testing.T) {
+	s := &Sensor{
+		ID:         "sensor-1",
+		randSource: rand.New(rand.NewSource(321)),
+	}
+
+	base := s.generateData()
+
+	s.mu.Lock()
+	s.signalLoss = true
+	s.signalIntensity = "high"
+	s.mu.Unlock()
+
+	s.randSource = rand.New(rand.NewSource(321))
+	degraded := s.generateData()
+
+	if degraded.RSSI >= base.RSSI {
+		t.Fatalf("expected signal loss to lower rssi, base=%v degraded=%v", base.RSSI, degraded.RSSI)
+	}
+	if degraded.SNR >= base.SNR {
+		t.Fatalf("expected signal loss to lower snr, base=%v degraded=%v", base.SNR, degraded.SNR)
+	}
+	if degraded.PacketLoss <= base.PacketLoss {
+		t.Fatalf("expected signal loss to increase packet loss, base=%v degraded=%v", base.PacketLoss, degraded.PacketLoss)
+	}
 }
 
 func TestSensor_handleChaos_SetsAndClearsSpike(t *testing.T) {
@@ -202,6 +238,42 @@ func TestSensor_handleChaos_SetsAndClearsSpike(t *testing.T) {
 
 	if spiking || intensity != "" {
 		t.Fatalf("expected spike to be cleared, spiking=%v intensity=%q", spiking, intensity)
+	}
+}
+
+func TestSensor_handleChaos_SetsAndClearsSignalLoss(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	cmd := ChaosCommand{
+		Command:   "signal_loss",
+		Duration:  "5ms",
+		Intensity: "medium",
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal chaos command: %v", err)
+	}
+
+	s.handleChaos(nil, &fakeMessage{payload: b})
+
+	s.mu.Lock()
+	signalLoss := s.signalLoss
+	intensity := s.signalIntensity
+	s.mu.Unlock()
+
+	if !signalLoss || intensity != "medium" {
+		t.Fatalf("expected signal loss to be active immediately, signalLoss=%v intensity=%q", signalLoss, intensity)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	signalLoss = s.signalLoss
+	intensity = s.signalIntensity
+	s.mu.Unlock()
+
+	if signalLoss || intensity != "" {
+		t.Fatalf("expected signal loss to be cleared, signalLoss=%v intensity=%q", signalLoss, intensity)
 	}
 }
 
@@ -271,7 +343,7 @@ func TestChaosController_injectChaos_PublishesToSensorTopic(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected string payload, got %T", pub.payload)
 	}
-	payloadRe := regexp.MustCompile(`^\{"command": "spike", "duration": "\d+s", "intensity": "(low|medium|high)"\}$`)
+	payloadRe := regexp.MustCompile(`^\{"command": "(spike|signal_loss)", "duration": "\d+s", "intensity": "(low|medium|high)"\}$`)
 	if !payloadRe.MatchString(payload) {
 		t.Fatalf("unexpected payload %q", payload)
 	}


### PR DESCRIPTION
### Summary

This change implements Phase 4 of the hardware simulator by adding radio and link-quality telemetry to each sensor payload. Signal-loss chaos now gives the simulator a weak-link failure mode that can be observed through degraded RSSI, SNR, and packet loss.

### List of Changes

- Expanded sensor telemetry so weak-link behavior can be monitored through RSSI, SNR, and packet-loss readings.
- Added signal-loss chaos so the simulator can model degraded radio conditions separately from thermal and power spikes.
- Updated the hardware simulator architecture page so the current telemetry and chaos behavior matches the implemented service.

### Verification

- [x] Ran `go test ./internal/hardware-sim ./cmd/sensor ./cmd/chaos-controller`
- [x] Ran `make lint`

