### PR TITLE
chore(hardware): prepare hardware split repo

### DIFF
--- a/k3s/bootstrap/hardware-sim-lab-app.yaml
+++ b/k3s/bootstrap/hardware-sim-lab-app.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hardware-sim-lab
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/victoriacheng15/hardware-sim-lab.git
+    targetRevision: main
+    path: k3s/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hardware-sim
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
### Summary
Prepared `observability-hub` for the hardware repo split by adding a child Argo CD application manifest that can later point at `hardware-sim-lab`. This keeps the platform repo focused on shared observability infrastructure while setting up a safer GitOps transition path for the hardware workloads.

### List of Changes
- Added a child Argo CD application manifest so the hardware workloads can be managed from their own repository when the cutover happens.
- Preserved a safe handoff path by preparing the GitOps hook first and leaving the current in-repo hardware resources untouched until cutover.

### Verification
- [x] Reviewed the child Argo CD `Application` fields against the existing root app pattern for `repoURL`, `targetRevision`, `path`, destination, and sync policy

