### PR TITLE
feat(mqtt-ingestor): add core processor library

### DIFF
--- a/internal/mqttingestor/processor.go
+++ b/internal/mqttingestor/processor.go
@@ -1,0 +1,168 @@
+package mqttingestor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const DefaultSchemaVersion = "1"
+
+var (
+	ErrMalformedPayload = errors.New("malformed payload")
+	ErrInvalidPayload   = errors.New("invalid payload")
+)
+
+type Config struct {
+	ExpectedSchemaVersion string
+	StaleAfter            time.Duration
+}
+
+type TelemetryMessage struct {
+	SensorID        string  `json:"sensor_id"`
+	SchemaVersion   string  `json:"schema_version"`
+	DeviceID        string  `json:"device_id"`
+	FirmwareVersion string  `json:"firmware_version"`
+	DeviceState     string  `json:"device_state"`
+	SequenceNumber  uint64  `json:"sequence_number"`
+	TelemetryTopic  string  `json:"telemetry_topic"`
+	Temperature     float64 `json:"temperature"`
+	Voltage         float64 `json:"voltage"`
+	Current         float64 `json:"current"`
+	PowerUsage      float64 `json:"power_usage"`
+	RSSI            float64 `json:"rssi"`
+	SNR             float64 `json:"snr"`
+	PacketLoss      float64 `json:"packet_loss_percent"`
+	FreeHeap        uint64  `json:"free_heap"`
+	LoopTimeMS      float64 `json:"loop_time_ms"`
+	UptimeSeconds   int64   `json:"uptime_seconds"`
+	RebootReason    string  `json:"reboot_reason"`
+	Timestamp       string  `json:"timestamp"`
+}
+
+type Analysis struct {
+	Message       TelemetryMessage
+	ReceivedAt    time.Time
+	DeviceTime    time.Time
+	MessageAge    time.Duration
+	IsStale       bool
+	IsDuplicate   bool
+	IsReboot      bool
+	SequenceGap   uint64
+	PreviousFound bool
+}
+
+type deviceState struct {
+	SequenceNumber uint64
+	UptimeSeconds  int64
+	RebootReason   string
+}
+
+type Processor struct {
+	expectedSchemaVersion string
+	staleAfter            time.Duration
+
+	mu      sync.Mutex
+	devices map[string]deviceState
+}
+
+func NewProcessor(cfg Config) *Processor {
+	expectedSchemaVersion := cfg.ExpectedSchemaVersion
+	if expectedSchemaVersion == "" {
+		expectedSchemaVersion = DefaultSchemaVersion
+	}
+
+	return &Processor{
+		expectedSchemaVersion: expectedSchemaVersion,
+		staleAfter:            cfg.StaleAfter,
+		devices:               make(map[string]deviceState),
+	}
+}
+
+func (p *Processor) Process(payload []byte, receivedAt time.Time) (Analysis, error) {
+	msg, deviceTime, err := p.DecodeAndValidate(payload)
+	if err != nil {
+		return Analysis{}, err
+	}
+
+	analysis := Analysis{
+		Message:    msg,
+		ReceivedAt: receivedAt,
+		DeviceTime: deviceTime,
+		MessageAge: receivedAt.Sub(deviceTime),
+	}
+
+	if p.staleAfter > 0 && analysis.MessageAge > p.staleAfter {
+		analysis.IsStale = true
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	previous, ok := p.devices[msg.DeviceID]
+	analysis.PreviousFound = ok
+
+	if ok {
+		switch {
+		case msg.SequenceNumber == previous.SequenceNumber:
+			analysis.IsDuplicate = true
+		case msg.SequenceNumber > previous.SequenceNumber+1:
+			analysis.SequenceGap = msg.SequenceNumber - previous.SequenceNumber - 1
+		case msg.SequenceNumber < previous.SequenceNumber && rebootEvidence(msg, previous):
+			analysis.IsReboot = true
+		case msg.SequenceNumber < previous.SequenceNumber:
+			analysis.IsDuplicate = true
+		}
+	}
+
+	p.devices[msg.DeviceID] = deviceState{
+		SequenceNumber: msg.SequenceNumber,
+		UptimeSeconds:  msg.UptimeSeconds,
+		RebootReason:   msg.RebootReason,
+	}
+
+	return analysis, nil
+}
+
+func (p *Processor) DecodeAndValidate(payload []byte) (TelemetryMessage, time.Time, error) {
+	var msg TelemetryMessage
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		return TelemetryMessage{}, time.Time{}, fmt.Errorf("%w: %v", ErrMalformedPayload, err)
+	}
+
+	if err := p.validate(msg); err != nil {
+		return TelemetryMessage{}, time.Time{}, err
+	}
+
+	deviceTime, err := time.Parse(time.RFC3339, msg.Timestamp)
+	if err != nil {
+		return TelemetryMessage{}, time.Time{}, fmt.Errorf("%w: invalid timestamp: %v", ErrInvalidPayload, err)
+	}
+
+	return msg, deviceTime, nil
+}
+
+func (p *Processor) validate(msg TelemetryMessage) error {
+	switch {
+	case msg.SchemaVersion == "":
+		return fmt.Errorf("%w: missing schema_version", ErrInvalidPayload)
+	case msg.SchemaVersion != p.expectedSchemaVersion:
+		return fmt.Errorf("%w: unexpected schema_version %q", ErrInvalidPayload, msg.SchemaVersion)
+	case msg.DeviceID == "":
+		return fmt.Errorf("%w: missing device_id", ErrInvalidPayload)
+	case msg.DeviceState == "":
+		return fmt.Errorf("%w: missing device_state", ErrInvalidPayload)
+	case msg.SequenceNumber == 0:
+		return fmt.Errorf("%w: missing sequence_number", ErrInvalidPayload)
+	case msg.Timestamp == "":
+		return fmt.Errorf("%w: missing timestamp", ErrInvalidPayload)
+	default:
+		return nil
+	}
+}
+
+func rebootEvidence(msg TelemetryMessage, previous deviceState) bool {
+	return msg.UptimeSeconds < previous.UptimeSeconds || msg.RebootReason != previous.RebootReason
+}

--- a/internal/mqttingestor/processor_test.go
+++ b/internal/mqttingestor/processor_test.go
@@ -1,0 +1,215 @@
+package mqttingestor
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProcessorProcess(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		processor *Processor
+		payloads  []string
+		received  []time.Time
+		check     func(t *testing.T, analyses []Analysis, err error)
+	}{
+		{
+			name:      "valid payload computes message age",
+			processor: NewProcessor(Config{StaleAfter: 5 * time.Minute}),
+			payloads: []string{
+				payloadJSON("device-1", 1, "running", "power_on", 120, now.Add(-30*time.Second)),
+			},
+			received: []time.Time{now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if len(analyses) != 1 {
+					t.Fatalf("expected one analysis, got %d", len(analyses))
+				}
+				got := analyses[0]
+				if got.Message.DeviceID != "device-1" {
+					t.Fatalf("expected device_id device-1, got %q", got.Message.DeviceID)
+				}
+				if got.MessageAge != 30*time.Second {
+					t.Fatalf("expected message age 30s, got %s", got.MessageAge)
+				}
+				if got.IsStale {
+					t.Fatal("expected message not to be stale")
+				}
+			},
+		},
+		{
+			name:      "malformed payload returns malformed error",
+			processor: NewProcessor(Config{}),
+			payloads:  []string{`{"device_id":`},
+			received:  []time.Time{now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err == nil {
+					t.Fatal("expected malformed payload error")
+				}
+				if !errors.Is(err, ErrMalformedPayload) {
+					t.Fatalf("expected ErrMalformedPayload, got %v", err)
+				}
+				if len(analyses) != 0 {
+					t.Fatalf("expected no analyses, got %d", len(analyses))
+				}
+			},
+		},
+		{
+			name:      "invalid schema returns invalid error",
+			processor: NewProcessor(Config{}),
+			payloads: []string{
+				payloadWithSchema("device-1", 1, "2", "running", "power_on", 100, now),
+			},
+			received: []time.Time{now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err == nil {
+					t.Fatal("expected invalid payload error")
+				}
+				if !errors.Is(err, ErrInvalidPayload) {
+					t.Fatalf("expected ErrInvalidPayload, got %v", err)
+				}
+				if !strings.Contains(err.Error(), "schema_version") {
+					t.Fatalf("expected schema_version error, got %v", err)
+				}
+			},
+		},
+		{
+			name:      "sequence gap is detected",
+			processor: NewProcessor(Config{}),
+			payloads: []string{
+				payloadJSON("device-1", 1, "running", "power_on", 120, now.Add(-2*time.Second)),
+				payloadJSON("device-1", 4, "running", "power_on", 123, now.Add(-1*time.Second)),
+			},
+			received: []time.Time{now, now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if analyses[1].SequenceGap != 2 {
+					t.Fatalf("expected sequence gap 2, got %d", analyses[1].SequenceGap)
+				}
+				if analyses[1].IsDuplicate {
+					t.Fatal("did not expect duplicate flag")
+				}
+			},
+		},
+		{
+			name:      "duplicate sequence is detected",
+			processor: NewProcessor(Config{}),
+			payloads: []string{
+				payloadJSON("device-1", 5, "running", "power_on", 120, now.Add(-2*time.Second)),
+				payloadJSON("device-1", 5, "running", "power_on", 121, now.Add(-1*time.Second)),
+			},
+			received: []time.Time{now, now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if !analyses[1].IsDuplicate {
+					t.Fatal("expected duplicate flag")
+				}
+				if analyses[1].IsReboot {
+					t.Fatal("did not expect reboot flag")
+				}
+			},
+		},
+		{
+			name:      "stale timestamp is detected",
+			processor: NewProcessor(Config{StaleAfter: 2 * time.Minute}),
+			payloads: []string{
+				payloadJSON("device-1", 1, "running", "power_on", 120, now.Add(-3*time.Minute)),
+			},
+			received: []time.Time{now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if !analyses[0].IsStale {
+					t.Fatal("expected stale flag")
+				}
+			},
+		},
+		{
+			name:      "sequence reset with lower uptime is treated as reboot",
+			processor: NewProcessor(Config{}),
+			payloads: []string{
+				payloadJSON("device-1", 9, "running", "power_on", 900, now.Add(-4*time.Second)),
+				payloadJSON("device-1", 1, "rebooting", "brownout", 2, now.Add(-1*time.Second)),
+			},
+			received: []time.Time{now, now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if !analyses[1].IsReboot {
+					t.Fatal("expected reboot flag")
+				}
+				if analyses[1].IsDuplicate {
+					t.Fatal("did not expect duplicate flag")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				analyses []Analysis
+				err      error
+			)
+
+			for i, payload := range tt.payloads {
+				var analysis Analysis
+				analysis, err = tt.processor.Process([]byte(payload), tt.received[i])
+				if err != nil {
+					break
+				}
+				analyses = append(analyses, analysis)
+			}
+
+			tt.check(t, analyses, err)
+		})
+	}
+}
+
+func payloadJSON(deviceID string, sequence uint64, state, rebootReason string, uptime int64, ts time.Time) string {
+	return payloadWithSchema(deviceID, sequence, DefaultSchemaVersion, state, rebootReason, uptime, ts)
+}
+
+func payloadWithSchema(deviceID string, sequence uint64, schemaVersion, state, rebootReason string, uptime int64, ts time.Time) string {
+	return fmt.Sprintf(`{
+		"sensor_id":"sensor-1",
+		"schema_version":"%s",
+		"device_id":"%s",
+		"firmware_version":"learning-lab-0.1.0",
+		"device_state":"%s",
+		"sequence_number":%d,
+		"telemetry_topic":"sensors/thermal",
+		"temperature":23.7,
+		"voltage":3.71,
+		"current":0.12,
+		"power_usage":0.45,
+		"rssi":-66,
+		"snr":18.4,
+		"packet_loss_percent":1.2,
+		"free_heap":184320,
+		"loop_time_ms":8.5,
+		"uptime_seconds":%d,
+		"reboot_reason":"%s",
+		"timestamp":"%s"
+	}`, schemaVersion, deviceID, state, sequence, uptime, rebootReason, ts.Format(time.RFC3339))
+}


### PR DESCRIPTION
### Summary
This change adds the core MQTT ingestor processing library that validates sensor
telemetry and interprets device behavior before any runtime wiring is added. It
creates a reusable middle layer for detecting stale messages, sequence gaps,
duplicates, and reboot resets without coupling those rules to MQTT transport,
Grafana output, or database storage.

### List of Changes
- Added a standalone `internal/mqttingestor` processor that decodes telemetry
  payloads, validates the contract, computes message age, and tracks per-device
  sequence state
- Improved future integration safety by covering duplicate, gap, stale-message,
  malformed-payload, and reboot-reset cases with focused table-driven tests

### Verification
- [x] `CCACHE_DISABLE=1 GOCACHE=/tmp/go-build-cache go test ./internal/mqttingestor`
- [x] Review that `internal/mqttingestor` stays limited to processing logic with
  no MQTT runtime, metrics, or database wiring

