### PR TITLE
fix(hardware-sim): manage images in overlays

### DIFF
--- a/k3s/base/hardware-sim/chaos-controller.yaml
+++ b/k3s/base/hardware-sim/chaos-controller.yaml
@@ -40,7 +40,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: chaos-controller
-        image: ghcr.io/victoriacheng15/observability-hub/chaos-controller:sha-b1789c1
+        image: ghcr.io/victoriacheng15/observability-hub/chaos-controller
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/k3s/base/hardware-sim/sensor-fleet.yaml
+++ b/k3s/base/hardware-sim/sensor-fleet.yaml
@@ -54,7 +54,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: sensor
-        image: ghcr.io/victoriacheng15/observability-hub/sensor:sha-b1789c1
+        image: ghcr.io/victoriacheng15/observability-hub/sensor
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/k3s/overlays/dev/kustomization.yaml
+++ b/k3s/overlays/dev/kustomization.yaml
@@ -32,6 +32,16 @@ patches:
       - op: replace
         path: /spec/replicas
         value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Always
+  - target:
+      kind: Deployment
+      name: chaos-controller
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Always
   - target:
       kind: Service
       name: sensor-fleet

--- a/k3s/overlays/prod/kustomization.yaml
+++ b/k3s/overlays/prod/kustomization.yaml
@@ -7,9 +7,9 @@ resources:
 
 images:
   - name: ghcr.io/victoriacheng15/observability-hub/chaos-controller
-    newTag: sha-b1789c1
+    newTag: sha-c67f457
   - name: ghcr.io/victoriacheng15/observability-hub/sensor
-    newTag: sha-b1789c1
+    newTag: sha-c67f457
 
 patches:
   # --- Simulation Fleet (hardware-sim) ---


### PR DESCRIPTION
### Summary

This change moves hardware simulator image version ownership out of the base manifests and into the dev/prod Kustomize overlays. Dev now pulls the mutable canary tag on restart, while prod stays pinned to the Phase 6 image revision that includes brownout and memory-leak behavior.

### List of Changes

- Removed fixed simulator image tags from `k3s/base/hardware-sim` so base defines workload shape instead of environment-specific versions.
- Updated the dev overlay so canary sensor and chaos-controller pods use `imagePullPolicy: Always`.
- Updated the prod overlay so non-dev hardware-sim renders the `sha-c67f457` sensor and chaos-controller images.

### Verification

- [x] Ran `kubectl kustomize k3s/overlays/dev | rg -n "image: ghcr.io/victoriacheng15/observability-hub/(chaos-controller|sensor)|imagePullPolicy:"`
- [x] Ran `kubectl kustomize k3s/overlays/prod | rg -n "image: ghcr.io/victoriacheng15/observability-hub/(chaos-controller|sensor)|imagePullPolicy:"`

