### PR TITLE
feat(hardware-sim): add runtime health telemetry

### DIFF
--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -14,7 +14,7 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - **Role**: Simulates an individual hardware device emitting real-time telemetry.
 - **Logic**:
   - **Boot Sequence**: Emits serial-style logs to Loki mimicking a hardware bootloader.
-  - **Telemetry**: Generates synthetic `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, and `packet_loss_percent` data.
+  - **Telemetry**: Generates synthetic sensor, power, link-quality, and runtime-health data.
   - **Identity**: Uses the stable StatefulSet pod name as `device_id`, while `sensor_id` remains the runtime sensor identity.
   - **Firmware Metadata**: Publishes `firmware_version` with every telemetry payload.
   - **Hardware Integration**: If available, reads the physical host temperature via `hostPath` mount (`/sys/class/thermal`).
@@ -23,7 +23,8 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 
 ### Current Baseline
 
-- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, `packet_loss_percent`, and `timestamp`.
+- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, `packet_loss_percent`, `free_heap`, `loop_time_ms`, `uptime_seconds`, `reboot_reason`, and `timestamp`.
+- Reports baseline runtime health through emulated heap, loop timing, uptime, and last reboot reason.
 - Uses `sensors/thermal` as the configured thermal telemetry topic.
 - Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
 - Supports the current `spike` chaos command for temporary thermal load, current draw, power increase, and voltage sag.

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -19,6 +19,8 @@ import (
 const (
 	DefaultThermalTelemetryTopic = "sensors/thermal"
 	DefaultFirmwareVersion       = "dev"
+	DefaultEmulatedHeapBytes     = 320 * 1024
+	DefaultRebootReason          = "power_on"
 )
 
 // SensorData represents the synthetic sensor payload.
@@ -34,6 +36,10 @@ type SensorData struct {
 	RSSI            float64 `json:"rssi"`
 	SNR             float64 `json:"snr"`
 	PacketLoss      float64 `json:"packet_loss_percent"`
+	FreeHeap        uint64  `json:"free_heap"`
+	LoopTimeMS      float64 `json:"loop_time_ms"`
+	UptimeSeconds   int64   `json:"uptime_seconds"`
+	RebootReason    string  `json:"reboot_reason"`
 	Timestamp       string  `json:"timestamp"`
 }
 
@@ -138,6 +144,8 @@ type Sensor struct {
 	spikeIntensity  string
 	signalLoss      bool
 	signalIntensity string
+	startTime       time.Time
+	rebootReason    string
 	randMu          sync.Mutex
 	randSource      *rand.Rand
 }
@@ -247,11 +255,20 @@ func (s *Sensor) handleChaos(client mqtt.Client, msg mqtt.Message) {
 
 func (s *Sensor) generateData() SensorData {
 	s.mu.Lock()
+	if s.startTime.IsZero() {
+		s.startTime = time.Now()
+	}
 	spiking := s.isSpiking
 	intensity := s.spikeIntensity
 	signalLoss := s.signalLoss
 	signalIntensity := s.signalIntensity
+	uptimeSeconds := int64(time.Since(s.startTime).Seconds())
+	rebootReason := s.rebootReason
 	s.mu.Unlock()
+
+	if rebootReason == "" {
+		rebootReason = DefaultRebootReason
+	}
 
 	// Base Simulation (Healthy state)
 	temp := 35.0 + s.randFloat64()*5.0
@@ -260,6 +277,8 @@ func (s *Sensor) generateData() SensorData {
 	rssi := -45.0 - s.randFloat64()*10.0
 	snr := 22.0 + s.randFloat64()*8.0
 	packetLoss := s.randFloat64() * 2.0
+	freeHeap := uint64(DefaultEmulatedHeapBytes) - uint64(64*1024+s.randFloat64()*32*1024)
+	loopTimeMS := 4.0 + s.randFloat64()*8.0
 
 	// Apply Dynamic Spike Logic
 	if spiking {
@@ -336,6 +355,10 @@ func (s *Sensor) generateData() SensorData {
 		RSSI:            rssi,
 		SNR:             snr,
 		PacketLoss:      packetLoss,
+		FreeHeap:        freeHeap,
+		LoopTimeMS:      loopTimeMS,
+		UptimeSeconds:   uptimeSeconds,
+		RebootReason:    rebootReason,
 		Timestamp:       time.Now().Format(time.RFC3339),
 	}
 }

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -176,6 +176,21 @@ func TestSensor_generateData_DefaultsDeviceMetadata(t *testing.T) {
 	if data.PacketLoss < 0 {
 		t.Fatalf("expected default packet loss to be non-negative, got %v", data.PacketLoss)
 	}
+	if data.FreeHeap == 0 {
+		t.Fatal("expected default free_heap to be set")
+	}
+	if data.FreeHeap > DefaultEmulatedHeapBytes {
+		t.Fatalf("expected free_heap to stay within emulated heap, got %v", data.FreeHeap)
+	}
+	if data.LoopTimeMS <= 0 {
+		t.Fatalf("expected default loop_time_ms to be positive, got %v", data.LoopTimeMS)
+	}
+	if data.UptimeSeconds < 0 {
+		t.Fatalf("expected default uptime_seconds to be non-negative, got %v", data.UptimeSeconds)
+	}
+	if data.RebootReason != DefaultRebootReason {
+		t.Fatalf("expected default reboot_reason %q, got %q", DefaultRebootReason, data.RebootReason)
+	}
 }
 
 func TestSensor_generateData_SignalLossDegradesLinkQuality(t *testing.T) {
@@ -202,6 +217,32 @@ func TestSensor_generateData_SignalLossDegradesLinkQuality(t *testing.T) {
 	}
 	if degraded.PacketLoss <= base.PacketLoss {
 		t.Fatalf("expected signal loss to increase packet loss, base=%v degraded=%v", base.PacketLoss, degraded.PacketLoss)
+	}
+}
+
+func TestSensor_generateData_ReportsRuntimeHealth(t *testing.T) {
+	s := &Sensor{
+		ID:         "sensor-1",
+		startTime:  time.Now().Add(-10 * time.Second),
+		randSource: rand.New(rand.NewSource(456)),
+	}
+
+	data := s.generateData()
+
+	if data.FreeHeap == 0 {
+		t.Fatal("expected free_heap to be set")
+	}
+	if data.FreeHeap > DefaultEmulatedHeapBytes {
+		t.Fatalf("expected free_heap to stay within emulated heap, got %v", data.FreeHeap)
+	}
+	if data.LoopTimeMS <= 0 {
+		t.Fatalf("expected loop_time_ms to be positive, got %v", data.LoopTimeMS)
+	}
+	if data.UptimeSeconds < 9 {
+		t.Fatalf("expected uptime_seconds to reflect sensor start time, got %v", data.UptimeSeconds)
+	}
+	if data.RebootReason != DefaultRebootReason {
+		t.Fatalf("expected reboot_reason %q, got %q", DefaultRebootReason, data.RebootReason)
 	}
 }
 


### PR DESCRIPTION
### Summary

This change implements Phase 5 of the hardware simulator by adding runtime-health telemetry to each sensor payload. The simulator now reports baseline heap, loop timing, uptime, and reboot-reason fields without adding later restart or memory-leak behavior.

### List of Changes

- Expanded sensor telemetry so runtime health can be monitored alongside sensor, power, and link-quality readings.
- Added baseline emulated heap, loop timing, uptime, and reboot-reason values for each simulated device.
- Updated the hardware simulator architecture page so the current telemetry baseline matches the implemented service.

### Verification

- [x] Ran `go test ./internal/hardware-sim ./cmd/sensor ./cmd/chaos-controller`
- [x] Ran `make lint`

