### PR TITLE
feat(mqtt-ingestor): publish sensor value metrics

### DIFF
--- a/cmd/mqtt-ingestor/main.go
+++ b/cmd/mqtt-ingestor/main.go
@@ -37,6 +37,7 @@ func main() {
 	runtime, err := mqttingestor.NewRuntime(mqttingestor.RuntimeConfig{
 		BrokerURL:             os.Getenv("MQTT_BROKER"),
 		ClientID:              os.Getenv("MQTT_CLIENT_ID"),
+		Environment:           os.Getenv("SIMULATION_ENV"),
 		ExpectedSchemaVersion: os.Getenv("MQTT_SCHEMA_VERSION"),
 		StaleAfter:            staleAfter,
 	})

--- a/internal/mqttingestor/runtime.go
+++ b/internal/mqttingestor/runtime.go
@@ -32,6 +32,7 @@ type client interface {
 type RuntimeConfig struct {
 	BrokerURL             string
 	ClientID              string
+	Environment           string
 	ExpectedSchemaVersion string
 	StaleAfter            time.Duration
 	Topics                []string
@@ -52,6 +53,16 @@ type runtimeMetrics struct {
 	duplicatesTotal      telemetry.Int64Counter
 	messageAge           telemetry.Int64Histogram
 	rebootTotal          telemetry.Int64Counter
+	temperature          telemetry.Float64Histogram
+	voltage              telemetry.Float64Histogram
+	current              telemetry.Float64Histogram
+	power                telemetry.Float64Histogram
+	rssi                 telemetry.Float64Histogram
+	snr                  telemetry.Float64Histogram
+	packetLoss           telemetry.Float64Histogram
+	freeHeap             telemetry.Int64Histogram
+	loopTime             telemetry.Float64Histogram
+	uptime               telemetry.Int64Histogram
 }
 
 type messageEvent struct {
@@ -231,19 +242,31 @@ func (r *Runtime) recordResult(ctx context.Context, result messageResult) {
 	}
 
 	if result.invalid {
-		telemetry.AddInt64Counter(ctx, r.metrics.invalidMessagesTotal, 1)
+		telemetry.AddInt64Counter(ctx, r.metrics.invalidMessagesTotal, 1, telemetry.StringAttribute("environment", r.config.Environment))
 		return
 	}
 
 	analysis := result.analysis
 	commonAttrs := []telemetry.Attribute{
+		telemetry.StringAttribute("environment", r.config.Environment),
 		telemetry.StringAttribute("device_id", analysis.Message.DeviceID),
+		telemetry.StringAttribute("firmware_version", analysis.Message.FirmwareVersion),
 		telemetry.StringAttribute("device_state", analysis.Message.DeviceState),
 		telemetry.StringAttribute("topic", analysis.Message.TelemetryTopic),
 	}
 
 	telemetry.AddInt64Counter(ctx, r.metrics.messagesTotal, 1, commonAttrs...)
 	telemetry.RecordInt64Histogram(ctx, r.metrics.messageAge, analysis.MessageAge.Milliseconds(), commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.temperature, analysis.Message.Temperature, commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.voltage, analysis.Message.Voltage, commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.current, analysis.Message.Current, commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.power, analysis.Message.PowerUsage, commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.rssi, analysis.Message.RSSI, commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.snr, analysis.Message.SNR, commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.packetLoss, analysis.Message.PacketLoss, commonAttrs...)
+	telemetry.RecordInt64Histogram(ctx, r.metrics.freeHeap, int64(analysis.Message.FreeHeap), commonAttrs...)
+	telemetry.RecordFloat64Histogram(ctx, r.metrics.loopTime, analysis.Message.LoopTimeMS, commonAttrs...)
+	telemetry.RecordInt64Histogram(ctx, r.metrics.uptime, analysis.Message.UptimeSeconds, append(commonAttrs, telemetry.StringAttribute("reboot_reason", analysis.Message.RebootReason))...)
 
 	if analysis.SequenceGap > 0 {
 		telemetry.AddInt64Counter(ctx, r.metrics.sequenceGapTotal, int64(analysis.SequenceGap), commonAttrs...)
@@ -275,6 +298,9 @@ func (cfg RuntimeConfig) withDefaults() RuntimeConfig {
 	}
 	if cfg.ClientID == "" {
 		cfg.ClientID = DefaultClientID
+	}
+	if cfg.Environment == "" {
+		cfg.Environment = "unknown"
 	}
 	if cfg.StaleAfter <= 0 {
 		cfg.StaleAfter = DefaultStaleAfter
@@ -312,6 +338,46 @@ func newRuntimeMetrics() (runtimeMetrics, error) {
 	if err != nil {
 		return runtimeMetrics{}, fmt.Errorf("create reboot counter: %w", err)
 	}
+	temperature, err := telemetry.NewFloat64Histogram(meter, "hardware.sensor.temperature", defaultMetricDescription, "C")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create temperature histogram: %w", err)
+	}
+	voltage, err := telemetry.NewFloat64Histogram(meter, "hardware.sensor.voltage", defaultMetricDescription, "V")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create voltage histogram: %w", err)
+	}
+	current, err := telemetry.NewFloat64Histogram(meter, "hardware.sensor.current", defaultMetricDescription, "A")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create current histogram: %w", err)
+	}
+	power, err := telemetry.NewFloat64Histogram(meter, "hardware.sensor.power", defaultMetricDescription, "W")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create power histogram: %w", err)
+	}
+	rssi, err := telemetry.NewFloat64Histogram(meter, "hardware.radio.rssi", defaultMetricDescription, "dBm")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create rssi histogram: %w", err)
+	}
+	snr, err := telemetry.NewFloat64Histogram(meter, "hardware.radio.snr", defaultMetricDescription, "dB")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create snr histogram: %w", err)
+	}
+	packetLoss, err := telemetry.NewFloat64Histogram(meter, "hardware.radio.packet_loss", defaultMetricDescription, "%")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create packet loss histogram: %w", err)
+	}
+	freeHeap, err := telemetry.NewInt64Histogram(meter, "hardware.runtime.free_heap", defaultMetricDescription, "By")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create free heap histogram: %w", err)
+	}
+	loopTime, err := telemetry.NewFloat64Histogram(meter, "hardware.runtime.loop_time", defaultMetricDescription, "ms")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create loop time histogram: %w", err)
+	}
+	uptime, err := telemetry.NewInt64Histogram(meter, "hardware.runtime.uptime", defaultMetricDescription, "s")
+	if err != nil {
+		return runtimeMetrics{}, fmt.Errorf("create uptime histogram: %w", err)
+	}
 
 	return runtimeMetrics{
 		messagesTotal:        messagesTotal,
@@ -320,5 +386,15 @@ func newRuntimeMetrics() (runtimeMetrics, error) {
 		duplicatesTotal:      duplicatesTotal,
 		messageAge:           messageAge,
 		rebootTotal:          rebootTotal,
+		temperature:          temperature,
+		voltage:              voltage,
+		current:              current,
+		power:                power,
+		rssi:                 rssi,
+		snr:                  snr,
+		packetLoss:           packetLoss,
+		freeHeap:             freeHeap,
+		loopTime:             loopTime,
+		uptime:               uptime,
 	}, nil
 }

--- a/internal/mqttingestor/runtime_test.go
+++ b/internal/mqttingestor/runtime_test.go
@@ -52,6 +52,9 @@ func TestRuntimeConfigDefaults(t *testing.T) {
 	if runtime.config.ClientID != DefaultClientID {
 		t.Fatalf("expected default client ID %q, got %q", DefaultClientID, runtime.config.ClientID)
 	}
+	if runtime.config.Environment != "unknown" {
+		t.Fatalf("expected default environment %q, got %q", "unknown", runtime.config.Environment)
+	}
 	if runtime.config.StaleAfter != DefaultStaleAfter {
 		t.Fatalf("expected default stale threshold %s, got %s", DefaultStaleAfter, runtime.config.StaleAfter)
 	}
@@ -64,7 +67,7 @@ func TestRuntimeEvaluateMessage(t *testing.T) {
 	telemetry.SilenceLogs()
 
 	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
-	runtime, err := NewRuntime(RuntimeConfig{StaleAfter: 2 * time.Minute})
+	runtime, err := NewRuntime(RuntimeConfig{StaleAfter: 2 * time.Minute, Environment: "dev"})
 	if err != nil {
 		t.Fatalf("NewRuntime failed: %v", err)
 	}
@@ -94,6 +97,19 @@ func TestRuntimeEvaluateMessage(t *testing.T) {
 		t.Fatalf("expected malformed payload error, got %v", invalid.err)
 	}
 	assertContainsEvent(t, eventNames(invalid.events), "mqtt_payload_invalid")
+}
+
+func TestRuntimeWithExplicitEnvironment(t *testing.T) {
+	telemetry.SilenceLogs()
+
+	runtime, err := NewRuntime(RuntimeConfig{Environment: "prod"})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+
+	if runtime.config.Environment != "prod" {
+		t.Fatalf("expected environment prod, got %q", runtime.config.Environment)
+	}
 }
 
 func TestRuntimeRunSubscribesToBothTopics(t *testing.T) {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -42,6 +42,18 @@ func NewInt64Histogram(meter metricapi.Meter, name, description, unit string) (m
 	return meter.Int64Histogram(name, opts...)
 }
 
+// NewFloat64Histogram creates a float64 histogram with optional description and unit.
+func NewFloat64Histogram(meter metricapi.Meter, name, description, unit string) (metricapi.Float64Histogram, error) {
+	opts := []metricapi.Float64HistogramOption{}
+	if description != "" {
+		opts = append(opts, metricapi.WithDescription(description))
+	}
+	if unit != "" {
+		opts = append(opts, metricapi.WithUnit(unit))
+	}
+	return meter.Float64Histogram(name, opts...)
+}
+
 // AddInt64Counter adds a value to an int64 counter with optional attributes.
 func AddInt64Counter(ctx context.Context, counter metricapi.Int64Counter, value int64, attrs ...Attribute) {
 	counter.Add(ctx, value, metricapi.WithAttributes(attrs...))
@@ -49,6 +61,11 @@ func AddInt64Counter(ctx context.Context, counter metricapi.Int64Counter, value 
 
 // RecordInt64Histogram records a value in an int64 histogram with optional attributes.
 func RecordInt64Histogram(ctx context.Context, histogram metricapi.Int64Histogram, value int64, attrs ...Attribute) {
+	histogram.Record(ctx, value, metricapi.WithAttributes(attrs...))
+}
+
+// RecordFloat64Histogram records a value in a float64 histogram with optional attributes.
+func RecordFloat64Histogram(ctx context.Context, histogram metricapi.Float64Histogram, value float64, attrs ...Attribute) {
 	histogram.Record(ctx, value, metricapi.WithAttributes(attrs...))
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -24,18 +24,19 @@ import (
 
 // Re-export common OTel types to centralize dependency management
 type (
-	Span            = trace.Span
-	Tracer          = trace.Tracer
-	Attribute       = attribute.KeyValue
-	Code            = codes.Code
-	MeterProvider   = metricapi.MeterProvider
-	Meter           = metricapi.Meter
-	Int64Counter    = metricapi.Int64Counter
-	Int64Histogram  = metricapi.Int64Histogram
-	Int64Observer   = metricapi.Int64Observer
-	Float64Observer = metricapi.Float64Observer
-	LoggerProvider  = otellog.LoggerProvider
-	Logger          = otellog.Logger
+	Span             = trace.Span
+	Tracer           = trace.Tracer
+	Attribute        = attribute.KeyValue
+	Code             = codes.Code
+	MeterProvider    = metricapi.MeterProvider
+	Meter            = metricapi.Meter
+	Int64Counter     = metricapi.Int64Counter
+	Int64Histogram   = metricapi.Int64Histogram
+	Float64Histogram = metricapi.Float64Histogram
+	Int64Observer    = metricapi.Int64Observer
+	Float64Observer  = metricapi.Float64Observer
+	LoggerProvider   = otellog.LoggerProvider
+	Logger           = otellog.Logger
 )
 
 const (

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -262,6 +262,12 @@ func TestMetrics(t *testing.T) {
 					t.Fatalf("Failed to create histogram: %v", err)
 				}
 				RecordInt64Histogram(ctx, h, 100, StringAttribute("tag", "val"))
+
+				fh, err := NewFloat64Histogram(meter, "test-float-histogram", "desc", "v")
+				if err != nil {
+					t.Fatalf("Failed to create float histogram: %v", err)
+				}
+				RecordFloat64Histogram(ctx, fh, 3.14, StringAttribute("tag", "val"))
 			},
 		},
 		{

--- a/k3s/base/hardware-sim/mqtt-ingestor.yaml
+++ b/k3s/base/hardware-sim/mqtt-ingestor.yaml
@@ -54,6 +54,8 @@ spec:
         env:
         - name: MQTT_BROKER
           value: "tcp://emqx.observability.svc.cluster.local:1883"
+        - name: SIMULATION_ENV
+          value: "prod"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "opentelemetry.observability.svc.cluster.local:4317"
         resources:

--- a/k3s/overlays/dev/kustomization.yaml
+++ b/k3s/overlays/dev/kustomization.yaml
@@ -59,6 +59,9 @@ patches:
         path: /metadata/namespace
         value: dev-hardware-sim
       - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: "dev"
+      - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: Always
   - target:


### PR DESCRIPTION
### Summary
This change publishes accepted sensor-value metrics from the MQTT ingestor so
the hardware simulation can drive dashboard-ready telemetry instead of only
validation signals. It also adds explicit environment labeling so dev and prod
ingestors can be split cleanly in later Grafana panels.

### List of Changes
- Added accepted-reading metrics for sensor, radio, and runtime values so the
  ingestor now exports the core signals needed for hardware health views.
- Improved dashboard safety by labeling ingestor metrics with environment and
  bounded device metadata, which keeps dev and prod data distinguishable.

### Verification
- [x] `CCACHE_DISABLE=1 GOCACHE=/tmp/go-build-cache go test ./internal/telemetry ./internal/mqttingestor ./cmd/mqtt-ingestor`
- [x] `kubectl kustomize k3s/overlays/dev`

