### PR TITLE
feat(idp): add kubernetes-backed catalog

### DIFF
--- a/internal/idp/catalog/catalog.go
+++ b/internal/idp/catalog/catalog.go
@@ -1,0 +1,252 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type KubernetesCatalog struct {
+	clientset kubernetes.Interface
+	now       func() time.Time
+}
+
+type Entry struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Status    string
+	Age       string
+}
+
+type Validation struct {
+	ResourceCount  int
+	NamespaceCount int
+	KindCounts     map[string]int
+}
+
+type ListOptions struct {
+	Namespace string
+}
+
+func NewKubernetesCatalog() (*KubernetesCatalog, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			home, _ := os.UserHomeDir()
+			kubeconfig = filepath.Join(home, ".kube", "config")
+		}
+
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("load kubeconfig: %w", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	return NewKubernetesCatalogWithClientset(clientset), nil
+}
+
+func NewKubernetesCatalogWithClientset(clientset kubernetes.Interface) *KubernetesCatalog {
+	return &KubernetesCatalog{
+		clientset: clientset,
+		now:       time.Now,
+	}
+}
+
+func (c *KubernetesCatalog) List(ctx context.Context, opts ListOptions) ([]Entry, error) {
+	entries := make([]Entry, 0)
+	namespace := opts.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceAll
+	}
+
+	services, err := c.clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+	for _, service := range services.Items {
+		entries = append(entries, c.serviceEntry(service))
+	}
+
+	deployments, err := c.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list deployments: %w", err)
+	}
+	for _, deployment := range deployments.Items {
+		entries = append(entries, c.deploymentEntry(deployment))
+	}
+
+	statefulSets, err := c.clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list statefulsets: %w", err)
+	}
+	for _, statefulSet := range statefulSets.Items {
+		entries = append(entries, c.statefulSetEntry(statefulSet))
+	}
+
+	daemonSets, err := c.clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list daemonsets: %w", err)
+	}
+	for _, daemonSet := range daemonSets.Items {
+		entries = append(entries, c.daemonSetEntry(daemonSet))
+	}
+
+	jobs, err := c.clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list jobs: %w", err)
+	}
+	for _, job := range jobs.Items {
+		entries = append(entries, c.jobEntry(job))
+	}
+
+	cronJobs, err := c.clientset.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list cronjobs: %w", err)
+	}
+	for _, cronJob := range cronJobs.Items {
+		entries = append(entries, c.cronJobEntry(cronJob))
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Namespace == entries[j].Namespace {
+			if entries[i].Kind == entries[j].Kind {
+				return entries[i].Name < entries[j].Name
+			}
+			return entries[i].Kind < entries[j].Kind
+		}
+		return entries[i].Namespace < entries[j].Namespace
+	})
+
+	return entries, nil
+}
+
+func (c *KubernetesCatalog) Validate(ctx context.Context, opts ListOptions) (Validation, error) {
+	entries, err := c.List(ctx, opts)
+	if err != nil {
+		return Validation{}, err
+	}
+
+	namespaces := make(map[string]struct{})
+	kinds := make(map[string]int)
+	for _, entry := range entries {
+		namespaces[entry.Namespace] = struct{}{}
+		kinds[entry.Kind]++
+	}
+
+	return Validation{
+		ResourceCount:  len(entries),
+		NamespaceCount: len(namespaces),
+		KindCounts:     kinds,
+	}, nil
+}
+
+func (c *KubernetesCatalog) serviceEntry(service corev1.Service) Entry {
+	return Entry{
+		Name:      service.Name,
+		Namespace: service.Namespace,
+		Kind:      "Service",
+		Status:    string(service.Spec.Type),
+		Age:       c.age(service.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCatalog) deploymentEntry(deployment appsv1.Deployment) Entry {
+	desired := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desired = *deployment.Spec.Replicas
+	}
+
+	return Entry{
+		Name:      deployment.Name,
+		Namespace: deployment.Namespace,
+		Kind:      "Deployment",
+		Status:    fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
+		Age:       c.age(deployment.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCatalog) statefulSetEntry(statefulSet appsv1.StatefulSet) Entry {
+	desired := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		desired = *statefulSet.Spec.Replicas
+	}
+
+	return Entry{
+		Name:      statefulSet.Name,
+		Namespace: statefulSet.Namespace,
+		Kind:      "StatefulSet",
+		Status:    fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
+		Age:       c.age(statefulSet.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCatalog) daemonSetEntry(daemonSet appsv1.DaemonSet) Entry {
+	return Entry{
+		Name:      daemonSet.Name,
+		Namespace: daemonSet.Namespace,
+		Kind:      "DaemonSet",
+		Status:    fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
+		Age:       c.age(daemonSet.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCatalog) jobEntry(job batchv1.Job) Entry {
+	desired := int32(1)
+	if job.Spec.Completions != nil {
+		desired = *job.Spec.Completions
+	}
+
+	return Entry{
+		Name:      job.Name,
+		Namespace: job.Namespace,
+		Kind:      "Job",
+		Status:    fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
+		Age:       c.age(job.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCatalog) cronJobEntry(cronJob batchv1.CronJob) Entry {
+	return Entry{
+		Name:      cronJob.Name,
+		Namespace: cronJob.Namespace,
+		Kind:      "CronJob",
+		Status:    fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
+		Age:       c.age(cronJob.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCatalog) age(created time.Time) string {
+	if created.IsZero() {
+		return "unknown"
+	}
+
+	duration := c.now().Sub(created)
+	switch {
+	case duration < time.Minute:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	case duration < time.Hour:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	case duration < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(duration.Hours()/24))
+	}
+}

--- a/internal/idp/catalog/catalog_test.go
+++ b/internal/idp/catalog/catalog_test.go
@@ -1,0 +1,188 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubernetesCatalogList(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+	completions := int32(1)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    ListOptions
+		want    []Entry
+	}{
+		{
+			name: "mixed kubernetes catalog entries",
+			objects: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability", CreationTimestamp: created},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability", CreationTimestamp: created},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+					Status:     appsv1.DeploymentStatus{ReadyReplicas: 1},
+				},
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: "observability", CreationTimestamp: created},
+					Spec:       appsv1.StatefulSetSpec{Replicas: &replicas},
+					Status:     appsv1.StatefulSetStatus{ReadyReplicas: 2},
+				},
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: "analytics", Namespace: "workers", CreationTimestamp: created},
+					Spec:       batchv1.JobSpec{Completions: &completions},
+					Status:     batchv1.JobStatus{Succeeded: 1},
+				},
+			},
+			want: []Entry{
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Status: "1/2", Age: "2h"},
+				{Name: "grafana", Namespace: "observability", Kind: "Service", Status: "ClusterIP", Age: "2h"},
+				{Name: "loki", Namespace: "observability", Kind: "StatefulSet", Status: "2/2", Age: "2h"},
+				{Name: "analytics", Namespace: "workers", Kind: "Job", Status: "1/1", Age: "2h"},
+			},
+		},
+		{
+			name: "filters by namespace",
+			objects: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability", CreationTimestamp: created},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "payments-api", Namespace: "payments", CreationTimestamp: created},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+					Status:     appsv1.DeploymentStatus{ReadyReplicas: 2},
+				},
+			},
+			opts: ListOptions{Namespace: "payments"},
+			want: []Entry{
+				{Name: "payments-api", Namespace: "payments", Kind: "Deployment", Status: "2/2", Age: "2h"},
+			},
+		},
+		{
+			name: "empty catalog",
+			want: []Entry{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			catalog := newTestCatalog(tt.objects...)
+
+			entries, err := catalog.List(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("List() error = %v", err)
+			}
+
+			assertEntries(t, entries, tt.want)
+		})
+	}
+}
+
+func TestKubernetesCatalogValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    ListOptions
+		want    Validation
+	}{
+		{
+			name: "counts resources across namespaces",
+			objects: []runtime.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability"}},
+				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability"}},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "analytics", Namespace: "workers"}},
+			},
+			want: Validation{
+				ResourceCount:  3,
+				NamespaceCount: 2,
+				KindCounts: map[string]int{
+					"Deployment": 1,
+					"Job":        1,
+					"Service":    1,
+				},
+			},
+		},
+		{
+			name: "counts filtered namespace",
+			objects: []runtime.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability"}},
+				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "payments-api", Namespace: "payments"}},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "payments-reconcile", Namespace: "payments"}},
+			},
+			opts: ListOptions{Namespace: "payments"},
+			want: Validation{
+				ResourceCount:  2,
+				NamespaceCount: 1,
+				KindCounts: map[string]int{
+					"Deployment": 1,
+					"Job":        1,
+				},
+			},
+		},
+		{
+			name: "empty catalog",
+			want: Validation{KindCounts: map[string]int{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			catalog := newTestCatalog(tt.objects...)
+
+			validation, err := catalog.Validate(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			if validation.ResourceCount != tt.want.ResourceCount {
+				t.Fatalf("ResourceCount = %d, want %d", validation.ResourceCount, tt.want.ResourceCount)
+			}
+			if validation.NamespaceCount != tt.want.NamespaceCount {
+				t.Fatalf("NamespaceCount = %d, want %d", validation.NamespaceCount, tt.want.NamespaceCount)
+			}
+			if len(validation.KindCounts) != len(tt.want.KindCounts) {
+				t.Fatalf("Validate() = %#v, want %#v", validation, tt.want)
+			}
+			for kind, count := range tt.want.KindCounts {
+				if validation.KindCounts[kind] != count {
+					t.Fatalf("KindCounts[%q] = %d, want %d", kind, validation.KindCounts[kind], count)
+				}
+			}
+		})
+	}
+}
+
+func assertEntries(t *testing.T, got []Entry, want []Entry) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(entries) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entries[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func newTestCatalog(objects ...runtime.Object) *KubernetesCatalog {
+	catalog := NewKubernetesCatalogWithClientset(fake.NewSimpleClientset(objects...))
+	catalog.now = func() time.Time {
+		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	}
+	return catalog
+}

--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -1,10 +1,24 @@
 package idp
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
+	"text/tabwriter"
+
+	"observability-hub/internal/idp/catalog"
 )
+
+type catalogClient interface {
+	List(context.Context, catalog.ListOptions) ([]catalog.Entry, error)
+	Validate(context.Context, catalog.ListOptions) (catalog.Validation, error)
+}
+
+var newCatalog = func() (catalogClient, error) {
+	return catalog.NewKubernetesCatalog()
+}
 
 const helpText = `Hub CLI (IDP)
 
@@ -103,8 +117,18 @@ func runCatalog(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	switch args[0] {
-	case "list", "validate":
-		return printCalled(stdout, "idp catalog "+args[0])
+	case "list":
+		opts, ok := parseCatalogOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return listCatalog(opts, stdout, stderr)
+	case "validate":
+		opts, ok := parseCatalogOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return validateCatalog(opts, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown catalog command: %s\n\n", args[0])
 		fmt.Fprint(stderr, catalogHelpText())
@@ -139,6 +163,76 @@ func printCalled(stdout io.Writer, command string) int {
 	return 0
 }
 
+func listCatalog(opts catalog.ListOptions, stdout io.Writer, stderr io.Writer) int {
+	catalogClient, err := newCatalog()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	entries, err := catalogClient.List(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tSTATUS\tAGE")
+	for _, entry := range entries {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", entry.Name, entry.Namespace, entry.Kind, entry.Status, entry.Age)
+	}
+	writer.Flush()
+	return 0
+}
+
+func validateCatalog(opts catalog.ListOptions, stdout io.Writer, stderr io.Writer) int {
+	catalogClient, err := newCatalog()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	validation, err := catalogClient.Validate(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "catalog valid: discovered %d resources across %d namespaces\n", validation.ResourceCount, validation.NamespaceCount)
+	for _, kind := range sortedKinds(validation.KindCounts) {
+		fmt.Fprintf(stdout, "- %s: %d\n", kind, validation.KindCounts[kind])
+	}
+	return 0
+}
+
+func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, bool) {
+	var opts catalog.ListOptions
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown catalog option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
+func sortedKinds(counts map[string]int) []string {
+	kinds := make([]string, 0, len(counts))
+	for kind := range counts {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
 func isHelp(arg string) bool {
 	return arg == "-h" || arg == "--help" || arg == "help"
 }
@@ -164,8 +258,8 @@ func clusterHelpText() string {
 
 func catalogHelpText() string {
 	return strings.TrimSpace(`Usage:
-  hub-cli catalog list
-  hub-cli catalog validate`) + "\n"
+  hub-cli catalog list [--namespace <namespace>]
+  hub-cli catalog validate [--namespace <namespace>]`) + "\n"
 }
 
 func envHelpText() string {

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -2,8 +2,11 @@ package idp
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
+
+	"observability-hub/internal/idp/catalog"
 )
 
 func TestRunPlaceholderCommands(t *testing.T) {
@@ -31,11 +34,6 @@ func TestRunPlaceholderCommands(t *testing.T) {
 			name: "cluster status",
 			args: []string{"cluster", "status"},
 			want: "called idp cluster status\n",
-		},
-		{
-			name: "catalog validate",
-			args: []string{"catalog", "validate"},
-			want: "called idp catalog validate\n",
 		},
 		{
 			name: "env describe",
@@ -79,6 +77,120 @@ func TestRunHelp(t *testing.T) {
 	}
 }
 
+func TestRunCatalogCommands(t *testing.T) {
+	fake := &fakeCatalog{
+		entries: []catalog.Entry{
+			{Name: "grafana", Namespace: "observability", Kind: "Deployment", Status: "1/1", Age: "2h"},
+			{Name: "loki", Namespace: "observability", Kind: "StatefulSet", Status: "1/1", Age: "2h"},
+		},
+		validation: catalog.Validation{
+			ResourceCount:  2,
+			NamespaceCount: 1,
+			KindCounts: map[string]int{
+				"Deployment":  1,
+				"StatefulSet": 1,
+			},
+		},
+	}
+	restore := stubCatalog(t, fake)
+	defer restore()
+
+	tests := []struct {
+		name       string
+		args       []string
+		want       string
+		wantList   []catalog.ListOptions
+		wantValid  []catalog.ListOptions
+		resetCalls bool
+	}{
+		{
+			name: "catalog list",
+			args: []string{"catalog", "list"},
+			want: "NAME     NAMESPACE      KIND         STATUS  AGE\n" +
+				"grafana  observability  Deployment   1/1     2h\n" +
+				"loki     observability  StatefulSet  1/1     2h\n",
+			wantList: []catalog.ListOptions{{}},
+		},
+		{
+			name:      "catalog validate",
+			args:      []string{"catalog", "validate"},
+			want:      "catalog valid: discovered 2 resources across 1 namespaces\n- Deployment: 1\n- StatefulSet: 1\n",
+			wantValid: []catalog.ListOptions{{}},
+		},
+		{
+			name:     "catalog list namespace",
+			args:     []string{"catalog", "list", "--namespace", "payments"},
+			want:     "NAME     NAMESPACE      KIND         STATUS  AGE\n" + "grafana  observability  Deployment   1/1     2h\n" + "loki     observability  StatefulSet  1/1     2h\n",
+			wantList: []catalog.ListOptions{{Namespace: "payments"}},
+		},
+		{
+			name:      "catalog validate shorthand namespace",
+			args:      []string{"catalog", "validate", "-n", "payments"},
+			want:      "catalog valid: discovered 2 resources across 1 namespaces\n- Deployment: 1\n- StatefulSet: 1\n",
+			wantValid: []catalog.ListOptions{{Namespace: "payments"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.listOpts = nil
+			fake.validOpts = nil
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("Run() code = %d, want 0; stderr = %q", code, stderr.String())
+			}
+			if got := stdout.String(); got != tt.want {
+				t.Fatalf("stdout = %q, want %q", got, tt.want)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("stderr = %q, want empty", got)
+			}
+			assertListOptions(t, fake.listOpts, tt.wantList)
+			assertListOptions(t, fake.validOpts, tt.wantValid)
+		})
+	}
+}
+
+func TestRunCatalogNamespaceOptionErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing namespace",
+			args: []string{"catalog", "list", "--namespace"},
+			want: "missing namespace for --namespace",
+		},
+		{
+			name: "unknown option",
+			args: []string{"catalog", "validate", "--team", "payments"},
+			want: "unknown catalog option: --team",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("Run() code = %d, want 1", code)
+			}
+			if got := stdout.String(); got != "" {
+				t.Fatalf("stdout = %q, want empty", got)
+			}
+			if got := stderr.String(); !strings.Contains(got, tt.want) {
+				t.Fatalf("stderr = %q, want containing %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunMissingRequiredArgument(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -92,5 +204,47 @@ func TestRunMissingRequiredArgument(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "missing service name") {
 		t.Fatalf("stderr missing required argument message: %q", got)
+	}
+}
+
+type fakeCatalog struct {
+	entries    []catalog.Entry
+	validation catalog.Validation
+	listOpts   []catalog.ListOptions
+	validOpts  []catalog.ListOptions
+}
+
+func (f *fakeCatalog) List(_ context.Context, opts catalog.ListOptions) ([]catalog.Entry, error) {
+	f.listOpts = append(f.listOpts, opts)
+	return f.entries, nil
+}
+
+func (f *fakeCatalog) Validate(_ context.Context, opts catalog.ListOptions) (catalog.Validation, error) {
+	f.validOpts = append(f.validOpts, opts)
+	return f.validation, nil
+}
+
+func assertListOptions(t *testing.T, got []catalog.ListOptions, want []catalog.ListOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func stubCatalog(t *testing.T, fake *fakeCatalog) func() {
+	t.Helper()
+
+	original := newCatalog
+	newCatalog = func() (catalogClient, error) {
+		return fake, nil
+	}
+	return func() {
+		newCatalog = original
 	}
 }


### PR DESCRIPTION
### Summary

This PR replaces the placeholder catalog commands with a Kubernetes-backed
catalog view. The CLI now discovers live Kubernetes resources for catalog
listing and validation, including namespace filtering for team-scoped views.

### List of Changes

- Added a Kubernetes-backed catalog provider that discovers Services,
  Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs from the cluster API.
- Made catalog review more useful by reporting resource counts by kind and
  supporting namespace-scoped catalog listing and validation.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

