### PR TITLE
refactor(mcp): validate pod and network tool inputs

### DIFF
--- a/internal/mcp/tools/network/network.go
+++ b/internal/mcp/tools/network/network.go
@@ -1,6 +1,18 @@
 package network
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	toolvalidation "observability-hub/internal/mcp/tools"
+)
+
+const (
+	maxFlowsLast       = 100
+	maxHTTPPathLength  = 256
+	maxHTTPStatusToken = 16
+	maxNetworkTokenLen = 32
+)
 
 // ObserveNetworkFlowsInput is the input for the observe_network_flows tool.
 type ObserveNetworkFlowsInput struct {
@@ -42,6 +54,9 @@ func NewObserveNetworkFlowsHandler(fn func(ctx context.Context, namespace, pod, 
 }
 
 func (h *ObserveNetworkFlowsHandler) Execute(ctx context.Context, input ObserveNetworkFlowsInput) (interface{}, error) {
+	if err := validateObserveNetworkFlowsInput(input); err != nil {
+		return nil, err
+	}
 	return h.queryFn(ctx,
 		input.Namespace,
 		input.Pod,
@@ -57,4 +72,47 @@ func (h *ObserveNetworkFlowsHandler) Execute(ctx context.Context, input ObserveN
 		input.ToPort,
 		input.Last,
 	)
+}
+
+func validateObserveNetworkFlowsInput(input ObserveNetworkFlowsInput) error {
+	if err := toolvalidation.OptionalDNS1123Label("namespace", input.Namespace); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalPodRef("pod", input.Pod); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalPodRef("from_pod", input.FromPod); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalPodRef("to_pod", input.ToPod); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalSafeToken("protocol", input.Protocol, maxNetworkTokenLen); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalSafeToken("verdict", input.Verdict, maxNetworkTokenLen); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalSafeToken("http_status", input.HTTPStatus, maxHTTPStatusToken); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalSafeToken("http_method", input.HTTPMethod, maxNetworkTokenLen); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalTextFilter("http_path", input.HTTPPath, maxHTTPPathLength); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalSafeToken("reserved", input.Reserved, maxNetworkTokenLen); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalPort("port", input.Port); err != nil {
+		return err
+	}
+	if err := toolvalidation.OptionalPort("to_port", input.ToPort); err != nil {
+		return err
+	}
+	if input.Last < 0 || input.Last > maxFlowsLast {
+		return fmt.Errorf("last must be between 0 and %d", maxFlowsLast)
+	}
+	return nil
 }

--- a/internal/mcp/tools/network/network_test.go
+++ b/internal/mcp/tools/network/network_test.go
@@ -41,6 +41,41 @@ func TestObserveNetworkFlowsHandler_Execute(t *testing.T) {
 			mockErr: errors.New("hubble unreachable"),
 			wantErr: true,
 		},
+		{
+			name: "Invalid Namespace",
+			input: ObserveNetworkFlowsInput{
+				Namespace: "Bad Namespace",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Pod Reference",
+			input: ObserveNetworkFlowsInput{
+				FromPod: "default/frontend/extra",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Port",
+			input: ObserveNetworkFlowsInput{
+				Port: 70000,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Last",
+			input: ObserveNetworkFlowsInput{
+				Last: 101,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid HTTP Path",
+			input: ObserveNetworkFlowsInput{
+				HTTPPath: "/api\nv1",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/mcp/tools/pods/pods.go
+++ b/internal/mcp/tools/pods/pods.go
@@ -2,8 +2,16 @@ package pods
 
 import (
 	"context"
+	"fmt"
+
+	toolvalidation "observability-hub/internal/mcp/tools"
 
 	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	maxLogTailLines       int64 = 1000
+	maxDeleteGraceSeconds int64 = 3600
 )
 
 // PodsInput is the common input for pod-related tools.
@@ -31,6 +39,10 @@ func NewInspectPodsHandler(listFn func(ctx context.Context, namespace string) (*
 }
 
 func (h *InspectPodsHandler) Execute(ctx context.Context, input PodsInput) (interface{}, error) {
+	if err := toolvalidation.OptionalDNS1123Label("namespace", input.Namespace); err != nil {
+		return nil, err
+	}
+
 	pods, err := h.listFn(ctx, input.Namespace)
 	if err != nil {
 		return nil, err
@@ -60,6 +72,9 @@ func NewDescribePodHandler(getFn func(ctx context.Context, namespace, name strin
 }
 
 func (h *DescribePodHandler) Execute(ctx context.Context, input PodsInput) (interface{}, error) {
+	if err := validatePodTarget(input.Namespace, input.Name); err != nil {
+		return nil, err
+	}
 	return h.getFn(ctx, input.Namespace, input.Name)
 }
 
@@ -73,6 +88,9 @@ func NewListPodEventsHandler(listEventsFn func(ctx context.Context, namespace, n
 }
 
 func (h *ListPodEventsHandler) Execute(ctx context.Context, input PodsInput) (interface{}, error) {
+	if err := validatePodTarget(input.Namespace, input.Name); err != nil {
+		return nil, err
+	}
 	return h.listEventsFn(ctx, input.Namespace, input.Name)
 }
 
@@ -95,6 +113,15 @@ func NewGetPodLogsHandler(getLogsFn func(ctx context.Context, namespace, name, c
 }
 
 func (h *GetPodLogsHandler) Execute(ctx context.Context, input PodLogsInput) (interface{}, error) {
+	if err := validatePodTarget(input.Namespace, input.Name); err != nil {
+		return nil, err
+	}
+	if err := toolvalidation.OptionalDNS1123Label("container", input.Container); err != nil {
+		return nil, err
+	}
+	if input.TailLines < 0 || input.TailLines > maxLogTailLines {
+		return nil, fmt.Errorf("tail_lines must be between 0 and %d", maxLogTailLines)
+	}
 	return h.getLogsFn(ctx, input.Namespace, input.Name, input.Container, input.TailLines, input.Previous)
 }
 
@@ -115,9 +142,26 @@ func NewDeletePodHandler(deleteFn func(ctx context.Context, namespace, name stri
 }
 
 func (h *DeletePodHandler) Execute(ctx context.Context, input DeletePodInput) (interface{}, error) {
+	if err := validatePodTarget(input.Namespace, input.Name); err != nil {
+		return nil, err
+	}
+	if input.GraceSeconds != nil && (*input.GraceSeconds < 0 || *input.GraceSeconds > maxDeleteGraceSeconds) {
+		return nil, fmt.Errorf("grace_seconds must be between 0 and %d", maxDeleteGraceSeconds)
+	}
+
 	err := h.deleteFn(ctx, input.Namespace, input.Name, input.GraceSeconds)
 	if err != nil {
 		return nil, err
 	}
 	return map[string]string{"status": "deleted", "pod": input.Name, "namespace": input.Namespace}, nil
+}
+
+func validatePodTarget(namespace, name string) error {
+	if err := toolvalidation.DNS1123Label("namespace", namespace); err != nil {
+		return err
+	}
+	if err := toolvalidation.DNS1123Subdomain("name", name); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/mcp/tools/pods/pods_test.go
+++ b/internal/mcp/tools/pods/pods_test.go
@@ -73,21 +73,36 @@ func TestInspectPodsHandler_Execute(t *testing.T) {
 func TestDescribePodHandler_Execute(t *testing.T) {
 	tests := []struct {
 		name    string
+		input   PodsInput
 		getFn   func(ctx context.Context, namespace, name string) (*corev1.Pod, error)
 		wantErr bool
 	}{
 		{
-			name: "successful get",
+			name:  "successful get",
+			input: PodsInput{Namespace: "default", Name: "test-pod"},
 			getFn: func(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
 				return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}}, nil
 			},
 			wantErr: false,
 		},
 		{
-			name: "not found error",
+			name:  "not found error",
+			input: PodsInput{Namespace: "default", Name: "test-pod"},
 			getFn: func(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
 				return nil, errors.New("not found")
 			},
+			wantErr: true,
+		},
+		{
+			name:    "missing namespace",
+			input:   PodsInput{Name: "test-pod"},
+			getFn:   func(ctx context.Context, namespace, name string) (*corev1.Pod, error) { return nil, nil },
+			wantErr: true,
+		},
+		{
+			name:    "invalid pod name",
+			input:   PodsInput{Namespace: "default", Name: "Bad Pod"},
+			getFn:   func(ctx context.Context, namespace, name string) (*corev1.Pod, error) { return nil, nil },
 			wantErr: true,
 		},
 	}
@@ -95,7 +110,7 @@ func TestDescribePodHandler_Execute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewDescribePodHandler(tt.getFn)
-			_, err := h.Execute(context.Background(), PodsInput{Namespace: "default", Name: "test-pod"})
+			_, err := h.Execute(context.Background(), tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -139,20 +154,47 @@ func TestListPodEventsHandler_Execute(t *testing.T) {
 func TestGetPodLogsHandler_Execute(t *testing.T) {
 	tests := []struct {
 		name      string
+		input     PodLogsInput
 		getLogsFn func(ctx context.Context, namespace, name, container string, tailLines int64, previous bool) (string, error)
 		wantErr   bool
 	}{
 		{
-			name: "successful logs get",
+			name:  "successful logs get",
+			input: PodLogsInput{Namespace: "default", Name: "test-pod"},
 			getLogsFn: func(ctx context.Context, namespace, name, container string, tailLines int64, previous bool) (string, error) {
 				return "logs", nil
 			},
 			wantErr: false,
 		},
 		{
-			name: "api error",
+			name:  "api error",
+			input: PodLogsInput{Namespace: "default", Name: "test-pod"},
 			getLogsFn: func(ctx context.Context, namespace, name, container string, tailLines int64, previous bool) (string, error) {
 				return "", errors.New("api error")
+			},
+			wantErr: true,
+		},
+		{
+			name:  "negative tail lines",
+			input: PodLogsInput{Namespace: "default", Name: "test-pod", TailLines: -1},
+			getLogsFn: func(ctx context.Context, namespace, name, container string, tailLines int64, previous bool) (string, error) {
+				return "", nil
+			},
+			wantErr: true,
+		},
+		{
+			name:  "tail lines over limit",
+			input: PodLogsInput{Namespace: "default", Name: "test-pod", TailLines: 1001},
+			getLogsFn: func(ctx context.Context, namespace, name, container string, tailLines int64, previous bool) (string, error) {
+				return "", nil
+			},
+			wantErr: true,
+		},
+		{
+			name:  "invalid container",
+			input: PodLogsInput{Namespace: "default", Name: "test-pod", Container: "bad/container"},
+			getLogsFn: func(ctx context.Context, namespace, name, container string, tailLines int64, previous bool) (string, error) {
+				return "", nil
 			},
 			wantErr: true,
 		},
@@ -161,7 +203,7 @@ func TestGetPodLogsHandler_Execute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewGetPodLogsHandler(tt.getLogsFn)
-			got, err := h.Execute(context.Background(), PodLogsInput{Namespace: "default", Name: "test-pod"})
+			got, err := h.Execute(context.Background(), tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -174,31 +216,49 @@ func TestGetPodLogsHandler_Execute(t *testing.T) {
 }
 
 func TestDeletePodHandler_Execute(t *testing.T) {
+	negativeGraceSeconds := int64(-1)
+	tooLongGraceSeconds := int64(3601)
+
 	tests := []struct {
 		name     string
+		input    DeletePodInput
 		deleteFn func(ctx context.Context, namespace, name string, gracePeriod *int64) error
 		wantErr  bool
 	}{
 		{
-			name: "successful delete",
+			name:  "successful delete",
+			input: DeletePodInput{Namespace: "default", Name: "test-pod"},
 			deleteFn: func(ctx context.Context, namespace, name string, gracePeriod *int64) error {
 				return nil
 			},
 			wantErr: false,
 		},
 		{
-			name: "api error",
+			name:  "api error",
+			input: DeletePodInput{Namespace: "default", Name: "test-pod"},
 			deleteFn: func(ctx context.Context, namespace, name string, gracePeriod *int64) error {
 				return errors.New("api error")
 			},
 			wantErr: true,
+		},
+		{
+			name:     "negative grace seconds",
+			input:    DeletePodInput{Namespace: "default", Name: "test-pod", GraceSeconds: &negativeGraceSeconds},
+			deleteFn: func(ctx context.Context, namespace, name string, gracePeriod *int64) error { return nil },
+			wantErr:  true,
+		},
+		{
+			name:     "grace seconds over limit",
+			input:    DeletePodInput{Namespace: "default", Name: "test-pod", GraceSeconds: &tooLongGraceSeconds},
+			deleteFn: func(ctx context.Context, namespace, name string, gracePeriod *int64) error { return nil },
+			wantErr:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewDeletePodHandler(tt.deleteFn)
-			_, err := h.Execute(context.Background(), DeletePodInput{Namespace: "default", Name: "test-pod"})
+			_, err := h.Execute(context.Background(), tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/mcp/tools/validation.go
+++ b/internal/mcp/tools/validation.go
@@ -1,0 +1,107 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+// OptionalDNS1123Label validates optional Kubernetes label-style identifiers
+// such as namespaces and container names.
+func OptionalDNS1123Label(field, value string) error {
+	if value == "" {
+		return nil
+	}
+	return DNS1123Label(field, value)
+}
+
+// DNS1123Label validates required Kubernetes label-style identifiers.
+func DNS1123Label(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if errs := k8svalidation.IsDNS1123Label(value); len(errs) > 0 {
+		return fmt.Errorf("%s is invalid: %s", field, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// DNS1123Subdomain validates required Kubernetes subdomain-style identifiers
+// such as pod names.
+func DNS1123Subdomain(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if errs := k8svalidation.IsDNS1123Subdomain(value); len(errs) > 0 {
+		return fmt.Errorf("%s is invalid: %s", field, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// OptionalPodRef validates optional pod references accepted by Hubble:
+// either pod-name or namespace/pod-name.
+func OptionalPodRef(field, value string) error {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, "/")
+	switch len(parts) {
+	case 1:
+		return DNS1123Subdomain(field, parts[0])
+	case 2:
+		if err := DNS1123Label(field+" namespace", parts[0]); err != nil {
+			return err
+		}
+		return DNS1123Subdomain(field+" pod", parts[1])
+	default:
+		return fmt.Errorf("%s must be pod-name or namespace/pod-name", field)
+	}
+}
+
+// OptionalSafeToken validates a short CLI filter token. It intentionally allows
+// only characters commonly used in protocol, verdict, method, and entity names.
+func OptionalSafeToken(field, value string, maxLen int) error {
+	if value == "" {
+		return nil
+	}
+	if len(value) > maxLen {
+		return fmt.Errorf("%s must be %d characters or fewer", field, maxLen)
+	}
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '+' {
+			continue
+		}
+		return fmt.Errorf("%s contains unsupported character %q", field, r)
+	}
+	return nil
+}
+
+// OptionalTextFilter rejects control characters and caps unstructured filter
+// strings that are passed as a single process argument.
+func OptionalTextFilter(field, value string, maxLen int) error {
+	if value == "" {
+		return nil
+	}
+	if len(value) > maxLen {
+		return fmt.Errorf("%s must be %d characters or fewer", field, maxLen)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%s contains control character %q", field, r)
+		}
+	}
+	return nil
+}
+
+// OptionalPort validates optional TCP/UDP port filters.
+func OptionalPort(field string, value int) error {
+	if value == 0 {
+		return nil
+	}
+	if value < 1 || value > 65535 {
+		return fmt.Errorf("%s must be between 1 and 65535", field)
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary

This change adds a shared validation layer for MCP tool inputs before pod and network requests reach Kubernetes or Hubble. It improves operator safety by rejecting malformed identifiers, unsafe numeric ranges, and invalid filter strings at the tool boundary.

### List of Changes

- Centralized reusable MCP validation helpers for Kubernetes names, Hubble pod references, ports, bounded result limits, and safe string filters.
- Hardened pod and network tools so destructive or command-backed operations fail early with clear validation errors.
- Expanded tool tests to cover invalid pod targets, log and delete bounds, network pod references, ports, result limits, and HTTP path filters.

### Verification

- [x] `go test ./internal/mcp/...` passes
- [x] `make test` passes

