### PR TITLE
feat(hardware-sim): add sensor mqtt contract

### DIFF
--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -23,7 +23,7 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 
 ### Current Baseline
 
-- Publishes sensor telemetry with `sensor_id`, `device_id`, `firmware_version`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, `packet_loss_percent`, `free_heap`, `loop_time_ms`, `uptime_seconds`, `reboot_reason`, and `timestamp`.
+- Publishes sensor telemetry with `sensor_id`, `schema_version`, `device_id`, `firmware_version`, `device_state`, `sequence_number`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, `packet_loss_percent`, `free_heap`, `loop_time_ms`, `uptime_seconds`, `reboot_reason`, and `timestamp`.
 - Reports baseline runtime health through emulated heap, loop timing, uptime, and last reboot reason.
 - Uses `sensors/thermal` as the configured thermal telemetry topic.
 - Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
@@ -31,7 +31,8 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - Supports the current `signal_loss` chaos command for temporary RSSI, SNR, and packet-loss degradation.
 - Supports the current `brownout` chaos command for voltage drops that record `reboot_reason=brownout`.
 - Supports the current `memory_leak` chaos command for reducing emulated `free_heap` until a simulated restart records `reboot_reason=memory_leak`.
-- Does not yet publish explicit lifecycle state in telemetry.
+- Publishes explicit lifecycle state in telemetry for `running`, `degraded`, and
+  short-lived `rebooting` samples.
 
 ### Device Lifecycle Model
 
@@ -47,7 +48,7 @@ The lifecycle model is the shared vocabulary for future sensor state reporting:
 | `rebooting` | Device is restarting because of a planned reset or simulated hardware-style fault. |
 | `failed` | Device cannot continue normal operation without an external restart or intervention. |
 
-In the current implementation, `running` is implied during normal telemetry publishing, `degraded` is implied while a spike, signal-loss, brownout, or memory-leak command is active, and `rebooting` is represented by `reboot_reason` plus reset uptime after brownout or memory-leak restart behavior.
+In the current implementation, `running` is published during normal telemetry, `degraded` is published while a spike, signal-loss, brownout, or memory-leak command is active, and `rebooting` is published on the sample that records a brownout or memory-leak restart.
 
 ### Chaos Controller (`chaos-controller`)
 

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -18,9 +18,13 @@ import (
 
 const (
 	DefaultThermalTelemetryTopic = "sensors/thermal"
+	DefaultSchemaVersion         = "1"
 	DefaultFirmwareVersion       = "dev"
 	DefaultEmulatedHeapBytes     = 320 * 1024
 	DefaultRebootReason          = "power_on"
+	DeviceStateRunning           = "running"
+	DeviceStateDegraded          = "degraded"
+	DeviceStateRebooting         = "rebooting"
 	BrownoutRebootReason         = "brownout"
 	MemoryLeakRebootReason       = "memory_leak"
 	BrownoutVoltageThreshold     = 3.3
@@ -30,8 +34,11 @@ const (
 // SensorData represents the synthetic sensor payload.
 type SensorData struct {
 	SensorID        string  `json:"sensor_id"`
+	SchemaVersion   string  `json:"schema_version"`
 	DeviceID        string  `json:"device_id"`
 	FirmwareVersion string  `json:"firmware_version"`
+	DeviceState     string  `json:"device_state"`
+	SequenceNumber  uint64  `json:"sequence_number"`
 	TelemetryTopic  string  `json:"telemetry_topic"`
 	Temperature     float64 `json:"temperature"`
 	Voltage         float64 `json:"voltage"`
@@ -156,6 +163,7 @@ type Sensor struct {
 	memoryLeakBytes     uint64
 	startTime           time.Time
 	rebootReason        string
+	sequenceNumber      uint64
 	randMu              sync.Mutex
 	randSource          *rand.Rand
 }
@@ -310,11 +318,15 @@ func (s *Sensor) generateData() SensorData {
 	memoryLeakBytes := s.memoryLeakBytes
 	uptimeSeconds := int64(time.Since(s.startTime).Seconds())
 	rebootReason := s.rebootReason
+	s.sequenceNumber++
+	sequenceNumber := s.sequenceNumber
 	s.mu.Unlock()
 
 	if rebootReason == "" {
 		rebootReason = DefaultRebootReason
 	}
+
+	deviceState := sensorState(spiking, signalLoss, brownout, memoryLeak)
 
 	// Base Simulation (Healthy state)
 	temp := 35.0 + s.randFloat64()*5.0
@@ -382,6 +394,7 @@ func (s *Sensor) generateData() SensorData {
 		if voltage < BrownoutVoltageThreshold && !brownoutRebooted {
 			rebootReason = BrownoutRebootReason
 			uptimeSeconds = 0
+			deviceState = DeviceStateRebooting
 			s.mu.Lock()
 			s.rebootReason = BrownoutRebootReason
 			s.startTime = time.Now()
@@ -395,6 +408,7 @@ func (s *Sensor) generateData() SensorData {
 		if memoryLeakBytes >= freeHeap-MemoryLeakRebootHeapBytes {
 			rebootReason = MemoryLeakRebootReason
 			uptimeSeconds = 0
+			deviceState = DeviceStateRebooting
 			memoryLeakBytes = 0
 			s.mu.Lock()
 			s.rebootReason = MemoryLeakRebootReason
@@ -425,8 +439,11 @@ func (s *Sensor) generateData() SensorData {
 
 	return SensorData{
 		SensorID:        s.ID,
+		SchemaVersion:   DefaultSchemaVersion,
 		DeviceID:        s.deviceID(),
 		FirmwareVersion: s.firmwareVersion(),
+		DeviceState:     deviceState,
+		SequenceNumber:  sequenceNumber,
 		TelemetryTopic:  s.telemetryTopic(),
 		Temperature:     temp,
 		Voltage:         voltage,
@@ -441,6 +458,13 @@ func (s *Sensor) generateData() SensorData {
 		RebootReason:    rebootReason,
 		Timestamp:       time.Now().Format(time.RFC3339),
 	}
+}
+
+func sensorState(spiking, signalLoss, brownout, memoryLeak bool) string {
+	if spiking || signalLoss || brownout || memoryLeak {
+		return DeviceStateDegraded
+	}
+	return DeviceStateRunning
 }
 
 func (s *Sensor) deviceID() string {

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -124,11 +124,20 @@ func TestSensor_generateData_SpikeIncreasesPowerAndSagsVoltage(t *testing.T) {
 	if spike.SensorID != "sensor-1" {
 		t.Fatalf("expected sensor_id to be set, got %q", spike.SensorID)
 	}
+	if spike.SchemaVersion != DefaultSchemaVersion {
+		t.Fatalf("expected schema_version %q, got %q", DefaultSchemaVersion, spike.SchemaVersion)
+	}
 	if spike.DeviceID != "device-1" {
 		t.Fatalf("expected device_id to be set, got %q", spike.DeviceID)
 	}
 	if spike.FirmwareVersion != "2026.04.0" {
 		t.Fatalf("expected firmware_version to be set, got %q", spike.FirmwareVersion)
+	}
+	if spike.DeviceState != DeviceStateDegraded {
+		t.Fatalf("expected device_state %q, got %q", DeviceStateDegraded, spike.DeviceState)
+	}
+	if spike.SequenceNumber != 2 {
+		t.Fatalf("expected sequence_number 2, got %d", spike.SequenceNumber)
 	}
 	if spike.TelemetryTopic != "sensors/thermal" {
 		t.Fatalf("expected telemetry_topic to be set, got %q", spike.TelemetryTopic)
@@ -152,8 +161,17 @@ func TestSensor_generateData_DefaultsDeviceMetadata(t *testing.T) {
 	if data.DeviceID != "sensor-1" {
 		t.Fatalf("expected device_id to default to sensor id, got %q", data.DeviceID)
 	}
+	if data.SchemaVersion != DefaultSchemaVersion {
+		t.Fatalf("expected schema_version %q, got %q", DefaultSchemaVersion, data.SchemaVersion)
+	}
 	if data.FirmwareVersion != DefaultFirmwareVersion {
 		t.Fatalf("expected default firmware version %q, got %q", DefaultFirmwareVersion, data.FirmwareVersion)
+	}
+	if data.DeviceState != DeviceStateRunning {
+		t.Fatalf("expected default device_state %q, got %q", DeviceStateRunning, data.DeviceState)
+	}
+	if data.SequenceNumber != 1 {
+		t.Fatalf("expected first sequence_number to be 1, got %d", data.SequenceNumber)
 	}
 	if data.TelemetryTopic != DefaultThermalTelemetryTopic {
 		t.Fatalf("expected default telemetry topic %q, got %q", DefaultThermalTelemetryTopic, data.TelemetryTopic)
@@ -218,6 +236,27 @@ func TestSensor_generateData_SignalLossDegradesLinkQuality(t *testing.T) {
 	if degraded.PacketLoss <= base.PacketLoss {
 		t.Fatalf("expected signal loss to increase packet loss, base=%v degraded=%v", base.PacketLoss, degraded.PacketLoss)
 	}
+	if degraded.DeviceState != DeviceStateDegraded {
+		t.Fatalf("expected device_state %q, got %q", DeviceStateDegraded, degraded.DeviceState)
+	}
+}
+
+func TestSensor_generateData_IncrementsSequenceNumber(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	first := s.generateData()
+	second := s.generateData()
+	third := s.generateData()
+
+	if first.SequenceNumber != 1 {
+		t.Fatalf("expected first sequence_number 1, got %d", first.SequenceNumber)
+	}
+	if second.SequenceNumber != 2 {
+		t.Fatalf("expected second sequence_number 2, got %d", second.SequenceNumber)
+	}
+	if third.SequenceNumber != 3 {
+		t.Fatalf("expected third sequence_number 3, got %d", third.SequenceNumber)
+	}
 }
 
 func TestSensor_generateData_ReportsRuntimeHealth(t *testing.T) {
@@ -275,6 +314,9 @@ func TestSensor_generateData_BrownoutDropsVoltageAndRecordsReboot(t *testing.T) 
 	if brownout.UptimeSeconds != 0 {
 		t.Fatalf("expected brownout reboot to reset uptime, got %v", brownout.UptimeSeconds)
 	}
+	if brownout.DeviceState != DeviceStateRebooting {
+		t.Fatalf("expected device_state %q, got %q", DeviceStateRebooting, brownout.DeviceState)
+	}
 }
 
 func TestSensor_generateData_MemoryLeakReducesHeapThenRecordsReboot(t *testing.T) {
@@ -300,6 +342,9 @@ func TestSensor_generateData_MemoryLeakReducesHeapThenRecordsReboot(t *testing.T
 	if leaking.RebootReason != DefaultRebootReason {
 		t.Fatalf("expected first leak sample to keep reboot_reason %q, got %q", DefaultRebootReason, leaking.RebootReason)
 	}
+	if leaking.DeviceState != DeviceStateDegraded {
+		t.Fatalf("expected leaking device_state %q, got %q", DeviceStateDegraded, leaking.DeviceState)
+	}
 
 	s.mu.Lock()
 	s.memoryLeakBytes = DefaultEmulatedHeapBytes
@@ -312,6 +357,9 @@ func TestSensor_generateData_MemoryLeakReducesHeapThenRecordsReboot(t *testing.T
 	}
 	if restarted.UptimeSeconds != 0 {
 		t.Fatalf("expected memory leak reboot to reset uptime, got %v", restarted.UptimeSeconds)
+	}
+	if restarted.DeviceState != DeviceStateRebooting {
+		t.Fatalf("expected device_state %q, got %q", DeviceStateRebooting, restarted.DeviceState)
 	}
 }
 


### PR DESCRIPTION
### Summary
This change updates the hardware simulator payload to carry a minimal MQTT
contract that downstream monitoring can rely on without introducing any new
transport or storage behavior. It gives the later ingestor work stable fields
for schema validation, lifecycle visibility, and sequence tracking while keeping
the current broker path unchanged.

### List of Changes
- Added explicit sensor contract fields for schema version, device state, and
  sequence number in the existing hardware simulator payload
- Improved review and follow-on implementation safety by documenting the new
  payload behavior and covering it with focused package tests

### Verification
- [x] `CCACHE_DISABLE=1 GOCACHE=/tmp/go-build-cache go test ./internal/hardware-sim`


