### PR TITLE
feat(mqtt-ingestor): add service runtime

### DIFF
--- a/cmd/mqtt-ingestor/main.go
+++ b/cmd/mqtt-ingestor/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"observability-hub/internal/env"
+	"observability-hub/internal/mqttingestor"
+	"observability-hub/internal/telemetry"
+)
+
+const serviceName = "mqtt-ingestor"
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	env.Load()
+
+	shutdown, err := telemetry.Init(ctx, serviceName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize telemetry: %v\n", err)
+		os.Exit(1)
+	}
+	defer shutdown()
+
+	staleAfter, err := staleAfterFromEnv()
+	if err != nil {
+		telemetry.Error("mqtt_ingestor_invalid_stale_after", "error", err)
+		os.Exit(1)
+	}
+
+	runtime, err := mqttingestor.NewRuntime(mqttingestor.RuntimeConfig{
+		BrokerURL:             os.Getenv("MQTT_BROKER"),
+		ClientID:              os.Getenv("MQTT_CLIENT_ID"),
+		ExpectedSchemaVersion: os.Getenv("MQTT_SCHEMA_VERSION"),
+		StaleAfter:            staleAfter,
+	})
+	if err != nil {
+		telemetry.Error("mqtt_ingestor_init_failed", "error", err)
+		os.Exit(1)
+	}
+
+	if err := runtime.Run(ctx); err != nil {
+		telemetry.Error("mqtt_ingestor_run_failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func staleAfterFromEnv() (time.Duration, error) {
+	raw := os.Getenv("MQTT_STALE_AFTER")
+	if raw == "" {
+		return 0, nil
+	}
+
+	duration, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse MQTT_STALE_AFTER: %w", err)
+	}
+
+	return duration, nil
+}

--- a/internal/mqttingestor/processor.go
+++ b/internal/mqttingestor/processor.go
@@ -43,21 +43,24 @@ type TelemetryMessage struct {
 }
 
 type Analysis struct {
-	Message       TelemetryMessage
-	ReceivedAt    time.Time
-	DeviceTime    time.Time
-	MessageAge    time.Duration
-	IsStale       bool
-	IsDuplicate   bool
-	IsReboot      bool
-	SequenceGap   uint64
-	PreviousFound bool
+	Message             TelemetryMessage
+	ReceivedAt          time.Time
+	DeviceTime          time.Time
+	MessageAge          time.Duration
+	IsStale             bool
+	IsDuplicate         bool
+	IsReboot            bool
+	StateChanged        bool
+	SequenceGap         uint64
+	PreviousFound       bool
+	PreviousDeviceState string
 }
 
 type deviceState struct {
 	SequenceNumber uint64
 	UptimeSeconds  int64
 	RebootReason   string
+	DeviceState    string
 }
 
 type Processor struct {
@@ -105,6 +108,9 @@ func (p *Processor) Process(payload []byte, receivedAt time.Time) (Analysis, err
 	analysis.PreviousFound = ok
 
 	if ok {
+		analysis.PreviousDeviceState = previous.DeviceState
+		analysis.StateChanged = previous.DeviceState != "" && msg.DeviceState != previous.DeviceState
+
 		switch {
 		case msg.SequenceNumber == previous.SequenceNumber:
 			analysis.IsDuplicate = true
@@ -121,6 +127,7 @@ func (p *Processor) Process(payload []byte, receivedAt time.Time) (Analysis, err
 		SequenceNumber: msg.SequenceNumber,
 		UptimeSeconds:  msg.UptimeSeconds,
 		RebootReason:   msg.RebootReason,
+		DeviceState:    msg.DeviceState,
 	}
 
 	return analysis, nil

--- a/internal/mqttingestor/processor_test.go
+++ b/internal/mqttingestor/processor_test.go
@@ -163,6 +163,27 @@ func TestProcessorProcess(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:      "device state changes are detected",
+			processor: NewProcessor(Config{}),
+			payloads: []string{
+				payloadJSON("device-1", 1, "running", "power_on", 100, now.Add(-2*time.Second)),
+				payloadJSON("device-1", 2, "degraded", "power_on", 101, now.Add(-1*time.Second)),
+			},
+			received: []time.Time{now, now},
+			check: func(t *testing.T, analyses []Analysis, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if !analyses[1].StateChanged {
+					t.Fatal("expected state change flag")
+				}
+				if analyses[1].PreviousDeviceState != "running" {
+					t.Fatalf("expected previous state running, got %q", analyses[1].PreviousDeviceState)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/mqttingestor/runtime.go
+++ b/internal/mqttingestor/runtime.go
@@ -1,0 +1,324 @@
+package mqttingestor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"observability-hub/internal/telemetry"
+)
+
+const (
+	DefaultBrokerURL         = "tcp://emqx.observability:1883"
+	DefaultClientID          = "mqtt-ingestor"
+	DefaultStaleAfter        = 30 * time.Second
+	defaultMetricDescription = "Synthetic hardware telemetry signal"
+)
+
+var DefaultTopics = []string{
+	"devices/+/telemetry",
+	"sensors/thermal",
+}
+
+type client interface {
+	Connect() mqtt.Token
+	Disconnect(quiesce uint)
+	SubscribeMultiple(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token
+}
+
+type RuntimeConfig struct {
+	BrokerURL             string
+	ClientID              string
+	ExpectedSchemaVersion string
+	StaleAfter            time.Duration
+	Topics                []string
+}
+
+type Runtime struct {
+	config    RuntimeConfig
+	processor *Processor
+	metrics   runtimeMetrics
+	newClient func(*mqtt.ClientOptions) client
+	now       func() time.Time
+}
+
+type runtimeMetrics struct {
+	messagesTotal        telemetry.Int64Counter
+	invalidMessagesTotal telemetry.Int64Counter
+	sequenceGapTotal     telemetry.Int64Counter
+	duplicatesTotal      telemetry.Int64Counter
+	messageAge           telemetry.Int64Histogram
+	rebootTotal          telemetry.Int64Counter
+}
+
+type messageEvent struct {
+	name  string
+	attrs []any
+}
+
+type messageResult struct {
+	analysis Analysis
+	invalid  bool
+	err      error
+	events   []messageEvent
+}
+
+func NewRuntime(cfg RuntimeConfig) (*Runtime, error) {
+	cfg = cfg.withDefaults()
+
+	metrics, err := newRuntimeMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Runtime{
+		config:    cfg,
+		processor: NewProcessor(Config{ExpectedSchemaVersion: cfg.ExpectedSchemaVersion, StaleAfter: cfg.StaleAfter}),
+		metrics:   metrics,
+		newClient: func(opts *mqtt.ClientOptions) client { return mqtt.NewClient(opts) },
+		now:       time.Now,
+	}, nil
+}
+
+func (r *Runtime) Run(ctx context.Context) error {
+	opts := mqtt.NewClientOptions().AddBroker(r.config.BrokerURL)
+	opts.SetClientID(r.config.ClientID)
+	opts.SetCleanSession(true)
+	opts.SetConnectTimeout(10 * time.Second)
+	opts.SetKeepAlive(30 * time.Second)
+	opts.SetPingTimeout(5 * time.Second)
+	opts.SetAutoReconnect(true)
+	opts.SetOnConnectHandler(func(c mqtt.Client) {
+		r.subscribe(c)
+	})
+	opts.SetConnectionLostHandler(func(_ mqtt.Client, err error) {
+		telemetry.Warn("mqtt_connection_lost", "error", err)
+	})
+
+	mqttClient := r.newClient(opts)
+	token := mqttClient.Connect()
+	if token.Wait() && token.Error() != nil {
+		return fmt.Errorf("connect mqtt client: %w", token.Error())
+	}
+	defer mqttClient.Disconnect(250)
+
+	r.subscribe(mqttClient)
+
+	telemetry.Info("mqtt_ingestor_started", "broker", r.config.BrokerURL, "topics", r.config.Topics)
+
+	<-ctx.Done()
+	telemetry.Info("mqtt_ingestor_stopped", "reason", ctx.Err())
+	return nil
+}
+
+func (r *Runtime) subscribe(c client) {
+	token := c.SubscribeMultiple(r.subscriptionFilters(), r.handleMQTTMessage)
+	if token.Wait() && token.Error() != nil {
+		telemetry.Error("mqtt_subscription_failed", "error", token.Error())
+		return
+	}
+	telemetry.Info("mqtt_subscription_established", "topics", r.config.Topics)
+}
+
+func (r *Runtime) evaluateMessage(topic string, payload []byte, receivedAt time.Time) messageResult {
+	analysis, err := r.processor.Process(payload, receivedAt)
+	if err != nil {
+		if errors.Is(err, ErrMalformedPayload) || errors.Is(err, ErrInvalidPayload) {
+			return messageResult{
+				invalid: true,
+				err:     err,
+				events: []messageEvent{{
+					name: "mqtt_payload_invalid",
+					attrs: []any{
+						"topic", topic,
+						"error", err.Error(),
+					},
+				}},
+			}
+		}
+
+		return messageResult{err: err}
+	}
+
+	result := messageResult{
+		analysis: analysis,
+		events: []messageEvent{{
+			name: "mqtt_message_received",
+			attrs: []any{
+				"topic", topic,
+				"device_id", analysis.Message.DeviceID,
+				"device_state", analysis.Message.DeviceState,
+				"sequence_number", analysis.Message.SequenceNumber,
+			},
+		}},
+	}
+
+	if analysis.SequenceGap > 0 {
+		result.events = append(result.events, messageEvent{
+			name: "mqtt_sequence_gap_detected",
+			attrs: []any{
+				"topic", topic,
+				"device_id", analysis.Message.DeviceID,
+				"sequence_gap", analysis.SequenceGap,
+				"sequence_number", analysis.Message.SequenceNumber,
+			},
+		})
+	}
+
+	if analysis.IsDuplicate {
+		result.events = append(result.events, messageEvent{
+			name: "mqtt_duplicate_sequence_detected",
+			attrs: []any{
+				"topic", topic,
+				"device_id", analysis.Message.DeviceID,
+				"sequence_number", analysis.Message.SequenceNumber,
+			},
+		})
+	}
+
+	if analysis.IsReboot {
+		result.events = append(result.events, messageEvent{
+			name: "device_reboot_detected",
+			attrs: []any{
+				"topic", topic,
+				"device_id", analysis.Message.DeviceID,
+				"reboot_reason", analysis.Message.RebootReason,
+			},
+		})
+	}
+
+	if analysis.StateChanged {
+		result.events = append(result.events, messageEvent{
+			name: "device_state_changed",
+			attrs: []any{
+				"topic", topic,
+				"device_id", analysis.Message.DeviceID,
+				"previous_state", analysis.PreviousDeviceState,
+				"device_state", analysis.Message.DeviceState,
+			},
+		})
+	}
+
+	if analysis.IsStale {
+		result.events = append(result.events, messageEvent{
+			name: "device_message_stale",
+			attrs: []any{
+				"topic", topic,
+				"device_id", analysis.Message.DeviceID,
+				"message_age_ms", analysis.MessageAge.Milliseconds(),
+			},
+		})
+	}
+
+	return result
+}
+
+func (r *Runtime) recordResult(ctx context.Context, result messageResult) {
+	if result.err != nil && !result.invalid {
+		telemetry.Error("mqtt_message_processing_failed", "error", result.err)
+		return
+	}
+
+	for _, event := range result.events {
+		if event.name == "mqtt_payload_invalid" {
+			telemetry.Warn(event.name, event.attrs...)
+			continue
+		}
+		telemetry.Info(event.name, event.attrs...)
+	}
+
+	if result.invalid {
+		telemetry.AddInt64Counter(ctx, r.metrics.invalidMessagesTotal, 1)
+		return
+	}
+
+	analysis := result.analysis
+	commonAttrs := []telemetry.Attribute{
+		telemetry.StringAttribute("device_id", analysis.Message.DeviceID),
+		telemetry.StringAttribute("device_state", analysis.Message.DeviceState),
+		telemetry.StringAttribute("topic", analysis.Message.TelemetryTopic),
+	}
+
+	telemetry.AddInt64Counter(ctx, r.metrics.messagesTotal, 1, commonAttrs...)
+	telemetry.RecordInt64Histogram(ctx, r.metrics.messageAge, analysis.MessageAge.Milliseconds(), commonAttrs...)
+
+	if analysis.SequenceGap > 0 {
+		telemetry.AddInt64Counter(ctx, r.metrics.sequenceGapTotal, int64(analysis.SequenceGap), commonAttrs...)
+	}
+	if analysis.IsDuplicate {
+		telemetry.AddInt64Counter(ctx, r.metrics.duplicatesTotal, 1, commonAttrs...)
+	}
+	if analysis.IsReboot {
+		telemetry.AddInt64Counter(ctx, r.metrics.rebootTotal, 1, commonAttrs...)
+	}
+}
+
+func (r *Runtime) handleMQTTMessage(_ mqtt.Client, msg mqtt.Message) {
+	result := r.evaluateMessage(msg.Topic(), msg.Payload(), r.now().UTC())
+	r.recordResult(context.Background(), result)
+}
+
+func (r *Runtime) subscriptionFilters() map[string]byte {
+	filters := make(map[string]byte, len(r.config.Topics))
+	for _, topic := range r.config.Topics {
+		filters[topic] = 1
+	}
+	return filters
+}
+
+func (cfg RuntimeConfig) withDefaults() RuntimeConfig {
+	if cfg.BrokerURL == "" {
+		cfg.BrokerURL = DefaultBrokerURL
+	}
+	if cfg.ClientID == "" {
+		cfg.ClientID = DefaultClientID
+	}
+	if cfg.StaleAfter <= 0 {
+		cfg.StaleAfter = DefaultStaleAfter
+	}
+	if len(cfg.Topics) == 0 {
+		cfg.Topics = append([]string(nil), DefaultTopics...)
+	}
+	return cfg
+}
+
+func newRuntimeMetrics() (runtimeMetrics, error) {
+	meter := telemetry.GetMeter("mqtt-ingestor.runtime")
+
+	messagesTotal, err := telemetry.NewInt64Counter(meter, "hardware.telemetry.messages.total", defaultMetricDescription)
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create messages counter: %w", err)
+	}
+	invalidMessagesTotal, err := telemetry.NewInt64Counter(meter, "hardware.telemetry.invalid_messages.total", defaultMetricDescription)
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create invalid messages counter: %w", err)
+	}
+	sequenceGapTotal, err := telemetry.NewInt64Counter(meter, "hardware.telemetry.sequence_gap.total", defaultMetricDescription)
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create sequence gap counter: %w", err)
+	}
+	duplicatesTotal, err := telemetry.NewInt64Counter(meter, "hardware.telemetry.duplicates.total", defaultMetricDescription)
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create duplicates counter: %w", err)
+	}
+	messageAge, err := telemetry.NewInt64Histogram(meter, "hardware.telemetry.message_age", defaultMetricDescription, "ms")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create message age histogram: %w", err)
+	}
+	rebootTotal, err := telemetry.NewInt64Counter(meter, "hardware.reboot.total", defaultMetricDescription)
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create reboot counter: %w", err)
+	}
+
+	return runtimeMetrics{
+		messagesTotal:        messagesTotal,
+		invalidMessagesTotal: invalidMessagesTotal,
+		sequenceGapTotal:     sequenceGapTotal,
+		duplicatesTotal:      duplicatesTotal,
+		messageAge:           messageAge,
+		rebootTotal:          rebootTotal,
+	}, nil
+}

--- a/internal/mqttingestor/runtime_test.go
+++ b/internal/mqttingestor/runtime_test.go
@@ -1,0 +1,143 @@
+package mqttingestor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"observability-hub/internal/telemetry"
+)
+
+type fakeMQTTToken struct {
+	err error
+}
+
+func (t *fakeMQTTToken) Wait() bool                     { return true }
+func (t *fakeMQTTToken) WaitTimeout(time.Duration) bool { return true }
+func (t *fakeMQTTToken) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+func (t *fakeMQTTToken) Error() error { return t.err }
+
+type fakeRuntimeClient struct {
+	subscriptions map[string]byte
+	handler       mqtt.MessageHandler
+	connectErr    error
+}
+
+func (c *fakeRuntimeClient) Connect() mqtt.Token { return &fakeMQTTToken{err: c.connectErr} }
+func (c *fakeRuntimeClient) Disconnect(uint)     {}
+func (c *fakeRuntimeClient) SubscribeMultiple(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token {
+	c.subscriptions = filters
+	c.handler = callback
+	return &fakeMQTTToken{}
+}
+
+func TestRuntimeConfigDefaults(t *testing.T) {
+	telemetry.SilenceLogs()
+
+	runtime, err := NewRuntime(RuntimeConfig{})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+
+	if runtime.config.BrokerURL != DefaultBrokerURL {
+		t.Fatalf("expected default broker %q, got %q", DefaultBrokerURL, runtime.config.BrokerURL)
+	}
+	if runtime.config.ClientID != DefaultClientID {
+		t.Fatalf("expected default client ID %q, got %q", DefaultClientID, runtime.config.ClientID)
+	}
+	if runtime.config.StaleAfter != DefaultStaleAfter {
+		t.Fatalf("expected default stale threshold %s, got %s", DefaultStaleAfter, runtime.config.StaleAfter)
+	}
+	if len(runtime.config.Topics) != 2 {
+		t.Fatalf("expected two default topics, got %d", len(runtime.config.Topics))
+	}
+}
+
+func TestRuntimeEvaluateMessage(t *testing.T) {
+	telemetry.SilenceLogs()
+
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	runtime, err := NewRuntime(RuntimeConfig{StaleAfter: 2 * time.Minute})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+
+	first := runtime.evaluateMessage("devices/device-1/telemetry", []byte(payloadJSON("device-1", 1, "running", "power_on", 100, now.Add(-30*time.Second))), now)
+	second := runtime.evaluateMessage("devices/device-1/telemetry", []byte(payloadJSON("device-1", 4, "degraded", "power_on", 101, now.Add(-10*time.Second))), now)
+	invalid := runtime.evaluateMessage("devices/device-1/telemetry", []byte(`{"device_id":`), now)
+
+	if first.err != nil {
+		t.Fatalf("expected first message to succeed, got %v", first.err)
+	}
+	if first.events[0].name != "mqtt_message_received" {
+		t.Fatalf("expected mqtt_message_received, got %q", first.events[0].name)
+	}
+	if second.err != nil {
+		t.Fatalf("expected second message to succeed, got %v", second.err)
+	}
+	names := eventNames(second.events)
+	assertContainsEvent(t, names, "mqtt_message_received")
+	assertContainsEvent(t, names, "mqtt_sequence_gap_detected")
+	assertContainsEvent(t, names, "device_state_changed")
+
+	if !invalid.invalid {
+		t.Fatal("expected invalid payload classification")
+	}
+	if !errors.Is(invalid.err, ErrMalformedPayload) {
+		t.Fatalf("expected malformed payload error, got %v", invalid.err)
+	}
+	assertContainsEvent(t, eventNames(invalid.events), "mqtt_payload_invalid")
+}
+
+func TestRuntimeRunSubscribesToBothTopics(t *testing.T) {
+	telemetry.SilenceLogs()
+
+	runtime, err := NewRuntime(RuntimeConfig{})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+
+	fakeClient := &fakeRuntimeClient{}
+	runtime.newClient = func(*mqtt.ClientOptions) client { return fakeClient }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := runtime.Run(ctx); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if len(fakeClient.subscriptions) != len(DefaultTopics) {
+		t.Fatalf("expected %d subscriptions, got %d", len(DefaultTopics), len(fakeClient.subscriptions))
+	}
+	for _, topic := range DefaultTopics {
+		if _, ok := fakeClient.subscriptions[topic]; !ok {
+			t.Fatalf("expected subscription to %q", topic)
+		}
+	}
+}
+
+func eventNames(events []messageEvent) []string {
+	names := make([]string, 0, len(events))
+	for _, event := range events {
+		names = append(names, event.name)
+	}
+	return names
+}
+
+func assertContainsEvent(t *testing.T, names []string, want string) {
+	t.Helper()
+	for _, name := range names {
+		if name == want {
+			return
+		}
+	}
+	t.Fatalf("expected event %q in %v", want, names)
+}

--- a/k3s/overlays/prod/kustomization.yaml
+++ b/k3s/overlays/prod/kustomization.yaml
@@ -7,9 +7,9 @@ resources:
 
 images:
   - name: ghcr.io/victoriacheng15/observability-hub/chaos-controller
-    newTag: sha-c67f457
+    newTag: sha-428eb8b
   - name: ghcr.io/victoriacheng15/observability-hub/sensor
-    newTag: sha-c67f457
+    newTag: sha-428eb8b
 
 patches:
   # --- Simulation Fleet (hardware-sim) ---


### PR DESCRIPTION
### Summary
This change adds the MQTT ingestor runtime that subscribes to the synthetic
sensor telemetry topics, sends payloads through the existing processor, and
emits the first logs and metrics needed for monitoring. It also updates the
prod hardware-sim image tags to the latest sensor and chaos-controller build.

### List of Changes
- Added the first runnable MQTT ingestor service so synthetic device telemetry
  can be consumed and turned into monitoring signals.
- Improved rollout and review safety by keeping the change scoped to runtime
  behavior and updating the prod overlay to the latest hardware-sim images.

### Verification
- [x] `CCACHE_DISABLE=1 GOCACHE=/tmp/go-build-cache go test ./internal/mqttingestor ./cmd/mqtt-ingestor`
- [x] `kubectl kustomize k3s/overlays/prod`

