### PR TITLE
feat(hardware-sim): support per-device telemetry topics

### DIFF
--- a/cmd/sensor/main.go
+++ b/cmd/sensor/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	firmwareVersion := os.Getenv("FIRMWARE_VERSION")
 	telemetryTopic := os.Getenv("TELEMETRY_TOPIC")
+	telemetryTopicMode := os.Getenv("TELEMETRY_TOPIC_MODE")
 
 	s := &hardwaresim.Sensor{
 		ID:              sensorID,
@@ -37,6 +38,7 @@ func main() {
 		FirmwareVersion: firmwareVersion,
 		MqttBroker:      mqttBroker,
 		TelemetryTopic:  telemetryTopic,
+		TelemetryMode:   telemetryTopicMode,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -26,6 +26,9 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - Publishes sensor telemetry with `sensor_id`, `schema_version`, `device_id`, `firmware_version`, `device_state`, `sequence_number`, `telemetry_topic`, `temperature`, `voltage`, `current`, `power_usage`, `rssi`, `snr`, `packet_loss_percent`, `free_heap`, `loop_time_ms`, `uptime_seconds`, `reboot_reason`, and `timestamp`.
 - Reports baseline runtime health through emulated heap, loop timing, uptime, and last reboot reason.
 - Uses `sensors/thermal` as the configured thermal telemetry topic.
+- Supports opt-in per-device telemetry topics in the form
+  `devices/<device_id>/telemetry` while keeping `sensors/thermal` as the
+  default path.
 - Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
 - Supports the current `spike` chaos command for temporary thermal load, current draw, power increase, and voltage sag.
 - Supports the current `signal_loss` chaos command for temporary RSSI, SNR, and packet-loss degradation.

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -20,6 +20,8 @@ const (
 	DefaultThermalTelemetryTopic = "sensors/thermal"
 	DefaultSchemaVersion         = "1"
 	DefaultFirmwareVersion       = "dev"
+	TelemetryTopicModeShared     = "shared"
+	TelemetryTopicModePerDevice  = "per-device"
 	DefaultEmulatedHeapBytes     = 320 * 1024
 	DefaultRebootReason          = "power_on"
 	DeviceStateRunning           = "running"
@@ -149,6 +151,7 @@ type Sensor struct {
 	FirmwareVersion string
 	MqttBroker      string
 	TelemetryTopic  string
+	TelemetryMode   string
 
 	mu                  sync.Mutex
 	isSpiking           bool
@@ -485,7 +488,17 @@ func (s *Sensor) telemetryTopic() string {
 	if s.TelemetryTopic != "" {
 		return s.TelemetryTopic
 	}
+	if s.telemetryTopicMode() == TelemetryTopicModePerDevice {
+		return fmt.Sprintf("devices/%s/telemetry", s.deviceID())
+	}
 	return DefaultThermalTelemetryTopic
+}
+
+func (s *Sensor) telemetryTopicMode() string {
+	if s.TelemetryMode != "" {
+		return s.TelemetryMode
+	}
+	return TelemetryTopicModeShared
 }
 
 func chaosDuration(raw string) time.Duration {

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -211,6 +211,46 @@ func TestSensor_generateData_DefaultsDeviceMetadata(t *testing.T) {
 	}
 }
 
+func TestSensor_telemetryTopic_DefaultsToSharedTopic(t *testing.T) {
+	s := &Sensor{ID: "sensor-1", DeviceID: "device-1"}
+
+	got := s.telemetryTopic()
+
+	if got != DefaultThermalTelemetryTopic {
+		t.Fatalf("expected default telemetry topic %q, got %q", DefaultThermalTelemetryTopic, got)
+	}
+}
+
+func TestSensor_telemetryTopic_UsesExplicitOverride(t *testing.T) {
+	s := &Sensor{
+		ID:             "sensor-1",
+		DeviceID:       "device-1",
+		TelemetryTopic: "custom/topic",
+		TelemetryMode:  TelemetryTopicModePerDevice,
+	}
+
+	got := s.telemetryTopic()
+
+	if got != "custom/topic" {
+		t.Fatalf("expected explicit telemetry topic override, got %q", got)
+	}
+}
+
+func TestSensor_telemetryTopic_UsesPerDeviceTopicWhenEnabled(t *testing.T) {
+	s := &Sensor{
+		ID:            "sensor-1",
+		DeviceID:      "esp32-lab-001",
+		TelemetryMode: TelemetryTopicModePerDevice,
+	}
+
+	got := s.telemetryTopic()
+
+	want := "devices/esp32-lab-001/telemetry"
+	if got != want {
+		t.Fatalf("expected per-device telemetry topic %q, got %q", want, got)
+	}
+}
+
 func TestSensor_generateData_SignalLossDegradesLinkQuality(t *testing.T) {
 	s := &Sensor{
 		ID:         "sensor-1",


### PR DESCRIPTION
### Summary
This change adds transitional support for per-device MQTT telemetry topics
without changing the current default publish path. It lets the simulator move
toward `devices/<device_id>/telemetry` safely while preserving the existing
shared topic and explicit override behavior used by the current deployment.

### List of Changes
- Added an opt-in topic mode so sensors can publish to per-device telemetry
  topics while keeping `sensors/thermal` as the default path
- Improved rollout safety by preserving `TELEMETRY_TOPIC` as the highest-priority
  override and covering the routing behavior with focused tests and docs

### Verification
- [x] `CCACHE_DISABLE=1 GOCACHE=/tmp/go-build-cache go test ./internal/hardware-sim`
- [x] `kubectl kustomize k3s/base/hardware-sim`
- [x] Review that the rendered sensor manifest still pins
  `TELEMETRY_TOPIC=sensors/thermal`

