### PR TITLE
chore(hardware): manage split apps and docs

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -71,7 +71,9 @@ The runtime environment and foundational deployment strategies.
 
 Deep dives into the logic and implementation of specific system components.
 
-- **[Hardware Simulation](./services/hardware-sim.md)**: Fleet of synthetic sensors and chaos injection engine.
+- **[Hardware Simulation](./services/hardware-sim.md)**: External synthetic
+  workload repo observed by this platform through shared MQTT and
+  observability interfaces.
 - **[MCP Servers](./services/mcp-servers.md)**: The "Agentic Interface" suite for autonomous operations.
 - **[Proxy Service](./services/proxy.md)**: The API Gateway and GitOps listener.
 - **[Tailscale Gate](./services/tailscale-gate.md)**: Logic for the automated funnel gatekeeper.

--- a/docs/architecture/services/hardware-sim.md
+++ b/docs/architecture/services/hardware-sim.md
@@ -1,6 +1,21 @@
 # Hardware Simulation Learning Lab
 
-The Hardware Simulation domain (`cmd/sensor`, `cmd/chaos-controller`) is an exploratory learning lab for hardware-style telemetry. It is not a production robotics stack or a serious hardware-control system. It simulates a small fleet of sensor-like workloads so the project can explore how data from sensors, drones, robots, or other edge devices might be collected, transported, monitored, and diagnosed.
+The Hardware Simulation domain now lives in the public `hardware-sim-lab` repo.
+It remains an exploratory learning lab for hardware-style telemetry rather than
+production robotics or hardware control. The purpose is still the same:
+simulate a small fleet of sensor-like workloads so the platform can explore how
+data from sensors, drones, robots, or other edge devices might be collected,
+transported, monitored, and diagnosed.
+
+Within `observability-hub`, hardware simulation is now treated as an external
+workload domain:
+
+- `hardware-sim-lab` owns the sensor, chaos, and MQTT-ingestor code, images,
+  and Kubernetes manifests
+- `observability-hub` owns the shared MQTT, OpenTelemetry, Prometheus, and
+  Grafana environment that receives and visualizes that telemetry
+- Argo CD child applications in this repo point at `hardware-sim-lab` for
+  `dev` and `prod` overlays
 
 ## Objective
 
@@ -10,7 +25,7 @@ To build practical intuition for hardware monitoring. By simulating physical-ish
 
 ### Sensor Fleet (`sensor`)
 
-- **Type**: Kubernetes StatefulSet (`hardware-sim` namespace).
+- **Type**: Kubernetes StatefulSet in `hardware-sim-lab`.
 - **Role**: Simulates an individual hardware device emitting real-time telemetry.
 - **Logic**:
   - **Boot Sequence**: Emits serial-style logs to Loki mimicking a hardware bootloader.
@@ -60,7 +75,7 @@ In the current implementation, `running` is published during normal telemetry, `
 
 ### Chaos Controller (`chaos-controller`)
 
-- **Type**: Kubernetes Deployment.
+- **Type**: Kubernetes Deployment in `hardware-sim-lab`.
 - **Role**: A small experiment driver that injects periodic failure modes into the sensor fleet.
 - **Logic**:
   - **Discovery**: Queries the Kubernetes API to identify active `sensor-fleet` pods.
@@ -91,9 +106,10 @@ sequenceDiagram
     end
 ```
 
-## Observability Implementation
+## Platform Integration
 
-The simulation uses the platform's observability stack as a learning surface:
+The simulation uses the platform's shared observability environment as a
+learning surface:
 
 - **Logs**: Boot sequences and chaos event transitions are emitted as structured logs and collected by Grafana Loki.
 - **Metrics**: EMQX stats are scraped by Prometheus, providing visibility into the message throughput and client connectivity of the simulation fleet.

--- a/docs/decisions/025-decouple-hardware-simulation.md
+++ b/docs/decisions/025-decouple-hardware-simulation.md
@@ -1,0 +1,104 @@
+# ADR 025: Decouple Hardware Simulation
+
+- **Status:** Accepted
+- **Date:** 2026-04-25
+- **Author:** Victoria Cheng
+
+## Context and Problem Statement
+
+`observability-hub` had been carrying two different responsibilities in the
+same repo:
+
+- platform and observability ownership
+- hardware simulation workloads used as a telemetry-producing learning lab
+
+That arrangement was useful while the simulation was being developed alongside
+the platform, but it created an increasingly blurry boundary. The repo was
+mixing platform concerns such as Argo CD bootstrap, shared observability
+infrastructure, and operator tooling with workload-specific concerns such as the
+sensor fleet, chaos controller, MQTT ingestor, hardware Dockerfiles, and
+hardware Kubernetes manifests.
+
+The result was avoidable coupling:
+
+- platform CI/CD still built hardware images
+- the active `k3s/` tree rendered hardware workloads directly
+- architecture and workflow docs implied hardware was still an internal service
+  domain
+- the repo drifted away from a pure platform and observability focus
+
+The project needs a cleaner platform boundary: `observability-hub` should own
+the shared control plane, telemetry plane, and operator workflows, while the
+hardware simulation should evolve independently as an external workload repo.
+
+## Decision Outcome
+
+Extract the hardware simulation domain into a separate public repo,
+`hardware-sim-lab`, and keep `observability-hub` focused on platform and
+observability ownership.
+
+- **Workload Ownership Moves Out:** `sensor`, `chaos-controller`,
+  `mqtt-ingestor`, their Dockerfiles, and their Kubernetes manifests move to
+  `hardware-sim-lab`.
+- **Telemetry Contract Stays Shared:** The hardware repo continues to emit to
+  the shared MQTT and OpenTelemetry environment so Grafana and Prometheus views
+  remain part of the same operational plane.
+- **Private Internals Stay Private:** The new repo gets its own
+  `internal/telemetry` and related internal packages instead of importing
+  `observability-hub/internal/...` across repo boundaries.
+- **GitOps Control Stays Here:** `observability-hub` keeps Argo CD bootstrap and
+  owns child `Application` objects that point at `hardware-sim-lab` overlays.
+- **Active Kustomize Ownership Ends Here:** The old in-repo hardware base,
+  overlays, and hardware-only RBAC are removed from the active `k3s/` tree in
+  `observability-hub`.
+
+### Rationale
+
+- **Platform boundary becomes explicit:** This repo returns to its primary role
+  as the platform, observability, and operator control plane.
+- **Hardware can evolve independently:** The simulation can ship code, images,
+  and manifests without dragging unrelated platform changes into the same review
+  path.
+- **GitOps ownership becomes cleaner:** Argo CD app-of-apps is easier to reason
+  about than a mixed repo where root manifests and extracted workloads overlap.
+- **Interfaces become real contracts:** MQTT topics, payload shape, and OTEL
+  conventions become external integration points instead of accidental in-repo
+  coupling.
+- **Documentation aligns with reality:** Architecture and workflow docs can
+  describe the platform as observing external workloads rather than embedding
+  them.
+
+## Consequences
+
+### Positive
+
+- **Cleaner repo purpose:** `observability-hub` stays centered on platform and
+  observability concerns.
+- **Independent release cadence:** `hardware-sim-lab` can build and publish its
+  own images without coupling to platform image workflows.
+- **Clearer GitOps control plane:** Argo CD child apps in this repo point to the
+  new workload repo instead of reconciling the hardware manifests directly.
+- **Better long-term maintainability:** Internal package boundaries, docs, and
+  CI ownership are easier to keep coherent.
+
+### Negative
+
+- **More moving parts:** Two repos must stay aligned on MQTT, telemetry labels,
+  and deployment expectations.
+- **Cutover requires a clean handoff:** Argo CD ownership needs a one-time
+  transition from the old in-repo manifests to the child applications in order
+  to avoid duplicate resource management.
+- **Docs split across repos:** Some operational knowledge now belongs in the
+  hardware repo while platform-facing guidance stays here.
+
+## Verification
+
+- [x] **Code Ownership Cleanup:** Hardware build/source ownership was removed
+  from `observability-hub`.
+- [x] **Kustomize Render:** `kubectl kustomize k3s` completed successfully after
+  removing the old in-repo hardware manifests.
+- [x] **Argo CD Structure:** Child `Application` manifests for
+  `hardware-sim-lab-dev` and `hardware-sim-lab-prod` were added under
+  `k3s/base/hub-apps`.
+- [x] **Documentation:** Core platform docs were updated to describe hardware
+  simulation as an external workload repo.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 
 | ADR | Title | Status |
 | :--- | :--- | :--- |
+| **025** | [Decouple Hardware Simulation](./025-decouple-hardware-simulation.md) | 🔵 Accepted |
 | **024** | [Trivy-Verified Workload Hardening](./024-trivy-verified-workload-hardening.md) | 🔵 Accepted |
 | **023** | [Benchmark-Validated Rust Obs Processor](./023-benchmark-rust-obs-processor.md) | 🔵 Accepted |
 | **022** | [Structured Summaries for Obs Processor](./022-obs-processor-structured-summaries.md) | 🔵 Accepted |

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -5,7 +5,9 @@ This directory contains technical "cheat sheets" and operational guides for main
 ## 📂 Available Notes
 
 - **[Cilium & Hubble](./cilium-networking.md)**: Breakdown of L3/L4/L7 visibility and policy-driven network observability.
-- **[Hardware Simulation Validation](./hardware-sim-validation.md)**: End-to-end validation steps for the synthetic sensor, MQTT, ingestor, and Grafana flow.
+- **[Hardware Simulation Validation](./hardware-sim-validation.md)**: End-to-end
+  validation steps for the synthetic sensor, MQTT, ingestor, and Grafana flow
+  now sourced from `hardware-sim-lab`.
 - **[k3s Operations Guide](./k3s-operations.md)**: Procedures for deployment, image management, and data migration in the cluster.
 - **[MCP Gateway](./mcp-gateway-deployment.md)**: Unified agentic execution guide for autonomous platform operations.
 - **[Network Flow Baseline](./network-flow-baseline.md)**: Current reference matrix for required in-cluster and external traffic paths.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -42,7 +42,8 @@ Handles the automated build and hosting of the public-facing portfolio web.
 Automates the containerization and delivery of Hub services to the GitHub Container Registry (GHCR).
 
 - **Trigger**: Pushes to the main branch or manual trigger.
-- **Responsibility**: Builds Docker images for core services (`worker`, `sensor`, `chaos-controller`, `postgres-cnpg`) using a matrix strategy.
+- **Responsibility**: Builds Docker images for platform-owned services
+  (`worker`, `postgres-cnpg`) using a matrix strategy.
 - **Key Feature**: Tags images with both `latest` and short-SHA for precise GitOps referencing and rollbacks.
 
 ### 🧪 [Go Lint & Test](../.github/workflows/go-ci.yml)

--- a/k3s/README.md
+++ b/k3s/README.md
@@ -9,16 +9,15 @@ For detailed operational procedures, including deployment commands, image sidelo
 ## 📂 Directory Structure
 
 - **base/**: Shared Kustomize base for cluster workloads and infrastructure.
-- **base/hardware-sim/**: Synthetic hardware simulation workloads such as
-  `sensor-fleet`, `chaos-controller`, and `mqtt-ingestor`.
-- **base/hub-apps/**: Hub application workloads managed in-cluster.
+- **base/hub-apps/**: Hub-managed application objects, including Argo CD child
+  apps that point at external workload repos such as `hardware-sim-lab`.
 - **base/infra/**: Helm values and provisioned assets for Grafana, Loki, MinIO,
   OpenTelemetry, Prometheus, Tempo, and Thanos.
-- **base/rbac/**: Shared service accounts, roles, and bindings.
+- **base/rbac/**: Shared platform service accounts, roles, and bindings.
 - **base/worker/**: Worker CronJobs and their base image/tag configuration.
 - **bootstrap/**: Cluster bootstrap assets.
 - **cilium-policies/**: Network policy definitions for Cilium.
-- **overlays/dev/**: Development overlay for namespace, image, and rollout
-  overrides.
-- **overlays/prod/**: Production overlay for namespace, image, and rollout
-  overrides.
+
+Hardware simulation workloads no longer live directly in this tree. They are
+managed from the public `hardware-sim-lab` repo through Argo CD child
+applications declared under `base/hub-apps/`.

--- a/k3s/base/hub-apps/hardware-sim-lab-dev.yaml
+++ b/k3s/base/hub-apps/hardware-sim-lab-dev.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: hardware-sim-lab
+  name: hardware-sim-lab-dev
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
@@ -13,7 +13,7 @@ spec:
     path: k3s/overlays/dev
   destination:
     server: https://kubernetes.default.svc
-    namespace: hardware-sim
+    namespace: dev-hardware-sim
   syncPolicy:
     automated:
       prune: true

--- a/k3s/base/hub-apps/hardware-sim-lab-prod.yaml
+++ b/k3s/base/hub-apps/hardware-sim-lab-prod.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hardware-sim-lab-prod
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/victoriacheng15/hardware-sim-lab.git
+    targetRevision: main
+    path: k3s/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hardware-sim
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true

--- a/k3s/base/hub-apps/kustomization.yaml
+++ b/k3s/base/hub-apps/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 
 resources:
   - automation.yaml
+  - hardware-sim-lab-dev.yaml
+  - hardware-sim-lab-prod.yaml

--- a/k3s/kustomization.yaml
+++ b/k3s/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - base/hub-apps/automation.yaml
+  - base/hub-apps
   - base/rbac/cluster-rbac.yaml
   - base/worker
   - cilium-policies/observability-stack-policy.yaml


### PR DESCRIPTION
### Summary

This change moves the hardware simulation Argo CD control objects into the
managed `hub-apps` tree and updates the platform docs to reflect the new repo
boundary. It makes the hardware split declarative under `root-app` while
reframing `observability-hub` as the platform and observability control plane.

### List of Changes

- Replaced the old bootstrap-era hardware app manifest with root-managed Argo CD
  child applications for `hardware-sim-lab-dev` and `hardware-sim-lab-prod`.
- Updated architecture, workflow, k3s, and ADR docs so hardware simulation is
  described as an external workload repo rather than an in-repo service domain.

### Verification

- [x] `kubectl kustomize k3s >/dev/null`


