### PR TITLE
feat(hardware-sim): add restart chaos modes

### DIFF
--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -29,6 +29,8 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
 - Supports the current `spike` chaos command for temporary thermal load, current draw, power increase, and voltage sag.
 - Supports the current `signal_loss` chaos command for temporary RSSI, SNR, and packet-loss degradation.
+- Supports the current `brownout` chaos command for voltage drops that record `reboot_reason=brownout`.
+- Supports the current `memory_leak` chaos command for reducing emulated `free_heap` until a simulated restart records `reboot_reason=memory_leak`.
 - Does not yet publish explicit lifecycle state in telemetry.
 
 ### Device Lifecycle Model
@@ -45,7 +47,7 @@ The lifecycle model is the shared vocabulary for future sensor state reporting:
 | `rebooting` | Device is restarting because of a planned reset or simulated hardware-style fault. |
 | `failed` | Device cannot continue normal operation without an external restart or intervention. |
 
-In the current implementation, `running` is implied during normal telemetry publishing, and `degraded` is implied while a spike or signal-loss command is active.
+In the current implementation, `running` is implied during normal telemetry publishing, `degraded` is implied while a spike, signal-loss, brownout, or memory-leak command is active, and `rebooting` is represented by `reboot_reason` plus reset uptime after brownout or memory-leak restart behavior.
 
 ### Chaos Controller (`chaos-controller`)
 
@@ -53,7 +55,7 @@ In the current implementation, `running` is implied during normal telemetry publ
 - **Role**: A small experiment driver that injects periodic failure modes into the sensor fleet.
 - **Logic**:
   - **Discovery**: Queries the Kubernetes API to identify active `sensor-fleet` pods.
-  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike" or "signal_loss") via MQTT.
+  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike", "signal_loss", "brownout", or "memory_leak") via MQTT.
   - **Parameters**: Randomizes the duration (10s-30s) and intensity (low, medium, high) of the failure.
 
 ## Data Flow & Orchestration
@@ -70,7 +72,7 @@ sequenceDiagram
     K8s-->>Chaos: [sensor-01, sensor-02, ...]
     
     Note over Chaos, Sensor: Chaos Injection Loop
-    Chaos->>Broker: Publish Chaos (Target: sensor-01, Command: Spike or Signal Loss)
+    Chaos->>Broker: Publish Chaos (Target: sensor-01, Command: Spike, Signal Loss, Brownout, or Memory Leak)
     Broker->>Sensor: Deliver Command
     Sensor->>Sensor: Enter degraded behavior
 

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -21,6 +21,10 @@ const (
 	DefaultFirmwareVersion       = "dev"
 	DefaultEmulatedHeapBytes     = 320 * 1024
 	DefaultRebootReason          = "power_on"
+	BrownoutRebootReason         = "brownout"
+	MemoryLeakRebootReason       = "memory_leak"
+	BrownoutVoltageThreshold     = 3.3
+	MemoryLeakRebootHeapBytes    = 32 * 1024
 )
 
 // SensorData represents the synthetic sensor payload.
@@ -115,7 +119,7 @@ func (c *ChaosController) injectChaos(ctx context.Context, k8s kubernetes.Interf
 	targetPod := pods.Items[c.randIntn(len(pods.Items))]
 
 	// Randomize chaos parameters
-	command := []string{"spike", "signal_loss"}[c.randIntn(2)]
+	command := []string{"spike", "signal_loss", "brownout", "memory_leak"}[c.randIntn(4)]
 	durationSec := 10 + c.randIntn(21) // 10s to 30s
 	intensity := []string{"low", "medium", "high"}[c.randIntn(3)]
 
@@ -139,15 +143,21 @@ type Sensor struct {
 	MqttBroker      string
 	TelemetryTopic  string
 
-	mu              sync.Mutex
-	isSpiking       bool
-	spikeIntensity  string
-	signalLoss      bool
-	signalIntensity string
-	startTime       time.Time
-	rebootReason    string
-	randMu          sync.Mutex
-	randSource      *rand.Rand
+	mu                  sync.Mutex
+	isSpiking           bool
+	spikeIntensity      string
+	signalLoss          bool
+	signalIntensity     string
+	brownout            bool
+	brownoutRebooted    bool
+	brownoutIntensity   string
+	memoryLeak          bool
+	memoryLeakIntensity string
+	memoryLeakBytes     uint64
+	startTime           time.Time
+	rebootReason        string
+	randMu              sync.Mutex
+	randSource          *rand.Rand
 }
 
 // Run starts the sensor data generation and chaos subscription loop.
@@ -213,10 +223,7 @@ func (s *Sensor) handleChaos(client mqtt.Client, msg mqtt.Message) {
 
 	switch cmd.Command {
 	case "spike":
-		duration, _ := time.ParseDuration(cmd.Duration)
-		if duration == 0 {
-			duration = 10 * time.Second
-		}
+		duration := chaosDuration(cmd.Duration)
 
 		log.Printf("!!! Chaos Spike Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
 		s.mu.Lock()
@@ -232,10 +239,7 @@ func (s *Sensor) handleChaos(client mqtt.Client, msg mqtt.Message) {
 			log.Println("Chaos Spike Ended.")
 		})
 	case "signal_loss":
-		duration, _ := time.ParseDuration(cmd.Duration)
-		if duration == 0 {
-			duration = 10 * time.Second
-		}
+		duration := chaosDuration(cmd.Duration)
 
 		log.Printf("!!! Signal Loss Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
 		s.mu.Lock()
@@ -250,6 +254,42 @@ func (s *Sensor) handleChaos(client mqtt.Client, msg mqtt.Message) {
 			s.mu.Unlock()
 			log.Println("Signal Loss Ended.")
 		})
+	case "brownout":
+		duration := chaosDuration(cmd.Duration)
+
+		log.Printf("!!! Brownout Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
+		s.mu.Lock()
+		s.brownout = true
+		s.brownoutRebooted = false
+		s.brownoutIntensity = cmd.Intensity
+		s.mu.Unlock()
+
+		time.AfterFunc(duration, func() {
+			s.mu.Lock()
+			s.brownout = false
+			s.brownoutRebooted = false
+			s.brownoutIntensity = ""
+			s.mu.Unlock()
+			log.Println("Brownout Ended.")
+		})
+	case "memory_leak":
+		duration := chaosDuration(cmd.Duration)
+
+		log.Printf("!!! Memory Leak Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
+		s.mu.Lock()
+		s.memoryLeak = true
+		s.memoryLeakIntensity = cmd.Intensity
+		s.memoryLeakBytes = 0
+		s.mu.Unlock()
+
+		time.AfterFunc(duration, func() {
+			s.mu.Lock()
+			s.memoryLeak = false
+			s.memoryLeakIntensity = ""
+			s.memoryLeakBytes = 0
+			s.mu.Unlock()
+			log.Println("Memory Leak Ended.")
+		})
 	}
 }
 
@@ -262,6 +302,12 @@ func (s *Sensor) generateData() SensorData {
 	intensity := s.spikeIntensity
 	signalLoss := s.signalLoss
 	signalIntensity := s.signalIntensity
+	brownout := s.brownout
+	brownoutRebooted := s.brownoutRebooted
+	brownoutIntensity := s.brownoutIntensity
+	memoryLeak := s.memoryLeak
+	memoryLeakIntensity := s.memoryLeakIntensity
+	memoryLeakBytes := s.memoryLeakBytes
 	uptimeSeconds := int64(time.Since(s.startTime).Seconds())
 	rebootReason := s.rebootReason
 	s.mu.Unlock()
@@ -331,6 +377,40 @@ func (s *Sensor) generateData() SensorData {
 		packetLoss += packetLossAdd
 	}
 
+	if brownout {
+		voltage -= brownoutVoltageSag(brownoutIntensity)
+		if voltage < BrownoutVoltageThreshold && !brownoutRebooted {
+			rebootReason = BrownoutRebootReason
+			uptimeSeconds = 0
+			s.mu.Lock()
+			s.rebootReason = BrownoutRebootReason
+			s.startTime = time.Now()
+			s.brownoutRebooted = true
+			s.mu.Unlock()
+		}
+	}
+
+	if memoryLeak {
+		memoryLeakBytes += memoryLeakStepBytes(memoryLeakIntensity)
+		if memoryLeakBytes >= freeHeap-MemoryLeakRebootHeapBytes {
+			rebootReason = MemoryLeakRebootReason
+			uptimeSeconds = 0
+			memoryLeakBytes = 0
+			s.mu.Lock()
+			s.rebootReason = MemoryLeakRebootReason
+			s.startTime = time.Now()
+			s.memoryLeak = false
+			s.memoryLeakIntensity = ""
+			s.memoryLeakBytes = 0
+			s.mu.Unlock()
+		} else {
+			freeHeap -= memoryLeakBytes
+			s.mu.Lock()
+			s.memoryLeakBytes = memoryLeakBytes
+			s.mu.Unlock()
+		}
+	}
+
 	// Try to read actual temperature if available (HostPath mount)
 	if b, err := os.ReadFile("/sys/class/thermal/thermal_zone0/temp"); err == nil {
 		var t int
@@ -382,6 +462,40 @@ func (s *Sensor) telemetryTopic() string {
 		return s.TelemetryTopic
 	}
 	return DefaultThermalTelemetryTopic
+}
+
+func chaosDuration(raw string) time.Duration {
+	duration, _ := time.ParseDuration(raw)
+	if duration == 0 {
+		return 10 * time.Second
+	}
+	return duration
+}
+
+func brownoutVoltageSag(intensity string) float64 {
+	switch intensity {
+	case "low":
+		return 1.2
+	case "medium":
+		return 1.8
+	case "high":
+		return 2.4
+	default:
+		return 1.5
+	}
+}
+
+func memoryLeakStepBytes(intensity string) uint64 {
+	switch intensity {
+	case "low":
+		return 24 * 1024
+	case "medium":
+		return 64 * 1024
+	case "high":
+		return 128 * 1024
+	default:
+		return 48 * 1024
+	}
 }
 
 func (c *ChaosController) randIntn(n int) int {

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -246,6 +246,75 @@ func TestSensor_generateData_ReportsRuntimeHealth(t *testing.T) {
 	}
 }
 
+func TestSensor_generateData_BrownoutDropsVoltageAndRecordsReboot(t *testing.T) {
+	s := &Sensor{
+		ID:         "sensor-1",
+		startTime:  time.Now().Add(-10 * time.Second),
+		randSource: rand.New(rand.NewSource(789)),
+	}
+
+	base := s.generateData()
+
+	s.mu.Lock()
+	s.brownout = true
+	s.brownoutIntensity = "high"
+	s.mu.Unlock()
+
+	s.randSource = rand.New(rand.NewSource(789))
+	brownout := s.generateData()
+
+	if brownout.Voltage >= base.Voltage {
+		t.Fatalf("expected brownout voltage to drop, base=%v brownout=%v", base.Voltage, brownout.Voltage)
+	}
+	if brownout.Voltage >= BrownoutVoltageThreshold {
+		t.Fatalf("expected brownout voltage below threshold %v, got %v", BrownoutVoltageThreshold, brownout.Voltage)
+	}
+	if brownout.RebootReason != BrownoutRebootReason {
+		t.Fatalf("expected reboot_reason %q, got %q", BrownoutRebootReason, brownout.RebootReason)
+	}
+	if brownout.UptimeSeconds != 0 {
+		t.Fatalf("expected brownout reboot to reset uptime, got %v", brownout.UptimeSeconds)
+	}
+}
+
+func TestSensor_generateData_MemoryLeakReducesHeapThenRecordsReboot(t *testing.T) {
+	s := &Sensor{
+		ID:         "sensor-1",
+		startTime:  time.Now().Add(-10 * time.Second),
+		randSource: rand.New(rand.NewSource(987)),
+	}
+
+	base := s.generateData()
+
+	s.mu.Lock()
+	s.memoryLeak = true
+	s.memoryLeakIntensity = "low"
+	s.mu.Unlock()
+
+	s.randSource = rand.New(rand.NewSource(987))
+	leaking := s.generateData()
+
+	if leaking.FreeHeap >= base.FreeHeap {
+		t.Fatalf("expected memory leak to reduce free_heap, base=%v leaking=%v", base.FreeHeap, leaking.FreeHeap)
+	}
+	if leaking.RebootReason != DefaultRebootReason {
+		t.Fatalf("expected first leak sample to keep reboot_reason %q, got %q", DefaultRebootReason, leaking.RebootReason)
+	}
+
+	s.mu.Lock()
+	s.memoryLeakBytes = DefaultEmulatedHeapBytes
+	s.mu.Unlock()
+
+	restarted := s.generateData()
+
+	if restarted.RebootReason != MemoryLeakRebootReason {
+		t.Fatalf("expected reboot_reason %q, got %q", MemoryLeakRebootReason, restarted.RebootReason)
+	}
+	if restarted.UptimeSeconds != 0 {
+		t.Fatalf("expected memory leak reboot to reset uptime, got %v", restarted.UptimeSeconds)
+	}
+}
+
 func TestSensor_handleChaos_SetsAndClearsSpike(t *testing.T) {
 	s := &Sensor{ID: "sensor-1"}
 
@@ -318,6 +387,78 @@ func TestSensor_handleChaos_SetsAndClearsSignalLoss(t *testing.T) {
 	}
 }
 
+func TestSensor_handleChaos_SetsAndClearsBrownout(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	cmd := ChaosCommand{
+		Command:   "brownout",
+		Duration:  "5ms",
+		Intensity: "medium",
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal chaos command: %v", err)
+	}
+
+	s.handleChaos(nil, &fakeMessage{payload: b})
+
+	s.mu.Lock()
+	brownout := s.brownout
+	intensity := s.brownoutIntensity
+	s.mu.Unlock()
+
+	if !brownout || intensity != "medium" {
+		t.Fatalf("expected brownout to be active immediately, brownout=%v intensity=%q", brownout, intensity)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	brownout = s.brownout
+	intensity = s.brownoutIntensity
+	s.mu.Unlock()
+
+	if brownout || intensity != "" {
+		t.Fatalf("expected brownout to be cleared, brownout=%v intensity=%q", brownout, intensity)
+	}
+}
+
+func TestSensor_handleChaos_SetsAndClearsMemoryLeak(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	cmd := ChaosCommand{
+		Command:   "memory_leak",
+		Duration:  "5ms",
+		Intensity: "medium",
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal chaos command: %v", err)
+	}
+
+	s.handleChaos(nil, &fakeMessage{payload: b})
+
+	s.mu.Lock()
+	memoryLeak := s.memoryLeak
+	intensity := s.memoryLeakIntensity
+	s.mu.Unlock()
+
+	if !memoryLeak || intensity != "medium" {
+		t.Fatalf("expected memory leak to be active immediately, memoryLeak=%v intensity=%q", memoryLeak, intensity)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	memoryLeak = s.memoryLeak
+	intensity = s.memoryLeakIntensity
+	s.mu.Unlock()
+
+	if memoryLeak || intensity != "" {
+		t.Fatalf("expected memory leak to be cleared, memoryLeak=%v intensity=%q", memoryLeak, intensity)
+	}
+}
+
 func TestChaosController_injectChaos_NoPods_NoPublish(t *testing.T) {
 	ctx := context.Background()
 	k8s := fake.NewSimpleClientset()
@@ -384,7 +525,7 @@ func TestChaosController_injectChaos_PublishesToSensorTopic(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected string payload, got %T", pub.payload)
 	}
-	payloadRe := regexp.MustCompile(`^\{"command": "(spike|signal_loss)", "duration": "\d+s", "intensity": "(low|medium|high)"\}$`)
+	payloadRe := regexp.MustCompile(`^\{"command": "(spike|signal_loss|brownout|memory_leak)", "duration": "\d+s", "intensity": "(low|medium|high)"\}$`)
 	if !payloadRe.MatchString(payload) {
 		t.Fatalf("unexpected payload %q", payload)
 	}

--- a/k3s/base/hardware-sim/chaos-controller.yaml
+++ b/k3s/base/hardware-sim/chaos-controller.yaml
@@ -40,7 +40,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: chaos-controller
-        image: ghcr.io/victoriacheng15/observability-hub/chaos-controller:sha-f8b2a4a
+        image: ghcr.io/victoriacheng15/observability-hub/chaos-controller:sha-b1789c1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/k3s/base/hardware-sim/sensor-fleet.yaml
+++ b/k3s/base/hardware-sim/sensor-fleet.yaml
@@ -54,7 +54,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: sensor
-        image: ghcr.io/victoriacheng15/observability-hub/sensor:sha-f8b2a4a
+        image: ghcr.io/victoriacheng15/observability-hub/sensor:sha-b1789c1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
### Summary

This change implements Phase 6 of the hardware simulator by adding brownout and memory-leak restart behavior. The simulator can now exercise hardware-style restart signals through voltage drops, emulated heap pressure, reset uptime, and explicit reboot reasons.

### List of Changes

- Added brownout and memory-leak chaos modes so the simulator can model restart-oriented hardware failures, not only degraded readings.
- Extended sensor telemetry behavior so brownout and memory pressure are visible through voltage, `free_heap`, `uptime_seconds`, and `reboot_reason`.
- Updated the hardware simulator service documentation and base Kubernetes image tags so the deployed manifests match the simulator change.

### Verification

- [x] Ran `go test ./internal/hardware-sim ./cmd/sensor ./cmd/chaos-controller`
- [x] Ran `make lint`

