### PR TITLE
fix(cilium): allow n8n egress to ollama on 11434

### DIFF
--- a/k3s/cilium-policies/observability-stack-policy.yaml
+++ b/k3s/cilium-policies/observability-stack-policy.yaml
@@ -519,6 +519,8 @@ spec:
             protocol: TCP
           - port: "587"
             protocol: TCP
+          - port: "11434"
+            protocol: TCP
     # 7. Allow MongoDB Atlas replica set traffic for worker ingestion
     - toFQDNs:
       - matchPattern: "*.mongodb.net"


### PR DESCRIPTION
### Summary
This change updates the `hub-security` Cilium policy so the `n8n` workload can reach an external Ollama server on TCP port `11434`. It fixes a blocked integration path while avoiding any repository-level disclosure of a private PC IP address.

### List of Changes
- Expanded the `hub` namespace egress allowlist to include external TCP traffic on port `11434` for the `n8n` to Ollama connection.
- Preserved the current repository safety model by solving the connectivity issue without committing machine-specific network details.

### Verification
- [x] Confirmed the `hub-security` Cilium policy diff adds `11434/TCP` to the `world` egress allowlist for `hub` workloads
- [x] Confirmed the existing `hub-security` policy already permits external `n8n` traffic and this change only extends the egress port allowlist for the Ollama path

