### PR TITLE
feat(hardware-sim): add restart dashboard panel

### DIFF
--- a/k3s/base/infra/grafana/dashboards/edge-simulation.json
+++ b/k3s/base/infra/grafana/dashboards/edge-simulation.json
@@ -908,6 +908,97 @@
       ],
       "title": "Network Traffic Volume (Per-Sensor)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-provisioned"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "sum by (namespace, pod) (changes(container_start_time_seconds{namespace=~\"$simulation_namespace\", container=\"sensor\", pod=~\"sensor-fleet-.*\"}[30m]))",
+          "legendFormat": "{{namespace}} / {{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sensor Pod Restart Correlation",
+      "type": "timeseries"
     }
   ],
   "preload": false,


### PR DESCRIPTION
### Summary

This change updates the edge simulation dashboard with a sensor restart correlation panel. The dashboard can now show whether simulator failure windows line up with real sensor pod restarts.

### List of Changes

- Added dashboard visibility for sensor pod restart timing across `hardware-sim` and `dev-hardware-sim`.
- Made restart correlation easier to check while exercising brownout and memory-leak simulator behavior.

### Verification

- [x] Ran Prometheus query `count(container_start_time_seconds{namespace=~"hardware-sim|dev-hardware-sim", container="sensor", pod=~"sensor-fleet-.*"})`
- [x] Ran Prometheus query `sum by (namespace, pod) (changes(container_start_time_seconds{namespace=~"hardware-sim|dev-hardware-sim", container="sensor", pod=~"sensor-fleet-.*"}[30m]))`
- [x] Ran `jq empty k3s/base/infra/grafana/dashboards/edge-simulation.json`

