### PR TITLE
feat(hardware-sim): add new failure scenarios

### DIFF
--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -35,6 +35,10 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 - Supports the current `signal_loss` chaos command for temporary RSSI, SNR, and packet-loss degradation.
 - Supports the current `brownout` chaos command for voltage drops that record `reboot_reason=brownout`.
 - Supports the current `memory_leak` chaos command for reducing emulated `free_heap` until a simulated restart records `reboot_reason=memory_leak`.
+- Supports `slow_loop` for elevated `loop_time_ms` and slower publish cadence.
+- Supports `sleep_mode` for slower publish cadence with `device_state=sleeping`.
+- Supports `malformed_payload` for bounded invalid MQTT publishes.
+- Supports `sequence_gap` for intentional sequence-number jumps.
 - Publishes explicit lifecycle state in telemetry for `running`, `degraded`, and
   short-lived `rebooting` samples.
 
@@ -52,7 +56,7 @@ The lifecycle model is the shared vocabulary for future sensor state reporting:
 | `rebooting` | Device is restarting because of a planned reset or simulated hardware-style fault. |
 | `failed` | Device cannot continue normal operation without an external restart or intervention. |
 
-In the current implementation, `running` is published during normal telemetry, `degraded` is published while a spike, signal-loss, brownout, or memory-leak command is active, and `rebooting` is published on the sample that records a brownout or memory-leak restart.
+In the current implementation, `running` is published during normal telemetry, `degraded` is published while a spike, signal-loss, slow-loop, brownout, or memory-leak command is active, `sleeping` is published during sleep-mode cadence reduction, and `rebooting` is published on the sample that records a brownout or memory-leak restart.
 
 ### Chaos Controller (`chaos-controller`)
 
@@ -60,7 +64,7 @@ In the current implementation, `running` is published during normal telemetry, `
 - **Role**: A small experiment driver that injects periodic failure modes into the sensor fleet.
 - **Logic**:
   - **Discovery**: Queries the Kubernetes API to identify active `sensor-fleet` pods.
-  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike", "signal_loss", "brownout", or "memory_leak") via MQTT, using the legacy chaos topic by default with opt-in per-device command topic support.
+  - **Injection**: Randomly selects a target pod and publishes a `ChaosCommand` (e.g., "spike", "signal_loss", "slow_loop", "sleep_mode", "malformed_payload", "sequence_gap", "brownout", or "memory_leak") via MQTT, using the legacy chaos topic by default with opt-in per-device command topic support.
   - **Parameters**: Randomizes the duration (10s-30s) and intensity (low, medium, high) of the failure.
 
 ## Data Flow & Orchestration

--- a/internal/hardware-sim/hardware_sim.go
+++ b/internal/hardware-sim/hardware_sim.go
@@ -28,6 +28,7 @@ const (
 	DefaultRebootReason          = "power_on"
 	DeviceStateRunning           = "running"
 	DeviceStateDegraded          = "degraded"
+	DeviceStateSleeping          = "sleeping"
 	DeviceStateRebooting         = "rebooting"
 	BrownoutRebootReason         = "brownout"
 	MemoryLeakRebootReason       = "memory_leak"
@@ -131,7 +132,7 @@ func (c *ChaosController) injectChaos(ctx context.Context, k8s kubernetes.Interf
 	targetPod := pods.Items[c.randIntn(len(pods.Items))]
 
 	// Randomize chaos parameters
-	command := []string{"spike", "signal_loss", "brownout", "memory_leak"}[c.randIntn(4)]
+	command := []string{"spike", "signal_loss", "brownout", "memory_leak", "slow_loop", "sleep_mode", "malformed_payload", "sequence_gap"}[c.randIntn(8)]
 	durationSec := 10 + c.randIntn(21) // 10s to 30s
 	intensity := []string{"low", "medium", "high"}[c.randIntn(3)]
 
@@ -156,22 +157,31 @@ type Sensor struct {
 	TelemetryTopic  string
 	TelemetryMode   string
 
-	mu                  sync.Mutex
-	isSpiking           bool
-	spikeIntensity      string
-	signalLoss          bool
-	signalIntensity     string
-	brownout            bool
-	brownoutRebooted    bool
-	brownoutIntensity   string
-	memoryLeak          bool
-	memoryLeakIntensity string
-	memoryLeakBytes     uint64
-	startTime           time.Time
-	rebootReason        string
-	sequenceNumber      uint64
-	randMu              sync.Mutex
-	randSource          *rand.Rand
+	mu                   sync.Mutex
+	isSpiking            bool
+	spikeIntensity       string
+	signalLoss           bool
+	signalIntensity      string
+	slowLoop             bool
+	slowLoopIntensity    string
+	sleepMode            bool
+	sleepModeIntensity   string
+	malformedPayload     bool
+	malformedIntensity   string
+	malformedRemaining   int
+	sequenceGap          bool
+	sequenceGapIntensity string
+	brownout             bool
+	brownoutRebooted     bool
+	brownoutIntensity    string
+	memoryLeak           bool
+	memoryLeakIntensity  string
+	memoryLeakBytes      uint64
+	startTime            time.Time
+	rebootReason         string
+	sequenceNumber       uint64
+	randMu               sync.Mutex
+	randSource           *rand.Rand
 }
 
 // Run starts the sensor data generation and chaos subscription loop.
@@ -196,21 +206,19 @@ func (s *Sensor) Run(ctx context.Context) error {
 	}
 	defer client.Disconnect(250)
 
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
 	telemetryTopic := s.telemetryTopic()
 	log.Printf("Sensor %s started publishing to %s...", s.ID, telemetryTopic)
 
 	for {
+		timer := time.NewTimer(s.publishInterval())
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return nil
-		case <-ticker.C:
-			data := s.generateData()
-			payload, err := json.Marshal(data)
+		case <-timer.C:
+			payload, err := s.publishPayload()
 			if err != nil {
-				log.Printf("Error marshaling data: %v", err)
+				log.Printf("Error building payload: %v", err)
 				continue
 			}
 
@@ -299,6 +307,72 @@ func (s *Sensor) handleChaos(client mqtt.Client, msg mqtt.Message) {
 			s.mu.Unlock()
 			log.Println("Memory Leak Ended.")
 		})
+	case "slow_loop":
+		duration := chaosDuration(cmd.Duration)
+
+		log.Printf("!!! Slow Loop Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
+		s.mu.Lock()
+		s.slowLoop = true
+		s.slowLoopIntensity = cmd.Intensity
+		s.mu.Unlock()
+
+		time.AfterFunc(duration, func() {
+			s.mu.Lock()
+			s.slowLoop = false
+			s.slowLoopIntensity = ""
+			s.mu.Unlock()
+			log.Println("Slow Loop Ended.")
+		})
+	case "sleep_mode":
+		duration := chaosDuration(cmd.Duration)
+
+		log.Printf("!!! Sleep Mode Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
+		s.mu.Lock()
+		s.sleepMode = true
+		s.sleepModeIntensity = cmd.Intensity
+		s.mu.Unlock()
+
+		time.AfterFunc(duration, func() {
+			s.mu.Lock()
+			s.sleepMode = false
+			s.sleepModeIntensity = ""
+			s.mu.Unlock()
+			log.Println("Sleep Mode Ended.")
+		})
+	case "malformed_payload":
+		duration := chaosDuration(cmd.Duration)
+
+		log.Printf("!!! Malformed Payload Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
+		s.mu.Lock()
+		s.malformedPayload = true
+		s.malformedIntensity = cmd.Intensity
+		s.malformedRemaining = malformedPublishCount(cmd.Intensity)
+		s.mu.Unlock()
+
+		time.AfterFunc(duration, func() {
+			s.mu.Lock()
+			s.malformedPayload = false
+			s.malformedIntensity = ""
+			s.malformedRemaining = 0
+			s.mu.Unlock()
+			log.Println("Malformed Payload Ended.")
+		})
+	case "sequence_gap":
+		duration := chaosDuration(cmd.Duration)
+
+		log.Printf("!!! Sequence Gap Started: %s duration (Intensity: %s) !!!", duration, cmd.Intensity)
+		s.mu.Lock()
+		s.sequenceGap = true
+		s.sequenceGapIntensity = cmd.Intensity
+		s.mu.Unlock()
+
+		time.AfterFunc(duration, func() {
+			s.mu.Lock()
+			s.sequenceGap = false
+			s.sequenceGapIntensity = ""
+			s.mu.Unlock()
+			log.Println("Sequence Gap Ended.")
+		})
 	}
 }
 
@@ -311,6 +385,9 @@ func (s *Sensor) generateData() SensorData {
 	intensity := s.spikeIntensity
 	signalLoss := s.signalLoss
 	signalIntensity := s.signalIntensity
+	slowLoop := s.slowLoop
+	slowLoopIntensity := s.slowLoopIntensity
+	sleepMode := s.sleepMode
 	brownout := s.brownout
 	brownoutRebooted := s.brownoutRebooted
 	brownoutIntensity := s.brownoutIntensity
@@ -319,7 +396,7 @@ func (s *Sensor) generateData() SensorData {
 	memoryLeakBytes := s.memoryLeakBytes
 	uptimeSeconds := int64(time.Since(s.startTime).Seconds())
 	rebootReason := s.rebootReason
-	s.sequenceNumber++
+	s.sequenceNumber += 1 + sequenceGapStep(s.sequenceGap, s.sequenceGapIntensity)
 	sequenceNumber := s.sequenceNumber
 	s.mu.Unlock()
 
@@ -327,7 +404,7 @@ func (s *Sensor) generateData() SensorData {
 		rebootReason = DefaultRebootReason
 	}
 
-	deviceState := sensorState(spiking, signalLoss, brownout, memoryLeak)
+	deviceState := sensorState(spiking, signalLoss, slowLoop, sleepMode, brownout, memoryLeak)
 
 	// Base Simulation (Healthy state)
 	temp := 35.0 + s.randFloat64()*5.0
@@ -338,6 +415,16 @@ func (s *Sensor) generateData() SensorData {
 	packetLoss := s.randFloat64() * 2.0
 	freeHeap := uint64(DefaultEmulatedHeapBytes) - uint64(64*1024+s.randFloat64()*32*1024)
 	loopTimeMS := 4.0 + s.randFloat64()*8.0
+
+	if slowLoop {
+		loopTimeMS += slowLoopLatencyAdd(slowLoopIntensity)
+	}
+
+	if sleepMode {
+		deviceState = DeviceStateSleeping
+		current *= 0.35
+		packetLoss *= 0.5
+	}
 
 	// Apply Dynamic Spike Logic
 	if spiking {
@@ -461,11 +548,120 @@ func (s *Sensor) generateData() SensorData {
 	}
 }
 
-func sensorState(spiking, signalLoss, brownout, memoryLeak bool) string {
-	if spiking || signalLoss || brownout || memoryLeak {
+func (s *Sensor) publishPayload() ([]byte, error) {
+	s.mu.Lock()
+	if s.malformedPayload && s.malformedRemaining > 0 {
+		s.malformedRemaining--
+		if s.malformedRemaining == 0 {
+			s.malformedPayload = false
+			s.malformedIntensity = ""
+		}
+		s.mu.Unlock()
+		return []byte(`{"schema_version":`), nil
+	}
+	s.mu.Unlock()
+
+	data := s.generateData()
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func sensorState(spiking, signalLoss, slowLoop, sleepMode, brownout, memoryLeak bool) string {
+	if sleepMode {
+		return DeviceStateSleeping
+	}
+	if spiking || signalLoss || slowLoop || brownout || memoryLeak {
 		return DeviceStateDegraded
 	}
 	return DeviceStateRunning
+}
+
+func (s *Sensor) publishInterval() time.Duration {
+	s.mu.Lock()
+	sleepMode := s.sleepMode
+	sleepIntensity := s.sleepModeIntensity
+	slowLoop := s.slowLoop
+	slowIntensity := s.slowLoopIntensity
+	s.mu.Unlock()
+
+	if sleepMode {
+		return sleepModeInterval(sleepIntensity)
+	}
+	if slowLoop {
+		return slowLoopInterval(slowIntensity)
+	}
+	return 2 * time.Second
+}
+
+func sleepModeInterval(intensity string) time.Duration {
+	switch intensity {
+	case "low":
+		return 5 * time.Second
+	case "medium":
+		return 8 * time.Second
+	case "high":
+		return 12 * time.Second
+	default:
+		return 6 * time.Second
+	}
+}
+
+func slowLoopInterval(intensity string) time.Duration {
+	switch intensity {
+	case "low":
+		return 3 * time.Second
+	case "medium":
+		return 5 * time.Second
+	case "high":
+		return 7 * time.Second
+	default:
+		return 4 * time.Second
+	}
+}
+
+func slowLoopLatencyAdd(intensity string) float64 {
+	switch intensity {
+	case "low":
+		return 18.0
+	case "medium":
+		return 35.0
+	case "high":
+		return 60.0
+	default:
+		return 24.0
+	}
+}
+
+func malformedPublishCount(intensity string) int {
+	switch intensity {
+	case "low":
+		return 1
+	case "medium":
+		return 2
+	case "high":
+		return 3
+	default:
+		return 1
+	}
+}
+
+func sequenceGapStep(enabled bool, intensity string) uint64 {
+	if !enabled {
+		return 0
+	}
+	switch intensity {
+	case "low":
+		return 1
+	case "medium":
+		return 2
+	case "high":
+		return 4
+	default:
+		return 1
+	}
 }
 
 func (s *Sensor) deviceID() string {

--- a/internal/hardware-sim/hardware_sim_test.go
+++ b/internal/hardware-sim/hardware_sim_test.go
@@ -384,6 +384,74 @@ func TestSensor_generateData_ReportsRuntimeHealth(t *testing.T) {
 	}
 }
 
+func TestSensor_generateData_SlowLoopIncreasesLoopTime(t *testing.T) {
+	s := &Sensor{
+		ID:         "sensor-1",
+		randSource: rand.New(rand.NewSource(654)),
+	}
+
+	base := s.generateData()
+
+	s.mu.Lock()
+	s.slowLoop = true
+	s.slowLoopIntensity = "high"
+	s.mu.Unlock()
+
+	s.randSource = rand.New(rand.NewSource(654))
+	slow := s.generateData()
+
+	if slow.LoopTimeMS <= base.LoopTimeMS {
+		t.Fatalf("expected slow loop to increase loop_time_ms, base=%v slow=%v", base.LoopTimeMS, slow.LoopTimeMS)
+	}
+	if slow.DeviceState != DeviceStateDegraded {
+		t.Fatalf("expected slow loop device_state %q, got %q", DeviceStateDegraded, slow.DeviceState)
+	}
+}
+
+func TestSensor_generateData_SleepModeReportsSleepingState(t *testing.T) {
+	s := &Sensor{
+		ID:         "sensor-1",
+		randSource: rand.New(rand.NewSource(777)),
+	}
+
+	base := s.generateData()
+
+	s.mu.Lock()
+	s.sleepMode = true
+	s.sleepModeIntensity = "medium"
+	s.mu.Unlock()
+
+	s.randSource = rand.New(rand.NewSource(777))
+	sleeping := s.generateData()
+
+	if sleeping.DeviceState != DeviceStateSleeping {
+		t.Fatalf("expected sleep mode device_state %q, got %q", DeviceStateSleeping, sleeping.DeviceState)
+	}
+	if sleeping.Current >= base.Current {
+		t.Fatalf("expected sleep mode to reduce current draw, base=%v sleeping=%v", base.Current, sleeping.Current)
+	}
+}
+
+func TestSensor_generateData_SequenceGapSkipsNumbers(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	first := s.generateData()
+
+	s.mu.Lock()
+	s.sequenceGap = true
+	s.sequenceGapIntensity = "medium"
+	s.mu.Unlock()
+
+	second := s.generateData()
+
+	if first.SequenceNumber != 1 {
+		t.Fatalf("expected first sequence_number 1, got %d", first.SequenceNumber)
+	}
+	if second.SequenceNumber != 4 {
+		t.Fatalf("expected sequence gap to skip to 4, got %d", second.SequenceNumber)
+	}
+}
+
 func TestSensor_generateData_BrownoutDropsVoltageAndRecordsReboot(t *testing.T) {
 	s := &Sensor{
 		ID:         "sensor-1",
@@ -606,6 +674,178 @@ func TestSensor_handleChaos_SetsAndClearsMemoryLeak(t *testing.T) {
 	}
 }
 
+func TestSensor_handleChaos_SetsAndClearsSlowLoop(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	cmd := ChaosCommand{
+		Command:   "slow_loop",
+		Duration:  "5ms",
+		Intensity: "medium",
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal chaos command: %v", err)
+	}
+
+	s.handleChaos(nil, &fakeMessage{payload: b})
+
+	s.mu.Lock()
+	active := s.slowLoop
+	intensity := s.slowLoopIntensity
+	s.mu.Unlock()
+
+	if !active || intensity != "medium" {
+		t.Fatalf("expected slow loop to be active immediately, active=%v intensity=%q", active, intensity)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	active = s.slowLoop
+	intensity = s.slowLoopIntensity
+	s.mu.Unlock()
+
+	if active || intensity != "" {
+		t.Fatalf("expected slow loop to be cleared, active=%v intensity=%q", active, intensity)
+	}
+}
+
+func TestSensor_handleChaos_SetsAndClearsSleepMode(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	cmd := ChaosCommand{
+		Command:   "sleep_mode",
+		Duration:  "5ms",
+		Intensity: "medium",
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal chaos command: %v", err)
+	}
+
+	s.handleChaos(nil, &fakeMessage{payload: b})
+
+	s.mu.Lock()
+	active := s.sleepMode
+	intensity := s.sleepModeIntensity
+	s.mu.Unlock()
+
+	if !active || intensity != "medium" {
+		t.Fatalf("expected sleep mode to be active immediately, active=%v intensity=%q", active, intensity)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	active = s.sleepMode
+	intensity = s.sleepModeIntensity
+	s.mu.Unlock()
+
+	if active || intensity != "" {
+		t.Fatalf("expected sleep mode to be cleared, active=%v intensity=%q", active, intensity)
+	}
+}
+
+func TestSensor_handleChaos_SetsAndClearsMalformedPayload(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	cmd := ChaosCommand{
+		Command:   "malformed_payload",
+		Duration:  "5ms",
+		Intensity: "medium",
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal chaos command: %v", err)
+	}
+
+	s.handleChaos(nil, &fakeMessage{payload: b})
+
+	s.mu.Lock()
+	active := s.malformedPayload
+	intensity := s.malformedIntensity
+	remaining := s.malformedRemaining
+	s.mu.Unlock()
+
+	if !active || intensity != "medium" || remaining != 2 {
+		t.Fatalf("expected malformed payload to be active immediately, active=%v intensity=%q remaining=%d", active, intensity, remaining)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	active = s.malformedPayload
+	intensity = s.malformedIntensity
+	remaining = s.malformedRemaining
+	s.mu.Unlock()
+
+	if active || intensity != "" || remaining != 0 {
+		t.Fatalf("expected malformed payload to be cleared, active=%v intensity=%q remaining=%d", active, intensity, remaining)
+	}
+}
+
+func TestSensor_handleChaos_SetsAndClearsSequenceGap(t *testing.T) {
+	s := &Sensor{ID: "sensor-1"}
+
+	cmd := ChaosCommand{
+		Command:   "sequence_gap",
+		Duration:  "5ms",
+		Intensity: "medium",
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal chaos command: %v", err)
+	}
+
+	s.handleChaos(nil, &fakeMessage{payload: b})
+
+	s.mu.Lock()
+	active := s.sequenceGap
+	intensity := s.sequenceGapIntensity
+	s.mu.Unlock()
+
+	if !active || intensity != "medium" {
+		t.Fatalf("expected sequence gap to be active immediately, active=%v intensity=%q", active, intensity)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	active = s.sequenceGap
+	intensity = s.sequenceGapIntensity
+	s.mu.Unlock()
+
+	if active || intensity != "" {
+		t.Fatalf("expected sequence gap to be cleared, active=%v intensity=%q", active, intensity)
+	}
+}
+
+func TestSensor_publishPayload_ProducesBoundedMalformedPayload(t *testing.T) {
+	s := &Sensor{
+		ID:                 "sensor-1",
+		malformedPayload:   true,
+		malformedIntensity: "low",
+		malformedRemaining: 1,
+	}
+
+	payload, err := s.publishPayload()
+	if err != nil {
+		t.Fatalf("publishPayload returned error: %v", err)
+	}
+	if string(payload) != `{"schema_version":` {
+		t.Fatalf("expected malformed payload, got %q", string(payload))
+	}
+
+	s.mu.Lock()
+	active := s.malformedPayload
+	remaining := s.malformedRemaining
+	s.mu.Unlock()
+
+	if active || remaining != 0 {
+		t.Fatalf("expected malformed state to clear after bounded publish, active=%v remaining=%d", active, remaining)
+	}
+}
+
 func TestChaosController_injectChaos_NoPods_NoPublish(t *testing.T) {
 	ctx := context.Background()
 	k8s := fake.NewSimpleClientset()
@@ -672,7 +912,7 @@ func TestChaosController_injectChaos_PublishesToSensorTopic(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected string payload, got %T", pub.payload)
 	}
-	payloadRe := regexp.MustCompile(`^\{"command": "(spike|signal_loss|brownout|memory_leak)", "duration": "\d+s", "intensity": "(low|medium|high)"\}$`)
+	payloadRe := regexp.MustCompile(`^\{"command": "(spike|signal_loss|brownout|memory_leak|slow_loop|sleep_mode|malformed_payload|sequence_gap)", "duration": "\d+s", "intensity": "(low|medium|high)"\}$`)
 	if !payloadRe.MatchString(payload) {
 		t.Fatalf("unexpected payload %q", payload)
 	}


### PR DESCRIPTION
### Summary

This change adds a small batch of new hardware-style failure scenarios to the simulator so the MQTT pipeline can surface more realistic edge-device behavior. It expands the learning surface without changing dashboard code, which keeps the scenario work isolated and easier to review.

### List of Changes

- Added new simulator behaviors for slow loops, sleep mode, malformed payloads, and sequence gaps so the platform can observe a broader set of device-side failure patterns
- Improved validation coverage by keeping the new scenarios bounded and test-driven, which makes the added failure modes safer to roll out and easier to diagnose

### Verification

- [x] `CCACHE_DISABLE=1 GOCACHE=/tmp/go-build-cache go test ./internal/hardware-sim`

