### PR TITLE
refactor(mcp): centralize command execution

### DIFF
--- a/internal/mcp/command/command.go
+++ b/internal/mcp/command/command.go
@@ -1,0 +1,133 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"observability-hub/internal/telemetry"
+)
+
+const DefaultTimeout = 10 * time.Second
+
+// Request describes one external command invocation.
+type Request struct {
+	Name    string
+	Args    []string
+	Stdin   []byte
+	Timeout time.Duration
+}
+
+// Result contains captured process output and execution metadata.
+type Result struct {
+	Stdout   []byte
+	Stderr   []byte
+	Duration time.Duration
+}
+
+// Runner executes external commands.
+type Runner interface {
+	Run(ctx context.Context, req Request) (Result, error)
+}
+
+// Executor is the production command boundary for MCP tools.
+type Executor struct {
+	allowed        map[string]struct{}
+	defaultTimeout time.Duration
+}
+
+// NewExecutor creates an Executor with an explicit binary allowlist.
+func NewExecutor(allowed []string) *Executor {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, name := range allowed {
+		allowedSet[name] = struct{}{}
+	}
+	return &Executor{
+		allowed:        allowedSet,
+		defaultTimeout: DefaultTimeout,
+	}
+}
+
+// Run executes the requested command with timeout, captured output, and typed errors.
+func (e *Executor) Run(ctx context.Context, req Request) (Result, error) {
+	if req.Name == "" {
+		return Result{}, fmt.Errorf("command name is required")
+	}
+	if _, ok := e.allowed[req.Name]; !ok {
+		return Result{}, fmt.Errorf("command %q is not allowed", req.Name)
+	}
+
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = e.defaultTimeout
+	}
+
+	childCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	cmd := exec.CommandContext(childCtx, req.Name, req.Args...)
+	if req.Stdin != nil {
+		cmd.Stdin = bytes.NewReader(req.Stdin)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	duration := time.Since(start)
+	result := Result{
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		Duration: duration,
+	}
+	if err == nil {
+		telemetry.Info("mcp command executed", "command", req.Name, "duration_ms", duration.Milliseconds())
+		return result, nil
+	}
+
+	commandErr := &Error{
+		Name:     req.Name,
+		Args:     append([]string(nil), req.Args...),
+		Stderr:   stderr.String(),
+		Err:      err,
+		Duration: duration,
+		TimedOut: childCtx.Err() == context.DeadlineExceeded,
+	}
+	telemetry.Error(
+		"mcp command failed",
+		"command", req.Name,
+		"duration_ms", duration.Milliseconds(),
+		"timed_out", commandErr.TimedOut,
+		"error", err,
+	)
+	return result, commandErr
+}
+
+// Error is a structured external command failure.
+type Error struct {
+	Name     string
+	Args     []string
+	Stderr   string
+	Err      error
+	Duration time.Duration
+	TimedOut bool
+}
+
+func (e *Error) Error() string {
+	if e.TimedOut {
+		return fmt.Sprintf("command %q timed out after %s: %v", e.Name, e.Duration.Round(time.Millisecond), e.Err)
+	}
+	if e.Stderr != "" {
+		return fmt.Sprintf("command %q failed: %v: %s", e.Name, e.Err, e.Stderr)
+	}
+	return fmt.Sprintf("command %q failed: %v", e.Name, e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}

--- a/internal/mcp/command/command_test.go
+++ b/internal/mcp/command/command_test.go
@@ -1,0 +1,45 @@
+package command
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecutor_RejectsDisallowedCommand(t *testing.T) {
+	executor := NewExecutor([]string{"kubectl"})
+
+	_, err := executor.Run(context.Background(), Request{Name: "sh"})
+	if err == nil {
+		t.Fatal("expected disallowed command error")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("got %q, want not allowed error", err.Error())
+	}
+}
+
+func TestError_ErrorIncludesTimeout(t *testing.T) {
+	err := &Error{
+		Name:     "kubectl",
+		Err:      context.DeadlineExceeded,
+		Duration: 10 * time.Millisecond,
+		TimedOut: true,
+	}
+
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("got %q, want timeout context", err.Error())
+	}
+}
+
+func TestError_ErrorIncludesStderr(t *testing.T) {
+	err := &Error{
+		Name:   "kubectl",
+		Err:    context.Canceled,
+		Stderr: "permission denied",
+	}
+
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("got %q, want stderr context", err.Error())
+	}
+}

--- a/internal/mcp/providers/network.go
+++ b/internal/mcp/providers/network.go
@@ -3,33 +3,20 @@ package providers
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 
+	mcpcommand "observability-hub/internal/mcp/command"
 	"observability-hub/internal/telemetry"
 )
 
-// CommandRunner defines the interface for executing external commands.
-type CommandRunner interface {
-	Run(ctx context.Context, name string, arg ...string) ([]byte, error)
-}
-
-// RealCommandRunner is the production command runner.
-type RealCommandRunner struct{}
-
-func (r *RealCommandRunner) Run(ctx context.Context, name string, arg ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, arg...)
-	return cmd.CombinedOutput()
-}
-
 // NetworkProvider provides network observability tools backed by Cilium Hubble.
 type NetworkProvider struct {
-	runner CommandRunner
+	runner mcpcommand.Runner
 }
 
 // NewNetworkProvider creates a NetworkProvider.
 func NewNetworkProvider() *NetworkProvider {
-	return &NetworkProvider{runner: &RealCommandRunner{}}
+	return &NetworkProvider{runner: mcpcommand.NewExecutor([]string{"kubectl"})}
 }
 
 // QueryHubbleFlows retrieves real-time flow data from Hubble Relay.
@@ -84,13 +71,14 @@ func (p *NetworkProvider) QueryHubbleFlows(ctx context.Context, namespace, pod, 
 	args := []string{"-n", "kube-system", "exec", "ds/cilium", "--", "hubble", "--server", "unix:///var/run/cilium/hubble.sock"}
 	args = append(args, hubbleArgs...)
 
-	out, err := p.runner.Run(ctx, "kubectl", args...)
+	result, err := p.runner.Run(ctx, mcpcommand.Request{Name: "kubectl", Args: args})
 	if err != nil {
-		telemetry.Error("hubble observe via kubectl failed", "error", err, "output", string(out))
+		output := string(result.Stdout) + string(result.Stderr)
+		telemetry.Error("hubble observe via kubectl failed", "error", err, "output", output)
 		return "", fmt.Errorf("hubble observe failed: %w", err)
 	}
 
-	lines := strings.Split(string(out), "\n")
+	lines := strings.Split(string(result.Stdout), "\n")
 	cleaned := make([]string, 0, len(lines))
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)

--- a/internal/mcp/providers/network_test.go
+++ b/internal/mcp/providers/network_test.go
@@ -6,18 +6,20 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	mcpcommand "observability-hub/internal/mcp/command"
 )
 
-// MockCommandRunner satisfies the CommandRunner interface for testing.
+// MockCommandRunner satisfies the command runner interface for testing.
 type MockCommandRunner struct {
-	RunFn func(ctx context.Context, name string, arg ...string) ([]byte, error)
+	RunFn func(ctx context.Context, req mcpcommand.Request) (mcpcommand.Result, error)
 }
 
-func (m *MockCommandRunner) Run(ctx context.Context, name string, arg ...string) ([]byte, error) {
+func (m *MockCommandRunner) Run(ctx context.Context, req mcpcommand.Request) (mcpcommand.Result, error) {
 	if m.RunFn != nil {
-		return m.RunFn(ctx, name, arg...)
+		return m.RunFn(ctx, req)
 	}
-	return nil, nil
+	return mcpcommand.Result{}, nil
 }
 
 func TestNetworkProvider_QueryHubbleFlows(t *testing.T) {
@@ -82,14 +84,14 @@ func TestNetworkProvider_QueryHubbleFlows(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &MockCommandRunner{
-				RunFn: func(ctx context.Context, name string, arg ...string) ([]byte, error) {
-					if name != "kubectl" {
-						t.Errorf("expected kubectl command, got %s", name)
+				RunFn: func(ctx context.Context, req mcpcommand.Request) (mcpcommand.Result, error) {
+					if req.Name != "kubectl" {
+						t.Errorf("expected kubectl command, got %s", req.Name)
 					}
-					if tt.wantArgs != nil && !reflect.DeepEqual(arg, tt.wantArgs) {
-						t.Errorf("got args %v, want %v", arg, tt.wantArgs)
+					if tt.wantArgs != nil && !reflect.DeepEqual(req.Args, tt.wantArgs) {
+						t.Errorf("got args %v, want %v", req.Args, tt.wantArgs)
 					}
-					return []byte(tt.mockOutput), tt.mockErr
+					return mcpcommand.Result{Stdout: []byte(tt.mockOutput)}, tt.mockErr
 				},
 			}
 			p := &NetworkProvider{runner: mock}

--- a/internal/mcp/tools/telemetry/queries.go
+++ b/internal/mcp/tools/telemetry/queries.go
@@ -1,15 +1,14 @@
 package telemetry
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
+	mcpcommand "observability-hub/internal/mcp/command"
 	libtelemetry "observability-hub/internal/telemetry"
 )
 
@@ -35,6 +34,7 @@ type QueryMetricsInput struct {
 type QueryMetricsHandler struct {
 	queryFunc     func(ctx context.Context, query string) (interface{}, error)
 	processorPath string
+	runner        mcpcommand.Runner
 }
 
 // NewQueryMetricsHandler creates a new query metrics handler.
@@ -42,6 +42,7 @@ func NewQueryMetricsHandler(queryFunc func(ctx context.Context, query string) (i
 	return &QueryMetricsHandler{
 		queryFunc:     queryFunc,
 		processorPath: "/usr/local/bin/obs-processor",
+		runner:        mcpcommand.NewExecutor([]string{"/usr/local/bin/obs-processor"}),
 	}
 }
 
@@ -79,22 +80,18 @@ func (h *QueryMetricsHandler) summarizeMetrics(ctx context.Context, raw interfac
 		return nil, fmt.Errorf("failed to marshal raw metrics: %w", err)
 	}
 
-	// Create command with 5s timeout to prevent hanging the MCP server
-	childCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(childCtx, h.processorPath, "--type", "metrics")
-	cmd.Stdin = bytes.NewReader(rawJSON)
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	if err := cmd.Run(); err != nil {
+	result, err := h.runner.Run(ctx, mcpcommand.Request{
+		Name:    h.processorPath,
+		Args:    []string{"--type", "metrics"},
+		Stdin:   rawJSON,
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
 		return nil, fmt.Errorf("rust processor execution failed: %w", err)
 	}
 
 	var summarized interface{}
-	if err := json.Unmarshal(out.Bytes(), &summarized); err != nil {
+	if err := json.Unmarshal(result.Stdout, &summarized); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal summarized metrics: %w", err)
 	}
 
@@ -138,6 +135,7 @@ type QueryLogsInput struct {
 type QueryLogsHandler struct {
 	queryFunc        func(ctx context.Context, query string, limit int, hours int) (interface{}, error)
 	logProcessorPath string
+	runner           mcpcommand.Runner
 }
 
 // NewQueryLogsHandler creates a new query logs handler.
@@ -145,6 +143,7 @@ func NewQueryLogsHandler(queryFunc func(ctx context.Context, query string, limit
 	return &QueryLogsHandler{
 		queryFunc:        queryFunc,
 		logProcessorPath: "/usr/local/bin/obs-processor",
+		runner:           mcpcommand.NewExecutor([]string{"/usr/local/bin/obs-processor"}),
 	}
 }
 
@@ -180,22 +179,18 @@ func (h *QueryLogsHandler) summarizeLogs(ctx context.Context, raw interface{}) (
 		return nil, fmt.Errorf("failed to marshal raw logs: %w", err)
 	}
 
-	// Create command with 5s timeout to prevent hanging the MCP server
-	childCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(childCtx, h.logProcessorPath, "--type", "logs")
-	cmd.Stdin = bytes.NewReader(rawJSON)
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	if err := cmd.Run(); err != nil {
+	result, err := h.runner.Run(ctx, mcpcommand.Request{
+		Name:    h.logProcessorPath,
+		Args:    []string{"--type", "logs"},
+		Stdin:   rawJSON,
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
 		return nil, fmt.Errorf("rust processor execution failed: %w", err)
 	}
 
 	var summarized interface{}
-	if err := json.Unmarshal(out.Bytes(), &summarized); err != nil {
+	if err := json.Unmarshal(result.Stdout, &summarized); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal summarized logs: %w", err)
 	}
 

--- a/internal/mcp/tools/telemetry/queries_test.go
+++ b/internal/mcp/tools/telemetry/queries_test.go
@@ -4,7 +4,18 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
+
+	mcpcommand "observability-hub/internal/mcp/command"
 )
+
+type mockCommandRunner struct {
+	runFn func(ctx context.Context, req mcpcommand.Request) (mcpcommand.Result, error)
+}
+
+func (m mockCommandRunner) Run(ctx context.Context, req mcpcommand.Request) (mcpcommand.Result, error) {
+	return m.runFn(ctx, req)
+}
 
 func TestQueryMetricsHandler_Execute(t *testing.T) {
 	mockQuery := func(ctx context.Context, query string) (interface{}, error) {
@@ -92,6 +103,41 @@ func TestQueryMetricsHandler_Execute(t *testing.T) {
 	}
 }
 
+func TestQueryMetricsHandler_ExecuteSummarizesWithCommandRunner(t *testing.T) {
+	mockQuery := func(ctx context.Context, query string) (interface{}, error) {
+		return map[string]interface{}{"status": "success"}, nil
+	}
+
+	handler := NewQueryMetricsHandler(mockQuery)
+	handler.runner = mockCommandRunner{
+		runFn: func(ctx context.Context, req mcpcommand.Request) (mcpcommand.Result, error) {
+			if req.Name != "/usr/local/bin/obs-processor" {
+				t.Fatalf("got command %q, want obs-processor", req.Name)
+			}
+			if strings.Join(req.Args, " ") != "--type metrics" {
+				t.Fatalf("got args %v, want metrics processor args", req.Args)
+			}
+			if len(req.Stdin) == 0 {
+				t.Fatal("expected raw query result on stdin")
+			}
+			if req.Timeout != 5*time.Second {
+				t.Fatalf("got timeout %s, want 5s", req.Timeout)
+			}
+			return mcpcommand.Result{Stdout: []byte(`{"summarized_count":1}`)}, nil
+		},
+	}
+
+	result, err := handler.Execute(context.Background(), QueryMetricsInput{Query: "up"})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	summarized := result.(map[string]interface{})
+	if summarized["summarized_count"].(float64) != 1 {
+		t.Fatalf("got %v, want summarized result", summarized)
+	}
+}
+
 func TestQueryLogsHandler_Execute(t *testing.T) {
 	mockQuery := func(ctx context.Context, query string, limit int, hours int) (interface{}, error) {
 		return map[string]interface{}{"streams": []interface{}{}}, nil
@@ -163,6 +209,41 @@ func TestQueryLogsHandler_Execute(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestQueryLogsHandler_ExecuteSummarizesWithCommandRunner(t *testing.T) {
+	mockQuery := func(ctx context.Context, query string, limit int, hours int) (interface{}, error) {
+		return map[string]interface{}{"streams": []interface{}{}}, nil
+	}
+
+	handler := NewQueryLogsHandler(mockQuery)
+	handler.runner = mockCommandRunner{
+		runFn: func(ctx context.Context, req mcpcommand.Request) (mcpcommand.Result, error) {
+			if req.Name != "/usr/local/bin/obs-processor" {
+				t.Fatalf("got command %q, want obs-processor", req.Name)
+			}
+			if strings.Join(req.Args, " ") != "--type logs" {
+				t.Fatalf("got args %v, want logs processor args", req.Args)
+			}
+			if len(req.Stdin) == 0 {
+				t.Fatal("expected raw query result on stdin")
+			}
+			if req.Timeout != 5*time.Second {
+				t.Fatalf("got timeout %s, want 5s", req.Timeout)
+			}
+			return mcpcommand.Result{Stdout: []byte(`{"summarized_count":1}`)}, nil
+		},
+	}
+
+	result, err := handler.Execute(context.Background(), QueryLogsInput{Query: `{service="proxy"}`})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	summarized := result.(map[string]interface{})
+	if summarized["summarized_count"].(float64) != 1 {
+		t.Fatalf("got %v, want summarized result", summarized)
 	}
 }
 


### PR DESCRIPTION
### Summary

This change extracts MCP external command execution into a shared internal boundary. It gives both Hubble network queries and telemetry processor summarization the same command allowlisting, timeout handling, output capture, injectable runner interface, and structured failure reporting.

### List of Changes

- Centralized MCP command execution so shell-backed tools no longer manage process invocation independently.
- Moved Hubble `kubectl` calls and `obs-processor` summarization onto the shared command runner while preserving their existing behavior.
- Added tests for command allowlisting, structured command errors, Hubble command requests, and telemetry processor runner wiring.

### Verification

- [x] `go test ./internal/mcp/...` passes
- [x] `make test` passes

