### PR TITLE
fix(hardware-sim): update prod image overlay

### DIFF
--- a/k3s/overlays/prod/kustomization.yaml
+++ b/k3s/overlays/prod/kustomization.yaml
@@ -7,9 +7,9 @@ resources:
 
 images:
   - name: ghcr.io/victoriacheng15/observability-hub/chaos-controller
-    newTag: sha-fe25b96
+    newTag: sha-b1789c1
   - name: ghcr.io/victoriacheng15/observability-hub/sensor
-    newTag: sha-fe25b96
+    newTag: sha-b1789c1
 
 patches:
   # --- Simulation Fleet (hardware-sim) ---


### PR DESCRIPTION
### Summary

This change updates the production hardware simulator overlay to deploy the same simulator image revision already selected in the base manifests. The prod GitOps render now resolves both `sensor` and `chaos-controller` to `sha-b1789c1`, so ArgoCD can reconcile the non-dev namespace to the intended version.

### List of Changes

- Updated the production overlay image transformer so non-dev hardware-sim no longer renders the older `sha-fe25b96` simulator images.
- Kept the change scoped to the GitOps source that actually controls the live `hardware-sim` deployment version.

### Verification

- [x] Ran `kubectl kustomize k3s/overlays/prod | rg -n "image: ghcr.io/victoriacheng15/observability-hub/(chaos-controller|sensor):"`

