### PR TITLE
feat(idp): add hub cli skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo "  make vuln-scan            - Run govulncheck for security vulnerabilities"
 	@echo "  make web-build            - Build the GitHub Page"
 	@echo "  make proxy-build          - Build and restart the go proxy server"
+	@echo "  make idp-build            - Build and install the Hub IDP CLI"
 	@echo "  make obs-processor        - Build the standalone Rust observability processor"
 	@echo "  make mcp-build            - Build and install the mcp-obs-hub server"
 	@echo ""

--- a/cmd/idp/main.go
+++ b/cmd/idp/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"observability-hub/internal/idp"
+)
+
+func main() {
+	os.Exit(idp.Run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/docs/decisions/027-hub-cli-developer-experience.md
+++ b/docs/decisions/027-hub-cli-developer-experience.md
@@ -1,0 +1,70 @@
+# ADR 027: Hub CLI Developer Experience
+
+- **Status:** Accepted
+- **Date:** 2026-04-28
+- **Author:** Victoria Cheng
+
+## Context and Problem Statement
+
+Observability Hub has operational surfaces across Kubernetes, telemetry, MCP
+tools, documentation, and host services. A local IDP CLI gives those surfaces a
+service-first developer interface for understanding runtime state, signals,
+ownership, and next steps.
+
+The first implementation should establish the command shape as a local Linux
+binary, with service-focused commands that can grow into Kubernetes service
+discovery, health summaries, logs, events, and developer helper commands.
+
+## Decision Outcome
+
+Add a local Hub IDP CLI with the source entry point at `cmd/idp` and internal
+logic under `internal/idp`.
+
+- **Local Binary:** Build the CLI as a local Linux binary for day-to-day
+  development.
+- **Service-First UX:** Design commands around services before pods or raw
+  Kubernetes objects.
+- **Read-Only First:** Start with command routing and help text before adding
+  Kubernetes access.
+
+## Consequences
+
+### Positive
+
+- **Fast Feedback:** The CLI shape can be tested locally as part of normal
+  development.
+- **Simple Operations:** A single Linux binary keeps the local workflow direct.
+- **Project Alignment:** The CLI follows the repository's `cmd/` and
+  `internal/` boundaries.
+- **Clear Growth Path:** Catalog, Kubernetes, telemetry, and helper behavior
+  have an explicit command surface to build on.
+
+### Negative
+
+- **Linux-First Assumption:** The initial binary targets the local Linux
+  environment instead of proving cross-platform behavior.
+- **Command Names Become Sticky:** Once commands such as `service health` or
+  `cluster status` are documented, changing them later can break habits,
+  scripts, or notes.
+
+## Verification
+
+- [ ] **Service Commands:**
+  - [ ] `service list` is routed.
+  - [ ] `service describe <service>` is routed.
+  - [ ] `service health <service>` is routed.
+  - [ ] `service logs <service>` is routed.
+  - [ ] `service events <service>` is routed.
+  - [ ] `service metrics <service>` is routed.
+  - [ ] `service traces <service>` is routed.
+  - [ ] `service ownership <service>` is routed.
+- [ ] **Cluster Commands:**
+  - [ ] `cluster status` is routed.
+  - [ ] `cluster namespaces` is routed.
+  - [ ] `cluster workloads` is routed.
+- [ ] **Catalog Commands:**
+  - [ ] `catalog list` is routed.
+  - [ ] `catalog validate` is routed.
+- [ ] **Environment Commands:**
+  - [ ] `env list` is routed.
+  - [ ] `env describe <env>` is routed.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 
 | ADR | Title | Status |
 | :--- | :--- | :--- |
+| **027** | [Hub CLI Developer Experience](./027-hub-cli-developer-experience.md) | 🔵 Accepted |
 | **026** | [Unified MCP Gateway With Capability Accounting](./026-unified-mcp-gateway-with-capability-accounting.md) | 🔵 Accepted |
 | **025** | [Decouple Hardware Simulation](./025-decouple-hardware-simulation.md) | 🔵 Accepted |
 | **024** | [Trivy-Verified Workload Hardening](./024-trivy-verified-workload-hardening.md) | 🔵 Accepted |

--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -1,0 +1,175 @@
+package idp
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+const helpText = `Hub CLI (IDP)
+
+Usage:
+  hub-cli <command> [arguments]
+
+Service commands:
+  service list
+  service describe <service>
+  service health <service>
+  service logs <service>
+  service events <service>
+  service metrics <service>
+  service traces <service>
+  service ownership <service>
+
+Cluster commands:
+  cluster status
+  cluster namespaces
+  cluster workloads
+
+Catalog commands:
+  catalog list
+  catalog validate
+
+Environment commands:
+  env list
+  env describe <env>
+`
+
+// Run executes the local IDP CLI command dispatcher.
+func Run(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 || isHelp(args[0]) {
+		fmt.Fprint(stdout, helpText)
+		return 0
+	}
+
+	switch args[0] {
+	case "service":
+		return runService(args[1:], stdout, stderr)
+	case "cluster":
+		return runCluster(args[1:], stdout, stderr)
+	case "catalog":
+		return runCatalog(args[1:], stdout, stderr)
+	case "env":
+		return runEnv(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown command: %s\n\n", args[0])
+		fmt.Fprint(stderr, helpText)
+		return 1
+	}
+}
+
+func runService(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 || isHelp(args[0]) {
+		fmt.Fprint(stdout, serviceHelpText())
+		return 0
+	}
+
+	switch args[0] {
+	case "list":
+		return printCalled(stdout, "idp service list")
+	case "describe", "health", "logs", "events", "metrics", "traces", "ownership":
+		if len(args) < 2 {
+			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
+			return 1
+		}
+		return printCalled(stdout, "idp service "+args[0]+" for "+args[1])
+	default:
+		fmt.Fprintf(stderr, "unknown service command: %s\n\n", args[0])
+		fmt.Fprint(stderr, serviceHelpText())
+		return 1
+	}
+}
+
+func runCluster(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 || isHelp(args[0]) {
+		fmt.Fprint(stdout, clusterHelpText())
+		return 0
+	}
+
+	switch args[0] {
+	case "status", "namespaces", "workloads":
+		return printCalled(stdout, "idp cluster "+args[0])
+	default:
+		fmt.Fprintf(stderr, "unknown cluster command: %s\n\n", args[0])
+		fmt.Fprint(stderr, clusterHelpText())
+		return 1
+	}
+}
+
+func runCatalog(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 || isHelp(args[0]) {
+		fmt.Fprint(stdout, catalogHelpText())
+		return 0
+	}
+
+	switch args[0] {
+	case "list", "validate":
+		return printCalled(stdout, "idp catalog "+args[0])
+	default:
+		fmt.Fprintf(stderr, "unknown catalog command: %s\n\n", args[0])
+		fmt.Fprint(stderr, catalogHelpText())
+		return 1
+	}
+}
+
+func runEnv(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 || isHelp(args[0]) {
+		fmt.Fprint(stdout, envHelpText())
+		return 0
+	}
+
+	switch args[0] {
+	case "list":
+		return printCalled(stdout, "idp env list")
+	case "describe":
+		if len(args) < 2 {
+			fmt.Fprint(stderr, "missing environment name for idp env describe\n")
+			return 1
+		}
+		return printCalled(stdout, "idp env describe for "+args[1])
+	default:
+		fmt.Fprintf(stderr, "unknown env command: %s\n\n", args[0])
+		fmt.Fprint(stderr, envHelpText())
+		return 1
+	}
+}
+
+func printCalled(stdout io.Writer, command string) int {
+	fmt.Fprintf(stdout, "called %s\n", command)
+	return 0
+}
+
+func isHelp(arg string) bool {
+	return arg == "-h" || arg == "--help" || arg == "help"
+}
+
+func serviceHelpText() string {
+	return strings.TrimSpace(`Usage:
+  hub-cli service list
+  hub-cli service describe <service>
+  hub-cli service health <service>
+  hub-cli service logs <service>
+  hub-cli service events <service>
+  hub-cli service metrics <service>
+  hub-cli service traces <service>
+  hub-cli service ownership <service>`) + "\n"
+}
+
+func clusterHelpText() string {
+	return strings.TrimSpace(`Usage:
+  hub-cli cluster status
+  hub-cli cluster namespaces
+  hub-cli cluster workloads`) + "\n"
+}
+
+func catalogHelpText() string {
+	return strings.TrimSpace(`Usage:
+  hub-cli catalog list
+  hub-cli catalog validate`) + "\n"
+}
+
+func envHelpText() string {
+	return strings.TrimSpace(`Usage:
+  hub-cli env list
+  hub-cli env describe <env>`) + "\n"
+}

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -1,0 +1,96 @@
+package idp
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunPlaceholderCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "service list",
+			args: []string{"service", "list"},
+			want: "called idp service list\n",
+		},
+		{
+			name: "service describe",
+			args: []string{"service", "describe", "loki"},
+			want: "called idp service describe for loki\n",
+		},
+		{
+			name: "service health",
+			args: []string{"service", "health", "tempo"},
+			want: "called idp service health for tempo\n",
+		},
+		{
+			name: "cluster status",
+			args: []string{"cluster", "status"},
+			want: "called idp cluster status\n",
+		},
+		{
+			name: "catalog validate",
+			args: []string{"catalog", "validate"},
+			want: "called idp catalog validate\n",
+		},
+		{
+			name: "env describe",
+			args: []string{"env", "describe", "local"},
+			want: "called idp env describe for local\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("Run() code = %d, want 0; stderr = %q", code, stderr.String())
+			}
+			if got := stdout.String(); got != tt.want {
+				t.Fatalf("stdout = %q, want %q", got, tt.want)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("stderr = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0", code)
+	}
+	if got := stdout.String(); !strings.Contains(got, "service list") {
+		t.Fatalf("help output missing service command: %q", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunMissingRequiredArgument(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"service", "describe"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("Run() code = %d, want 1", code)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "missing service name") {
+		t.Fatalf("stderr missing required argument message: %q", got)
+	}
+}

--- a/makefiles/go.mk
+++ b/makefiles/go.mk
@@ -1,7 +1,7 @@
 # Go Project Configuration
 GO_PACKAGES = ./cmd/... ./internal/...
 
-.PHONY: format test test-cov update vet vuln-scan setup-tailwind web-build proxy-build mcp-build obs-processor
+.PHONY: format test test-cov update vet vuln-scan setup-tailwind web-build proxy-build idp-build mcp-build obs-processor
 
 format:
 	@echo "Formatting Go code..." && \
@@ -47,6 +47,12 @@ proxy-build:
 	sudo install -m 755 ./bin/proxy_server /usr/local/bin/proxy_server && \
 	sudo systemctl restart proxy.service && \
 	rm ./bin/proxy_server
+
+idp-build:
+	@echo "Updating hub-cli..." && \
+	go build -o ./bin/hub-cli ./cmd/idp && \
+	sudo install -m 755 ./bin/hub-cli /usr/local/bin/hub-cli && \
+	rm ./bin/hub-cli
 
 obs-processor:
 	@echo "Building Rust observability processor..." && \


### PR DESCRIPTION
### Summary

This PR adds the first Hub IDP CLI skeleton for Observability Hub. It establishes
the service-first command surface, a local Linux build target, and the ADR that
records the developer experience direction before Kubernetes-backed behavior is
implemented.

### List of Changes

- Added a testable CLI dispatcher for service, cluster, catalog, and environment
  commands so the initial developer experience can be reviewed early.
- Added the local `idp-build` Make target and ADR entry so the CLI has a clear
  build path and architectural record.

### Verification

- [x] `go test ./internal/idp`
- [x] `go run ./cmd/idp --help`
- [x] `go build -o ./bin/hub-cli ./cmd/idp`
- [x] `make idp-build` installs the cli

