### PR TITLE
feat(hardware-sim): add command topic compatibility

### DIFF
--- a/cmd/chaos-controller/main.go
+++ b/cmd/chaos-controller/main.go
@@ -21,9 +21,12 @@ func main() {
 		namespace = "hardware-sim"
 	}
 
+	commandTopicMode := os.Getenv("COMMAND_TOPIC_MODE")
+
 	controller := &hardwaresim.ChaosController{
-		MqttBroker: mqttBroker,
-		Namespace:  namespace,
+		MqttBroker:       mqttBroker,
+		Namespace:        namespace,
+		CommandTopicMode: commandTopicMode,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -19,7 +19,7 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
   - **Firmware Metadata**: Publishes `firmware_version` with every telemetry payload.
   - **Hardware Integration**: If available, reads the physical host temperature via `hostPath` mount (`/sys/class/thermal`).
   - **Communication**: Publishes JSON payloads to the configured telemetry topic, currently `sensors/thermal`, on the EMQX broker.
-- **Failure Hooks**: Subscribes to its own chaos topic (`sensors/<pod-name>/chaos`) to receive simulated failure instructions.
+- **Failure Hooks**: Subscribes to both the legacy chaos topic (`sensors/<pod-name>/chaos`) and the target command topic (`devices/<device_id>/commands`) to receive simulated failure instructions.
 
 ### Current Baseline
 
@@ -29,7 +29,8 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - Supports opt-in per-device telemetry topics in the form
   `devices/<device_id>/telemetry` while keeping `sensors/thermal` as the
   default path.
-- Uses `sensors/<pod-name>/chaos` as the per-sensor chaos topic.
+- Uses `sensors/<pod-name>/chaos` as the legacy per-sensor chaos topic.
+- Supports `devices/<device_id>/commands` as the target per-device command topic.
 - Supports the current `spike` chaos command for temporary thermal load, current draw, power increase, and voltage sag.
 - Supports the current `signal_loss` chaos command for temporary RSSI, SNR, and packet-loss degradation.
 - Supports the current `brownout` chaos command for voltage drops that record `reboot_reason=brownout`.
@@ -59,7 +60,7 @@ In the current implementation, `running` is published during normal telemetry, `
 - **Role**: A small experiment driver that injects periodic failure modes into the sensor fleet.
 - **Logic**:
   - **Discovery**: Queries the Kubernetes API to identify active `sensor-fleet` pods.
-  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike", "signal_loss", "brownout", or "memory_leak") via MQTT.
+  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike", "signal_loss", "brownout", or "memory_leak") via MQTT, using the legacy chaos topic by default with opt-in per-device command topic support.
   - **Parameters**: Randomizes the duration (10s-30s) and intensity (low, medium, high) of the failure.
 
 ## Data Flow & Orchestration

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -22,6 +22,8 @@ const (
 	DefaultFirmwareVersion       = "dev"
 	TelemetryTopicModeShared     = "shared"
 	TelemetryTopicModePerDevice  = "per-device"
+	CommandTopicModeLegacy       = "legacy"
+	CommandTopicModePerDevice    = "per-device"
 	DefaultEmulatedHeapBytes     = 320 * 1024
 	DefaultRebootReason          = "power_on"
 	DeviceStateRunning           = "running"
@@ -65,8 +67,9 @@ type ChaosCommand struct {
 
 // ChaosController handles the periodic injection of chaos into the sensor fleet.
 type ChaosController struct {
-	MqttBroker string
-	Namespace  string
+	MqttBroker       string
+	Namespace        string
+	CommandTopicMode string
 
 	randMu     sync.Mutex
 	randSource *rand.Rand
@@ -134,7 +137,7 @@ func (c *ChaosController) injectChaos(ctx context.Context, k8s kubernetes.Interf
 
 	log.Printf("Injecting Chaos into %s: Command=%s, Intensity=%s, Duration=%ds", targetPod.Name, command, intensity, durationSec)
 
-	topic := fmt.Sprintf("sensors/%s/chaos", targetPod.Name)
+	topic := c.commandTopic(targetPod.Name)
 	payload := fmt.Sprintf(`{"command": "%s", "duration": "%ds", "intensity": "%s"}`, command, durationSec, intensity)
 
 	token := mqttClient.Publish(topic, 1, false, payload)
@@ -184,12 +187,7 @@ func (s *Sensor) Run(ctx context.Context) error {
 	// --- Chaos Subscription Logic ---
 	opts.SetOnConnectHandler(func(c mqtt.Client) {
 		log.Printf("Connected to MQTT broker at %s", s.MqttBroker)
-		topic := fmt.Sprintf("sensors/%s/chaos", s.ID)
-		if token := c.Subscribe(topic, 1, s.handleChaos); token.Wait() && token.Error() != nil {
-			log.Printf("Error subscribing to chaos topic: %v", token.Error())
-		} else {
-			log.Printf("Subscribed to chaos topic: %s", topic)
-		}
+		s.subscribeCommandTopics(c)
 	})
 
 	client := mqtt.NewClient(opts)
@@ -499,6 +497,38 @@ func (s *Sensor) telemetryTopicMode() string {
 		return s.TelemetryMode
 	}
 	return TelemetryTopicModeShared
+}
+
+func (c *ChaosController) commandTopic(deviceID string) string {
+	if c.commandTopicMode() == CommandTopicModePerDevice {
+		return fmt.Sprintf("devices/%s/commands", deviceID)
+	}
+	return fmt.Sprintf("sensors/%s/chaos", deviceID)
+}
+
+func (c *ChaosController) commandTopicMode() string {
+	if c.CommandTopicMode != "" {
+		return c.CommandTopicMode
+	}
+	return CommandTopicModeLegacy
+}
+
+func (s *Sensor) commandTopics() []string {
+	deviceID := s.deviceID()
+	return []string{
+		fmt.Sprintf("sensors/%s/chaos", s.ID),
+		fmt.Sprintf("devices/%s/commands", deviceID),
+	}
+}
+
+func (s *Sensor) subscribeCommandTopics(c mqtt.Client) {
+	for _, topic := range s.commandTopics() {
+		if token := c.Subscribe(topic, 1, s.handleChaos); token.Wait() && token.Error() != nil {
+			log.Printf("Error subscribing to command topic %s: %v", topic, token.Error())
+		} else {
+			log.Printf("Subscribed to command topic: %s", topic)
+		}
+	}
 }
 
 func chaosDuration(raw string) time.Duration {

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -42,13 +42,17 @@ type published struct {
 type fakeMQTTClient struct {
 	mu        sync.Mutex
 	published []published
+	subs      []string
 }
 
 func (c *fakeMQTTClient) IsConnected() bool      { return true }
 func (c *fakeMQTTClient) IsConnectionOpen() bool { return true }
 func (c *fakeMQTTClient) Connect() mqtt.Token    { return newFakeToken(nil) }
 func (c *fakeMQTTClient) Disconnect(uint)        {}
-func (c *fakeMQTTClient) Subscribe(string, byte, mqtt.MessageHandler) mqtt.Token {
+func (c *fakeMQTTClient) Subscribe(topic string, qos byte, handler mqtt.MessageHandler) mqtt.Token {
+	c.mu.Lock()
+	c.subs = append(c.subs, topic)
+	c.mu.Unlock()
 	return newFakeToken(nil)
 }
 func (c *fakeMQTTClient) SubscribeMultiple(map[string]byte, mqtt.MessageHandler) mqtt.Token {
@@ -77,6 +81,14 @@ func (c *fakeMQTTClient) Publishes() []published {
 	defer c.mu.Unlock()
 	out := make([]published, len(c.published))
 	copy(out, c.published)
+	return out
+}
+
+func (c *fakeMQTTClient) Subscriptions() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.subs))
+	copy(out, c.subs)
 	return out
 }
 
@@ -248,6 +260,53 @@ func TestSensor_telemetryTopic_UsesPerDeviceTopicWhenEnabled(t *testing.T) {
 	want := "devices/esp32-lab-001/telemetry"
 	if got != want {
 		t.Fatalf("expected per-device telemetry topic %q, got %q", want, got)
+	}
+}
+
+func TestSensor_commandTopics_IncludeLegacyAndPerDevice(t *testing.T) {
+	s := &Sensor{
+		ID:       "sensor-1",
+		DeviceID: "esp32-lab-001",
+	}
+
+	got := s.commandTopics()
+	want := []string{
+		"sensors/sensor-1/chaos",
+		"devices/esp32-lab-001/commands",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d command topics, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected command topic %q at index %d, got %q", want[i], i, got[i])
+		}
+	}
+}
+
+func TestSensor_subscribeCommandTopics_SubscribesToBothTopics(t *testing.T) {
+	s := &Sensor{
+		ID:       "sensor-1",
+		DeviceID: "esp32-lab-001",
+	}
+	mq := &fakeMQTTClient{}
+
+	s.subscribeCommandTopics(mq)
+
+	got := mq.Subscriptions()
+	want := []string{
+		"sensors/sensor-1/chaos",
+		"devices/esp32-lab-001/commands",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d subscriptions, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected subscription %q at index %d, got %q", want[i], i, got[i])
+		}
 	}
 }
 
@@ -616,6 +675,36 @@ func TestChaosController_injectChaos_PublishesToSensorTopic(t *testing.T) {
 	payloadRe := regexp.MustCompile(`^\{"command": "(spike|signal_loss|brownout|memory_leak)", "duration": "\d+s", "intensity": "(low|medium|high)"\}$`)
 	if !payloadRe.MatchString(payload) {
 		t.Fatalf("unexpected payload %q", payload)
+	}
+}
+
+func TestChaosController_injectChaos_PublishesToPerDeviceCommandTopicWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "esp32-lab-001",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "sensor-fleet"},
+		},
+	}
+	k8s := fake.NewSimpleClientset(pod)
+
+	mq := &fakeMQTTClient{}
+	c := &ChaosController{
+		Namespace:        "default",
+		CommandTopicMode: CommandTopicModePerDevice,
+		randSource:       rand.New(rand.NewSource(2)),
+	}
+
+	c.injectChaos(ctx, k8s, mq)
+
+	pubs := mq.Publishes()
+	if len(pubs) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(pubs))
+	}
+	if got, want := pubs[0].topic, "devices/esp32-lab-001/commands"; got != want {
+		t.Fatalf("expected command topic %q, got %q", want, got)
 	}
 }
 

--- a/k3s/base/hardware-sim/chaos-controller.yaml
+++ b/k3s/base/hardware-sim/chaos-controller.yaml
@@ -54,6 +54,8 @@ spec:
         env:
         - name: MQTT_BROKER
           value: "tcp://emqx.observability.svc.cluster.local:1883"
+        - name: COMMAND_TOPIC_MODE
+          value: "legacy"
         - name: TARGET_NAMESPACE
           value: "hardware-sim"
         resources:


### PR DESCRIPTION
### Summary
This change adds command-topic compatibility to the hardware simulator so sensors can accept both the current chaos topic and the target per-device MQTT command topic without breaking existing control flow. It keeps the current publish path as the default while making the per-device command topic an explicit opt-in, which keeps rollout and rollback simple.

### List of Changes
- Added command-topic compatibility so the sensor and controller can transition toward per-device MQTT commands without disrupting today’s chaos injection workflow
- Improved rollout safety by keeping the legacy command path as the default and documenting the new opt-in mode for review and deployment

### Verification
- [x] `CCACHE_DISABLE=1 GOCACHE=/tmp/go-build-cache go test ./internal/hardware-sim`
- [x] `kubectl kustomize k3s/base/hardware-sim`

