### PR TITLE
feat(gitops): bump argocd to latest stable v3.3.8

### DIFF
--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -41,7 +41,7 @@ variable "hardware_sim_namespace" {
 variable "argocd_chart_version" {
   description = "Helm chart version for ArgoCD."
   type        = string
-  default     = "9.4.17"
+  default     = "9.5.4"
 }
 
 # --- Azure Storage ---


### PR DESCRIPTION
### Summary
Updated Argo CD to the latest stable Helm chart and aligned the deployment with the v3.3.8 GA release. This transition ensures the infrastructure remains on a verified stable path, avoiding the operational risks associated with using non-GA release candidates.

### List of Changes
- Aligned the GitOps controller with the latest stable application release and Helm chart standards.
- Enhanced system stability by ensuring the core deployment follows official GA release tracks.

### Verification
- [x] Verified Argo CD v3.3.8 image presence on Quay.io and GitHub Releases.
- [x] Confirmed Helm chart 9.5.4 targets appVersion v3.3.8 via `helm show chart`.
- [x] Run `tofu apply` and verify the `argocd-server` deployment image in the cluster.

