### PR TITLE
feat(mqtt-ingestor): deploy service workload

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,6 +52,14 @@ jobs:
               - "docker/chaos-controller/**"
               - "go.mod"
               - "go.sum"
+            mqtt-ingestor:
+              - "cmd/mqtt-ingestor/**"
+              - "internal/env/**"
+              - "internal/mqttingestor/**"
+              - "internal/telemetry/**"
+              - "docker/mqtt-ingestor/**"
+              - "go.mod"
+              - "go.sum"
             postgres-cnpg:
               - "docker/postgres-cnpg/**"
             worker:
@@ -72,7 +80,7 @@ jobs:
           CHANGED_SERVICES: ${{ steps.filter.outputs.changes }}
         run: |
           if [ "$FULL_BUILD" = "true" ]; then
-            echo 'services=["sensor","chaos-controller","postgres-cnpg","worker"]' >> "$GITHUB_OUTPUT"
+            echo 'services=["sensor","chaos-controller","mqtt-ingestor","postgres-cnpg","worker"]' >> "$GITHUB_OUTPUT"
           else
             echo "services=${CHANGED_SERVICES:-[]}" >> "$GITHUB_OUTPUT"
           fi

--- a/docker/mqtt-ingestor/Dockerfile
+++ b/docker/mqtt-ingestor/Dockerfile
@@ -1,0 +1,31 @@
+# Stage 1: Build
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /app
+
+# Copy root module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY cmd/mqtt-ingestor/ cmd/mqtt-ingestor/
+COPY internal/env/ internal/env/
+COPY internal/mqttingestor/ internal/mqttingestor/
+COPY internal/telemetry/ internal/telemetry/
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build -o mqtt-ingestor ./cmd/mqtt-ingestor
+
+# Stage 2: Runtime
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates \
+    && addgroup -S app -g 1000 \
+    && adduser -S app -G app -u 1000
+
+WORKDIR /app
+COPY --from=builder /app/mqtt-ingestor .
+
+USER 1000:1000
+
+ENTRYPOINT ["./mqtt-ingestor"]

--- a/k3s/base/hardware-sim/kustomization.yaml
+++ b/k3s/base/hardware-sim/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
   - chaos-controller.yaml
+  - mqtt-ingestor.yaml
   - sensor-fleet.yaml

--- a/k3s/base/hardware-sim/mqtt-ingestor.yaml
+++ b/k3s/base/hardware-sim/mqtt-ingestor.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mqtt-ingestor
+  namespace: hardware-sim
+  labels:
+    app: mqtt-ingestor
+    feature: simulation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mqtt-ingestor
+  template:
+    metadata:
+      labels:
+        app: mqtt-ingestor
+    spec:
+      serviceAccountName: hw-mqtt-ingestor
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      imagePullSecrets:
+        - name: ghcr-auth
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - mqtt-ingestor
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: mqtt-ingestor
+        image: ghcr.io/victoriacheng15/observability-hub/mqtt-ingestor
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          capabilities:
+            drop:
+            - ALL
+        env:
+        - name: MQTT_BROKER
+          value: "tcp://emqx.observability.svc.cluster.local:1883"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "opentelemetry.observability.svc.cluster.local:4317"
+        resources:
+          requests:
+            cpu: "20m"
+            memory: "128Mi"
+          limits:
+            cpu: "100m"
+            memory: "256Mi"

--- a/k3s/base/rbac/serviceaccounts.yaml
+++ b/k3s/base/rbac/serviceaccounts.yaml
@@ -13,3 +13,10 @@ metadata:
   name: hw-sensor
   namespace: hardware-sim
 automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hw-mqtt-ingestor
+  namespace: hardware-sim
+automountServiceAccountToken: false

--- a/k3s/overlays/dev/kustomization.yaml
+++ b/k3s/overlays/dev/kustomization.yaml
@@ -8,13 +8,16 @@ resources:
 images:
   - name: ghcr.io/victoriacheng15/observability-hub/chaos-controller
     newTag: canary
+  - name: ghcr.io/victoriacheng15/observability-hub/mqtt-ingestor
+    newTag: canary
   - name: ghcr.io/victoriacheng15/observability-hub/sensor
     newTag: canary
 
 patches:
   # --- Simulation Fleet (dev-hardware-sim) ---
   - target:
-      labelSelector: "feature=simulation"
+      kind: Deployment
+      name: chaos-controller
     patch: |-
       - op: replace
         path: /metadata/namespace
@@ -30,8 +33,14 @@ patches:
       name: sensor-fleet
     patch: |-
       - op: replace
+        path: /metadata/namespace
+        value: dev-hardware-sim
+      - op: replace
         path: /spec/replicas
         value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: "dev-hardware-sim"
       - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: Always
@@ -39,6 +48,16 @@ patches:
       kind: Deployment
       name: chaos-controller
     patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Always
+  - target:
+      kind: Deployment
+      name: mqtt-ingestor
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: dev-hardware-sim
       - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: Always

--- a/k3s/overlays/prod/kustomization.yaml
+++ b/k3s/overlays/prod/kustomization.yaml
@@ -8,13 +8,16 @@ resources:
 images:
   - name: ghcr.io/victoriacheng15/observability-hub/chaos-controller
     newTag: sha-428eb8b
+  - name: ghcr.io/victoriacheng15/observability-hub/mqtt-ingestor
+    newTag: canary
   - name: ghcr.io/victoriacheng15/observability-hub/sensor
     newTag: sha-428eb8b
 
 patches:
   # --- Simulation Fleet (hardware-sim) ---
   - target:
-      labelSelector: "feature=simulation"
+      kind: Deployment
+      name: chaos-controller
     patch: |-
       - op: replace
         path: /metadata/namespace
@@ -30,8 +33,14 @@ patches:
       name: sensor-fleet
     patch: |-
       - op: replace
+        path: /metadata/namespace
+        value: hardware-sim
+      - op: replace
         path: /spec/replicas
         value: 3
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: "hardware-sim"
   - target:
       kind: Service
       name: sensor-fleet


### PR DESCRIPTION
### Summary
This change deploys the MQTT ingestor as a reconciled hardware-sim workload so
the runtime added in the previous PR can actually run in the cluster. It also
extends the image build and overlay wiring needed to promote the service
through dev and prod without breaking the existing simulation workloads.

### List of Changes
- Added the deployment path for `mqtt-ingestor`, including container build,
  Kubernetes workload wiring, and an explicit service account for the new pod.
- Improved rollout safety by updating the image build workflow and narrowing
  overlay patches so the new workload inherits the right namespace and env
  settings without mutating unrelated containers.

### Verification
- [x] `kubectl kustomize k3s/base/hardware-sim`

