### PR TITLE
refactor(mcp): add capability accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,14 @@ It proves an end-to-end platform ownership loop: declarative infrastructure runs
 
 ---
 
-## Highlights
+## Case Studies
 
-| Area | What it demonstrates |
-| :--- | :--- |
-| Platform orchestration | Systemd handles host-tier control while Kubernetes runs scalable data services |
-| GitOps delivery | Argo CD reconciles cluster manifests and Proxy webhooks trigger host sync |
-| Observability | OpenTelemetry, Grafana, Loki, Tempo, Prometheus, and Hubble correlate logs, metrics, traces, and network flows |
-| Agent operations | MCP tools expose telemetry queries, pod inspection, network flows, and bounded repair actions |
-| Data durability | CloudNativePG, MinIO, and Azure backup paths support persistent platform state |
-| Security | OpenBao, Trivy checks, Kubernetes security contexts, and Cilium policies reduce secret and workload risk |
-| Operational memory | ADRs, incident reports, notes, workflows, and ownership docs preserve decisions and recovery paths |
+| Case Study | Problem | How it was diagnosed | Result |
+| :--- | :--- | :--- | :--- |
+| [Rust Telemetry Summarization Processor](./docs/decisions/021-rust-telemetry-summarization-processor.md) | Raw logs and metrics returned too much data for agent workflows | Added a Rust `obs-processor` to summarize Loki and Prometheus responses before returning them through MCP | Reduced token load while preserving investigation pivots |
+| [Worker Ingestion Blocked from MongoDB Atlas](./docs/incidents/007-worker-ingestion-atlas-egress-block.md) | Scheduled ingestion could not reach Atlas | Used worker logs and Cilium policy review to identify blocked egress | Added Atlas egress policy and documented prevention |
+| [Loki Gateway DNS Timeout](./docs/incidents/006-loki-gateway-dns-timeout.md) | Grafana and agents could not reliably query logs | Traced the request path through gateway DNS resolution and Loki service routing | Fixed resolver config and added operational checks |
+| [SSH Lockout via Cilium IPAM Collision](./docs/incidents/004-ssh-lockout-cilium-ipam-collision.md) | Host access failed after networking drift | Correlated Cilium/IPAM state, pod readiness, and host reachability | Restored access and documented recovery path |
 
 ---
 

--- a/cmd/mcp-obs-hub/main.go
+++ b/cmd/mcp-obs-hub/main.go
@@ -19,6 +19,13 @@ const (
 	version     = "1.0.0"
 )
 
+var (
+	networkTools    = []string{"observe_network_flows"}
+	podsTools       = []string{"inspect_pods", "describe_pod", "list_pod_events", "get_pod_logs", "delete_pod"}
+	telemetryTools  = []string{"query_metrics", "query_logs", "query_traces", "investigate_incident"}
+	diagnosticTools = []string{"mcp_capabilities"}
+)
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -38,6 +45,7 @@ func main() {
 		Name:    "mcp-obs-hub",
 		Version: version,
 	}, nil)
+	capabilities := internalmcp.NewCapabilityRegistry(version)
 
 	// 3. Sequential Provider Initialization (Soft-Fail Pattern)
 
@@ -45,17 +53,22 @@ func main() {
 	networkProv := providers.NewNetworkProvider()
 	if networkProv != nil {
 		internalmcp.RegisterNetworkTools(server, networkProv, "mcp.network")
-		telemetry.Info("registered network tools")
+		capabilities.AddAvailable("mcp.network", networkTools)
+		telemetry.Info("registered network tools", "count", len(networkTools))
 	} else {
-		telemetry.Warn("mcp_network_init_failed_skipping_tools")
+		reason := "network provider initialization returned nil"
+		capabilities.AddSkipped("mcp.network", reason)
+		telemetry.Warn("mcp_network_init_failed_skipping_tools", "reason", reason)
 	}
 
 	// --- Pods Provider ---
 	if podsProv, err := providers.NewPodsProvider(); err != nil {
+		capabilities.AddSkipped("mcp.pods", err.Error())
 		telemetry.Warn("mcp_pods_init_failed_skipping_tools", "error", err)
 	} else {
 		internalmcp.RegisterPodsTools(server, podsProv, "mcp.pods")
-		telemetry.Info("registered pods tools (mcp.pods)")
+		capabilities.AddAvailable("mcp.pods", podsTools)
+		telemetry.Info("registered pods tools (mcp.pods)", "count", len(podsTools))
 	}
 
 	// --- Telemetry Provider ---
@@ -64,18 +77,34 @@ func main() {
 	tempoURL := os.Getenv("TEMPO_URL")
 
 	if thanosURL == "" || lokiURL == "" || tempoURL == "" {
-		telemetry.Warn("mcp_telemetry_init_failed_missing_env_skipping_tools")
+		reason := "THANOS_URL, LOKI_URL, or TEMPO_URL is missing"
+		capabilities.AddSkipped("mcp.telemetry", reason)
+		telemetry.Warn("mcp_telemetry_init_failed_missing_env_skipping_tools", "reason", reason)
 	} else {
 		telemetryProv := providers.NewTelemetryProvider(thanosURL, lokiURL, tempoURL)
 		if telemetryProv != nil {
 			defer telemetryProv.Close()
 			internalmcp.RegisterTelemetryTools(server, telemetryProv, "mcp.telemetry")
-			telemetry.Info("registered telemetry tools (mcp.telemetry)")
+			capabilities.AddAvailable("mcp.telemetry", telemetryTools)
+			telemetry.Info("registered telemetry tools (mcp.telemetry)", "count", len(telemetryTools))
+		} else {
+			reason := "telemetry provider initialization returned nil"
+			capabilities.AddSkipped("mcp.telemetry", reason)
+			telemetry.Warn("mcp_telemetry_init_failed_skipping_tools", "reason", reason)
 		}
 	}
 
+	capabilities.AddAvailable("mcp.diagnostics", diagnosticTools)
+	internalmcp.RegisterCapabilityTools(server, capabilities, "mcp.diagnostics")
+
 	// 4. Run Server (Stdio transport)
-	telemetry.Info("mcp-obs-hub ready, unified 10 tools available")
+	snapshot := capabilities.Snapshot()
+	telemetry.Info(
+		"mcp-obs-hub ready",
+		"tool_count", snapshot.ToolCount,
+		"domain_count", len(snapshot.Domains),
+		"domains", snapshot.Domains,
+	)
 
 	transport := &mcp.StdioTransport{}
 	if err := server.Run(ctx, transport); err != nil {

--- a/docs/architecture/services/mcp-servers.md
+++ b/docs/architecture/services/mcp-servers.md
@@ -34,22 +34,23 @@ The gateway consolidates capabilities into a single binary (`mcp_obs_hub`) while
 | **Telemetry** | `mcp.telemetry` | **Health Brain**: Bridges the LGTM stack for autonomous observability. | `query_metrics`, `query_logs`, `query_traces`, `investigate_incident` |
 | **Kubernetes**| `mcp.pods` | **Infrastructure Brain**: Provides high-fidelity cluster state for pod and event analysis. | `inspect_pods`, `describe_pod`, `list_pod_events`, `get_pod_logs`, `delete_pod` |
 | **Network**   | `mcp.network` | **Traffic Brain**: Real-time eBPF flow analysis and packet-level auditing. | `observe_network_flows` |
+| **Diagnostics** | `mcp.diagnostics` | **Capability Map**: Reports which MCP domains registered successfully at startup. | `mcp_capabilities` |
 
 ## ⚙️ Architectural Standards
 
 The MCP gateway adheres to a consistent, consolidated architectural standard:
 
 - **Protocol**: Model Context Protocol (MCP) over Stdio for seamless integration with local agent runtimes.
-- **Fat Binary Architecture**: Multi-domain logic is collapsed into a single high-performance binary to minimize management overhead and streamline the build/deploy pipeline.
-- **Soft-Fail Initialization**: Providers initialize sequentially; the gateway remains operational even if specific backends (e.g., a specific database or cluster API) are temporarily unreachable.
+- **Unified Gateway Architecture**: Multi-domain logic is consolidated into a single binary per [ADR 026](../../decisions/026-unified-mcp-gateway-with-capability-accounting.md), with domain isolation maintained through provider and tool package boundaries.
+- **Soft-Fail Initialization**: Providers initialize sequentially; the gateway remains operational even if specific backends (e.g., a specific database or cluster API) are temporarily unreachable. Startup logs and `mcp_capabilities` report the actual available domains and skipped-provider reasons.
 - **Guided Investigation**: Every tool metadata includes a direct link to a domain-specific `SKILL.md`. This ensures agents follow local "Standard Operating Procedures" (SOPs) rather than speculative missions.
 - **Unified Instrumentation**: The gateway is instrumented with the platform's Go SDK, emitting logs, metrics, and traces via OTLP to the central OpenTelemetry Collector using the `mcp.service` attribute as a domain discriminator.
 - **Decoupled Logic**: Tool handlers are decoupled into `internal/mcp/tools`, while domain access is abstracted into `internal/mcp/providers`, ensuring clean architectural boundaries.
 
 ## 🔭 Logic & Data Flow
 
-1. **Initialization**: The gateway initializes the OTel SDK and sequentially registers the Network, Pods, and Telemetry providers.
-2. **Registration**: 10 specialized tools are registered with the MCP SDK, defining strict JSON schemas for intent-based inputs.
+1. **Initialization**: The gateway initializes the OTel SDK and sequentially registers the Network, Pods, Telemetry, and Diagnostics providers.
+2. **Registration**: Available provider tools are registered with the MCP SDK, defining strict JSON schemas for intent-based inputs. The final tool count is computed from actual registered capabilities.
 3. **Execution**: When an agent invokes a tool, the gateway routes the request to the appropriate provider, captures results, and returns structured content.
 4. **Tracing**: Every tool invocation generates a trace span, correlating the agent's intent with the underlying system operations (e.g., `mcp.tool.query_metrics`).
 

--- a/docs/decisions/018-domain-isolated-mcp-architecture.md
+++ b/docs/decisions/018-domain-isolated-mcp-architecture.md
@@ -1,6 +1,6 @@
 # ADR 018: Domain-Isolated MCP Architecture
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR 026](./026-unified-mcp-gateway-with-capability-accounting.md)
 - **Date:** 2026-03-11
 - **Author:** Victoria Cheng
 

--- a/docs/decisions/026-unified-mcp-gateway-with-capability-accounting.md
+++ b/docs/decisions/026-unified-mcp-gateway-with-capability-accounting.md
@@ -1,0 +1,45 @@
+# ADR 026: Unified MCP Gateway With Capability Accounting
+
+- **Status:** Accepted
+- **Date:** 2026-04-27
+- **Author:** Victoria Cheng
+
+## Context and Problem Statement
+
+ADR 018 selected domain-isolated MCP binaries to reduce blast radius between telemetry, Kubernetes, and remediation capabilities. The implementation has since moved toward a unified MCP gateway because the active surface area is now limited to telemetry, pods, and network flows, while stale host and platform tools have been removed.
+
+The old decision no longer matched the running architecture. The gateway also used a static startup message for tool count, which made soft-failed providers hard to diagnose when Kubernetes configuration or telemetry environment variables were missing.
+
+## Decision Outcome
+
+Adopt a unified MCP gateway binary for the active operational domains, with provider-level isolation and runtime capability accounting as the compensating controls.
+
+- **Unified Binary:** `cmd/mcp-obs-hub` remains the single entry point for telemetry, pods, network, and diagnostic MCP tools.
+- **Provider Boundaries:** Domain behavior stays isolated behind `internal/mcp/providers` and `internal/mcp/tools` packages.
+- **Soft-Fail Visibility:** Startup records each domain as available or skipped, including skipped reasons.
+- **Diagnostic Capability:** The gateway exposes `mcp_capabilities` so agents can inspect active tools and missing providers before attempting a workflow.
+- **Reduced Blast Radius:** Host/platform MCP tools remain removed from the active gateway surface.
+
+This ADR supersedes ADR 018 for the current MCP gateway deployment model. The split-binary approach remains a valid future option if host-level tools or materially broader permissions return.
+
+## Consequences
+
+### Positive
+
+- **Simpler Operations:** Agents and local runtimes configure one MCP server instead of several domain-specific binaries.
+- **Clearer Failures:** Provider startup failures are visible in logs and through `mcp_capabilities`.
+- **Maintained Boundaries:** Provider and tool package boundaries preserve logical isolation inside the unified process.
+- **Lower Tool Noise:** Removed host/platform tools keep the active gateway focused on telemetry, pods, and network flows.
+
+### Negative
+
+- **Shared Process Risk:** A single binary still shares one process boundary across multiple domains.
+- **RBAC Discipline Required:** Kubernetes permissions must remain scoped to the active pod and network workflows.
+- **Future Review Needed:** Reintroducing host-level actions should trigger a new ADR or a return to domain-isolated binaries.
+
+## Verification
+
+- [x] **ADR Reconciliation:** ADR 026 documents the unified gateway decision and supersedes ADR 018.
+- [x] **Capability Accounting:** Startup records available and skipped MCP domains with actual tool counts.
+- [x] **Diagnostic Tool:** `mcp_capabilities` reports the same capability state exposed in startup logs.
+- [x] **Automated Tests:** `go test ./internal/mcp/...` passes.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 
 | ADR | Title | Status |
 | :--- | :--- | :--- |
+| **026** | [Unified MCP Gateway With Capability Accounting](./026-unified-mcp-gateway-with-capability-accounting.md) | 🔵 Accepted |
 | **025** | [Decouple Hardware Simulation](./025-decouple-hardware-simulation.md) | 🔵 Accepted |
 | **024** | [Trivy-Verified Workload Hardening](./024-trivy-verified-workload-hardening.md) | 🔵 Accepted |
 | **023** | [Benchmark-Validated Rust Obs Processor](./023-benchmark-rust-obs-processor.md) | 🔵 Accepted |
@@ -15,7 +16,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 | **021** | [Rust Telemetry Summarization Processor](./021-rust-telemetry-summarization-processor.md) | 🔵 Accepted |
 | **020** | [Cilium eBPF Foundation](./020-cilium-ebpf-foundation.md) | 🔵 Accepted |
 | **019** | [Hybrid Host-MCP Intelligence Layer](./019-hybrid-host-mcp-intelligence.md) | 🔵 Accepted |
-| **018** | [Domain-Isolated MCP Architecture](./018-domain-isolated-mcp-architecture.md) | 🔵 Accepted |
+| **018** | [Domain-Isolated MCP Architecture](./018-domain-isolated-mcp-architecture.md) | 🟡 Superseded |
 | **017** | [Agentic Interface via MCP](./017-agentic-interface-mcp.md) | 🔵 Accepted |
 | **016** | [OpenTofu for K3s Service Management](./016-opentofu-k3s-migration.md) | 🔵 Accepted |
 | **015** | [Unified Host Telemetry Collectors](./015-unified-host-telemetry-collectors.md) | 🔵 Accepted |

--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"context"
+	"sync"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// CapabilitySnapshot reports the MCP domains and tools registered at startup.
+type CapabilitySnapshot struct {
+	ServerVersion string             `json:"server_version"`
+	ToolCount     int                `json:"tool_count"`
+	Domains       []CapabilityDomain `json:"domains"`
+}
+
+// CapabilityDomain describes one logical MCP domain.
+type CapabilityDomain struct {
+	Name   string   `json:"name"`
+	Status string   `json:"status"`
+	Tools  []string `json:"tools,omitempty"`
+	Reason string   `json:"reason,omitempty"`
+}
+
+// CapabilityRegistry tracks startup capability state for logging and diagnostics.
+type CapabilityRegistry struct {
+	mu            sync.RWMutex
+	serverVersion string
+	domains       []CapabilityDomain
+}
+
+// NewCapabilityRegistry creates a registry for the current MCP process.
+func NewCapabilityRegistry(serverVersion string) *CapabilityRegistry {
+	return &CapabilityRegistry{serverVersion: serverVersion}
+}
+
+// AddAvailable records a registered tool domain.
+func (r *CapabilityRegistry) AddAvailable(name string, tools []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.domains = append(r.domains, CapabilityDomain{
+		Name:   name,
+		Status: "available",
+		Tools:  append([]string(nil), tools...),
+	})
+}
+
+// AddSkipped records a domain that was not registered.
+func (r *CapabilityRegistry) AddSkipped(name, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.domains = append(r.domains, CapabilityDomain{
+		Name:   name,
+		Status: "skipped",
+		Reason: reason,
+	})
+}
+
+// Snapshot returns a copy of the current startup capability state.
+func (r *CapabilityRegistry) Snapshot() CapabilitySnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	domains := make([]CapabilityDomain, 0, len(r.domains))
+	toolCount := 0
+	for _, domain := range r.domains {
+		copied := domain
+		copied.Tools = append([]string(nil), domain.Tools...)
+		toolCount += len(copied.Tools)
+		domains = append(domains, copied)
+	}
+
+	return CapabilitySnapshot{
+		ServerVersion: r.serverVersion,
+		ToolCount:     toolCount,
+		Domains:       domains,
+	}
+}
+
+// RegisterCapabilityTools registers diagnostic MCP tools.
+func RegisterCapabilityTools(server *sdkmcp.Server, registry *CapabilityRegistry, serviceName string) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "mcp_capabilities",
+		Description: "Report MCP domains, registered tools, and skipped providers for this gateway process",
+	}, handleMCPCapabilities(registry, serviceName))
+}
+
+func handleMCPCapabilities(registry *CapabilityRegistry, serviceName string) sdkmcp.ToolHandlerFor[struct{}, any] {
+	return NewJSONToolHandler("mcp_capabilities", serviceName, func(ctx context.Context, input struct{}) (interface{}, error) {
+		return registry.Snapshot(), nil
+	})
+}

--- a/internal/mcp/capabilities_test.go
+++ b/internal/mcp/capabilities_test.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestCapabilityRegistry_Snapshot(t *testing.T) {
+	registry := NewCapabilityRegistry("1.0.0")
+	registry.AddAvailable("mcp.network", []string{"observe_network_flows"})
+	registry.AddSkipped("mcp.pods", "failed to load kubeconfig")
+
+	snapshot := registry.Snapshot()
+	if snapshot.ServerVersion != "1.0.0" {
+		t.Fatalf("got version %q, want 1.0.0", snapshot.ServerVersion)
+	}
+	if snapshot.ToolCount != 1 {
+		t.Fatalf("got tool count %d, want 1", snapshot.ToolCount)
+	}
+	if len(snapshot.Domains) != 2 {
+		t.Fatalf("got %d domains, want 2", len(snapshot.Domains))
+	}
+	if snapshot.Domains[0].Status != "available" {
+		t.Fatalf("got status %q, want available", snapshot.Domains[0].Status)
+	}
+	if snapshot.Domains[1].Reason == "" {
+		t.Fatal("expected skipped domain reason")
+	}
+}
+
+func TestHandleMCPCapabilities(t *testing.T) {
+	registry := NewCapabilityRegistry("1.0.0")
+	registry.AddAvailable("mcp.diagnostics", []string{"mcp_capabilities"})
+	registry.AddSkipped("mcp.telemetry", "missing telemetry environment")
+
+	handler := handleMCPCapabilities(registry, "svc")
+	res, _, err := handler(context.Background(), &sdkmcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	text := res.Content[0].(*sdkmcp.TextContent).Text
+	for _, want := range []string{`"tool_count":1`, `"name":"mcp.telemetry"`, `"status":"skipped"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("got %s, want to contain %s", text, want)
+		}
+	}
+}


### PR DESCRIPTION
### Summary

This change reconciles the MCP gateway documentation with the current unified-binary design and adds runtime capability accounting for the gateway. It also replaces the README highlights inventory with concrete case studies that show how the platform has been used to reduce telemetry payloads and debug real incidents.

### List of Changes

- Added ADR 026 to document the unified MCP gateway decision, supersede ADR 018, and align architecture docs with actual startup behavior.
- Added `mcp_capabilities` and startup capability tracking so agents can see available domains, registered tools, and skipped-provider reasons.
- Reworked the README introduction from a broad highlights list into case studies covering telemetry summarization and resolved incidents.

### Verification

- [x] `go test ./cmd/mcp-obs-hub ./internal/mcp/...` passes
- [x] `make test` passes
- [x] Manually review the rendered README and ADR links

