### PR TITLE
feat(idp): add kubernetes-backed cluster commands

### DIFF
--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"observability-hub/internal/idp/catalog"
+	"observability-hub/internal/idp/cluster"
 )
 
 type catalogClient interface {
@@ -16,8 +17,18 @@ type catalogClient interface {
 	Validate(context.Context, catalog.ListOptions) (catalog.Validation, error)
 }
 
+type clusterClient interface {
+	Status(context.Context) (cluster.Status, error)
+	Namespaces(context.Context) ([]cluster.Namespace, error)
+	Workloads(context.Context, cluster.WorkloadOptions) ([]cluster.Workload, error)
+}
+
 var newCatalog = func() (catalogClient, error) {
 	return catalog.NewKubernetesCatalog()
+}
+
+var newCluster = func() (clusterClient, error) {
+	return cluster.NewKubernetesCluster()
 }
 
 const helpText = `Hub CLI (IDP)
@@ -101,8 +112,16 @@ func runCluster(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	switch args[0] {
-	case "status", "namespaces", "workloads":
-		return printCalled(stdout, "idp cluster "+args[0])
+	case "status":
+		return statusCluster(stdout, stderr)
+	case "namespaces":
+		return listClusterNamespaces(stdout, stderr)
+	case "workloads":
+		opts, ok := parseClusterWorkloadOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return listClusterWorkloads(opts, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown cluster command: %s\n\n", args[0])
 		fmt.Fprint(stderr, clusterHelpText())
@@ -163,6 +182,70 @@ func printCalled(stdout io.Writer, command string) int {
 	return 0
 }
 
+func statusCluster(stdout io.Writer, stderr io.Writer) int {
+	clusterClient, err := newCluster()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	status, err := clusterClient.Status(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "READY_NODES\tTOTAL_NODES\tNAMESPACES\tWORKLOADS")
+	fmt.Fprintf(writer, "%d\t%d\t%d\t%d\n", status.ReadyNodes, status.NodeCount, status.NamespaceCount, status.WorkloadCount)
+	writer.Flush()
+	return 0
+}
+
+func listClusterNamespaces(stdout io.Writer, stderr io.Writer) int {
+	clusterClient, err := newCluster()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	namespaces, err := clusterClient.Namespaces(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tPHASE\tAGE")
+	for _, namespace := range namespaces {
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", namespace.Name, namespace.Phase, namespace.Age)
+	}
+	writer.Flush()
+	return 0
+}
+
+func listClusterWorkloads(opts cluster.WorkloadOptions, stdout io.Writer, stderr io.Writer) int {
+	clusterClient, err := newCluster()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	workloads, err := clusterClient.Workloads(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tREADY\tAGE")
+	for _, workload := range workloads {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", workload.Name, workload.Namespace, workload.Kind, workload.Ready, workload.Age)
+	}
+	writer.Flush()
+	return 0
+}
+
 func listCatalog(opts catalog.ListOptions, stdout io.Writer, stderr io.Writer) int {
 	catalogClient, err := newCatalog()
 	if err != nil {
@@ -203,6 +286,25 @@ func validateCatalog(opts catalog.ListOptions, stdout io.Writer, stderr io.Write
 		fmt.Fprintf(stdout, "- %s: %d\n", kind, validation.KindCounts[kind])
 	}
 	return 0
+}
+
+func parseClusterWorkloadOptions(args []string, stderr io.Writer) (cluster.WorkloadOptions, bool) {
+	var opts cluster.WorkloadOptions
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown cluster workloads option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
 }
 
 func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, bool) {
@@ -253,7 +355,7 @@ func clusterHelpText() string {
 	return strings.TrimSpace(`Usage:
   hub-cli cluster status
   hub-cli cluster namespaces
-  hub-cli cluster workloads`) + "\n"
+  hub-cli cluster workloads [--namespace <namespace>]`) + "\n"
 }
 
 func catalogHelpText() string {

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"observability-hub/internal/idp/catalog"
+	"observability-hub/internal/idp/cluster"
 )
 
 func TestRunPlaceholderCommands(t *testing.T) {
@@ -29,11 +30,6 @@ func TestRunPlaceholderCommands(t *testing.T) {
 			name: "service health",
 			args: []string{"service", "health", "tempo"},
 			want: "called idp service health for tempo\n",
-		},
-		{
-			name: "cluster status",
-			args: []string{"cluster", "status"},
-			want: "called idp cluster status\n",
 		},
 		{
 			name: "env describe",
@@ -74,6 +70,121 @@ func TestRunHelp(t *testing.T) {
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunClusterCommands(t *testing.T) {
+	fake := &fakeCluster{
+		status: cluster.Status{
+			ReadyNodes:     1,
+			NodeCount:      2,
+			NamespaceCount: 3,
+			WorkloadCount:  4,
+		},
+		namespaces: []cluster.Namespace{
+			{Name: "default", Phase: "Active", Age: "3d"},
+			{Name: "observability", Phase: "Active", Age: "2d"},
+		},
+		workloads: []cluster.Workload{
+			{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/1", Age: "2h"},
+			{Name: "loki", Namespace: "observability", Kind: "StatefulSet", Ready: "1/1", Age: "2h"},
+		},
+	}
+	restore := stubCluster(t, fake)
+	defer restore()
+
+	tests := []struct {
+		name     string
+		args     []string
+		want     string
+		wantWork []cluster.WorkloadOptions
+	}{
+		{
+			name: "cluster status",
+			args: []string{"cluster", "status"},
+			want: "READY_NODES  TOTAL_NODES  NAMESPACES  WORKLOADS\n" +
+				"1            2            3           4\n",
+		},
+		{
+			name: "cluster namespaces",
+			args: []string{"cluster", "namespaces"},
+			want: "NAME           PHASE   AGE\n" +
+				"default        Active  3d\n" +
+				"observability  Active  2d\n",
+		},
+		{
+			name: "cluster workloads",
+			args: []string{"cluster", "workloads"},
+			want: "NAME     NAMESPACE      KIND         READY  AGE\n" +
+				"grafana  observability  Deployment   1/1    2h\n" +
+				"loki     observability  StatefulSet  1/1    2h\n",
+			wantWork: []cluster.WorkloadOptions{{}},
+		},
+		{
+			name: "cluster workloads namespace",
+			args: []string{"cluster", "workloads", "-n", "payments"},
+			want: "NAME     NAMESPACE      KIND         READY  AGE\n" +
+				"grafana  observability  Deployment   1/1    2h\n" +
+				"loki     observability  StatefulSet  1/1    2h\n",
+			wantWork: []cluster.WorkloadOptions{{Namespace: "payments"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.workloadOpts = nil
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("Run() code = %d, want 0; stderr = %q", code, stderr.String())
+			}
+			if got := stdout.String(); got != tt.want {
+				t.Fatalf("stdout = %q, want %q", got, tt.want)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("stderr = %q, want empty", got)
+			}
+			assertWorkloadOptions(t, fake.workloadOpts, tt.wantWork)
+		})
+	}
+}
+
+func TestRunClusterWorkloadOptionErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing namespace",
+			args: []string{"cluster", "workloads", "--namespace"},
+			want: "missing namespace for --namespace",
+		},
+		{
+			name: "unknown option",
+			args: []string{"cluster", "workloads", "--team", "payments"},
+			want: "unknown cluster workloads option: --team",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("Run() code = %d, want 1", code)
+			}
+			if got := stdout.String(); got != "" {
+				t.Fatalf("stdout = %q, want empty", got)
+			}
+			if got := stderr.String(); !strings.Contains(got, tt.want) {
+				t.Fatalf("stderr = %q, want containing %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -207,6 +318,26 @@ func TestRunMissingRequiredArgument(t *testing.T) {
 	}
 }
 
+type fakeCluster struct {
+	status       cluster.Status
+	namespaces   []cluster.Namespace
+	workloads    []cluster.Workload
+	workloadOpts []cluster.WorkloadOptions
+}
+
+func (f *fakeCluster) Status(_ context.Context) (cluster.Status, error) {
+	return f.status, nil
+}
+
+func (f *fakeCluster) Namespaces(_ context.Context) ([]cluster.Namespace, error) {
+	return f.namespaces, nil
+}
+
+func (f *fakeCluster) Workloads(_ context.Context, opts cluster.WorkloadOptions) ([]cluster.Workload, error) {
+	f.workloadOpts = append(f.workloadOpts, opts)
+	return f.workloads, nil
+}
+
 type fakeCatalog struct {
 	entries    []catalog.Entry
 	validation catalog.Validation
@@ -234,6 +365,31 @@ func assertListOptions(t *testing.T, got []catalog.ListOptions, want []catalog.L
 		if got[i] != want[i] {
 			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func assertWorkloadOptions(t *testing.T, got []cluster.WorkloadOptions, want []cluster.WorkloadOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func stubCluster(t *testing.T, fake *fakeCluster) func() {
+	t.Helper()
+
+	original := newCluster
+	newCluster = func() (clusterClient, error) {
+		return fake, nil
+	}
+	return func() {
+		newCluster = original
 	}
 }
 

--- a/internal/idp/cluster/cluster.go
+++ b/internal/idp/cluster/cluster.go
@@ -1,0 +1,283 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type KubernetesCluster struct {
+	clientset kubernetes.Interface
+	now       func() time.Time
+}
+
+type Status struct {
+	ReadyNodes     int
+	NodeCount      int
+	NamespaceCount int
+	WorkloadCount  int
+}
+
+type Namespace struct {
+	Name  string
+	Phase string
+	Age   string
+}
+
+type Workload struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Ready     string
+	Age       string
+}
+
+type WorkloadOptions struct {
+	Namespace string
+}
+
+func NewKubernetesCluster() (*KubernetesCluster, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			home, _ := os.UserHomeDir()
+			kubeconfig = filepath.Join(home, ".kube", "config")
+		}
+
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("load kubeconfig: %w", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	return NewKubernetesClusterWithClientset(clientset), nil
+}
+
+func NewKubernetesClusterWithClientset(clientset kubernetes.Interface) *KubernetesCluster {
+	return &KubernetesCluster{
+		clientset: clientset,
+		now:       time.Now,
+	}
+}
+
+func (c *KubernetesCluster) Status(ctx context.Context) (Status, error) {
+	nodes, err := c.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return Status{}, fmt.Errorf("list nodes: %w", err)
+	}
+
+	namespaces, err := c.Namespaces(ctx)
+	if err != nil {
+		return Status{}, err
+	}
+
+	workloads, err := c.Workloads(ctx, WorkloadOptions{})
+	if err != nil {
+		return Status{}, err
+	}
+
+	readyNodes := 0
+	for _, node := range nodes.Items {
+		if nodeReady(node) {
+			readyNodes++
+		}
+	}
+
+	return Status{
+		ReadyNodes:     readyNodes,
+		NodeCount:      len(nodes.Items),
+		NamespaceCount: len(namespaces),
+		WorkloadCount:  len(workloads),
+	}, nil
+}
+
+func (c *KubernetesCluster) Namespaces(ctx context.Context) ([]Namespace, error) {
+	namespaces, err := c.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list namespaces: %w", err)
+	}
+
+	entries := make([]Namespace, 0, len(namespaces.Items))
+	for _, namespace := range namespaces.Items {
+		entries = append(entries, Namespace{
+			Name:  namespace.Name,
+			Phase: string(namespace.Status.Phase),
+			Age:   c.age(namespace.CreationTimestamp.Time),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+
+	return entries, nil
+}
+
+func (c *KubernetesCluster) Workloads(ctx context.Context, opts WorkloadOptions) ([]Workload, error) {
+	workloads := make([]Workload, 0)
+	namespace := opts.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceAll
+	}
+
+	deployments, err := c.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list deployments: %w", err)
+	}
+	for _, deployment := range deployments.Items {
+		workloads = append(workloads, c.deploymentWorkload(deployment))
+	}
+
+	statefulSets, err := c.clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list statefulsets: %w", err)
+	}
+	for _, statefulSet := range statefulSets.Items {
+		workloads = append(workloads, c.statefulSetWorkload(statefulSet))
+	}
+
+	daemonSets, err := c.clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list daemonsets: %w", err)
+	}
+	for _, daemonSet := range daemonSets.Items {
+		workloads = append(workloads, c.daemonSetWorkload(daemonSet))
+	}
+
+	jobs, err := c.clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list jobs: %w", err)
+	}
+	for _, job := range jobs.Items {
+		workloads = append(workloads, c.jobWorkload(job))
+	}
+
+	cronJobs, err := c.clientset.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list cronjobs: %w", err)
+	}
+	for _, cronJob := range cronJobs.Items {
+		workloads = append(workloads, c.cronJobWorkload(cronJob))
+	}
+
+	sort.Slice(workloads, func(i, j int) bool {
+		if workloads[i].Namespace == workloads[j].Namespace {
+			if workloads[i].Kind == workloads[j].Kind {
+				return workloads[i].Name < workloads[j].Name
+			}
+			return workloads[i].Kind < workloads[j].Kind
+		}
+		return workloads[i].Namespace < workloads[j].Namespace
+	})
+
+	return workloads, nil
+}
+
+func nodeReady(node corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func (c *KubernetesCluster) deploymentWorkload(deployment appsv1.Deployment) Workload {
+	desired := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desired = *deployment.Spec.Replicas
+	}
+
+	return Workload{
+		Name:      deployment.Name,
+		Namespace: deployment.Namespace,
+		Kind:      "Deployment",
+		Ready:     fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
+		Age:       c.age(deployment.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCluster) statefulSetWorkload(statefulSet appsv1.StatefulSet) Workload {
+	desired := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		desired = *statefulSet.Spec.Replicas
+	}
+
+	return Workload{
+		Name:      statefulSet.Name,
+		Namespace: statefulSet.Namespace,
+		Kind:      "StatefulSet",
+		Ready:     fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
+		Age:       c.age(statefulSet.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCluster) daemonSetWorkload(daemonSet appsv1.DaemonSet) Workload {
+	return Workload{
+		Name:      daemonSet.Name,
+		Namespace: daemonSet.Namespace,
+		Kind:      "DaemonSet",
+		Ready:     fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
+		Age:       c.age(daemonSet.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCluster) jobWorkload(job batchv1.Job) Workload {
+	desired := int32(1)
+	if job.Spec.Completions != nil {
+		desired = *job.Spec.Completions
+	}
+
+	return Workload{
+		Name:      job.Name,
+		Namespace: job.Namespace,
+		Kind:      "Job",
+		Ready:     fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
+		Age:       c.age(job.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCluster) cronJobWorkload(cronJob batchv1.CronJob) Workload {
+	return Workload{
+		Name:      cronJob.Name,
+		Namespace: cronJob.Namespace,
+		Kind:      "CronJob",
+		Ready:     fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
+		Age:       c.age(cronJob.CreationTimestamp.Time),
+	}
+}
+
+func (c *KubernetesCluster) age(created time.Time) string {
+	if created.IsZero() {
+		return "unknown"
+	}
+
+	duration := c.now().Sub(created)
+	switch {
+	case duration < time.Minute:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	case duration < time.Hour:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	case duration < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(duration.Hours()/24))
+	}
+}

--- a/internal/idp/cluster/cluster_test.go
+++ b/internal/idp/cluster/cluster_test.go
@@ -1,0 +1,223 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubernetesClusterStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		want    Status
+	}{
+		{
+			name: "counts ready nodes namespaces and workloads",
+			objects: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "server-a"},
+					Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					}},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "server-b"},
+					Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+					}},
+				},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "observability"}},
+				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability"}},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "analytics", Namespace: "default"}},
+			},
+			want: Status{
+				ReadyNodes:     1,
+				NodeCount:      2,
+				NamespaceCount: 2,
+				WorkloadCount:  2,
+			},
+		},
+		{
+			name: "empty cluster",
+			want: Status{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newTestCluster(tt.objects...)
+
+			status, err := cluster.Status(context.Background())
+			if err != nil {
+				t.Fatalf("Status() error = %v", err)
+			}
+
+			if status != tt.want {
+				t.Fatalf("Status() = %#v, want %#v", status, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubernetesClusterNamespaces(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		want    []Namespace
+	}{
+		{
+			name: "lists namespaces sorted by name",
+			objects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "observability", CreationTimestamp: created},
+					Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "payments", CreationTimestamp: created},
+					Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+				},
+			},
+			want: []Namespace{
+				{Name: "observability", Phase: "Active", Age: "2h"},
+				{Name: "payments", Phase: "Terminating", Age: "2h"},
+			},
+		},
+		{
+			name: "empty namespaces",
+			want: []Namespace{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newTestCluster(tt.objects...)
+
+			namespaces, err := cluster.Namespaces(context.Background())
+			if err != nil {
+				t.Fatalf("Namespaces() error = %v", err)
+			}
+
+			assertNamespaces(t, namespaces, tt.want)
+		})
+	}
+}
+
+func TestKubernetesClusterWorkloads(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+	completions := int32(1)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    WorkloadOptions
+		want    []Workload
+	}{
+		{
+			name: "lists workloads sorted by namespace kind and name",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability", CreationTimestamp: created},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+					Status:     appsv1.DeploymentStatus{ReadyReplicas: 1},
+				},
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: "observability", CreationTimestamp: created},
+					Spec:       appsv1.StatefulSetSpec{Replicas: &replicas},
+					Status:     appsv1.StatefulSetStatus{ReadyReplicas: 2},
+				},
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: "analytics", Namespace: "workers", CreationTimestamp: created},
+					Spec:       batchv1.JobSpec{Completions: &completions},
+					Status:     batchv1.JobStatus{Succeeded: 1},
+				},
+			},
+			want: []Workload{
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/2", Age: "2h"},
+				{Name: "loki", Namespace: "observability", Kind: "StatefulSet", Ready: "2/2", Age: "2h"},
+				{Name: "analytics", Namespace: "workers", Kind: "Job", Ready: "1/1", Age: "2h"},
+			},
+		},
+		{
+			name: "filters workloads by namespace",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: "observability", CreationTimestamp: created},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+					Status:     appsv1.DeploymentStatus{ReadyReplicas: 1},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "payments-api", Namespace: "payments", CreationTimestamp: created},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+					Status:     appsv1.DeploymentStatus{ReadyReplicas: 2},
+				},
+			},
+			opts: WorkloadOptions{Namespace: "payments"},
+			want: []Workload{
+				{Name: "payments-api", Namespace: "payments", Kind: "Deployment", Ready: "2/2", Age: "2h"},
+			},
+		},
+		{
+			name: "empty workloads",
+			want: []Workload{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newTestCluster(tt.objects...)
+
+			workloads, err := cluster.Workloads(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("Workloads() error = %v", err)
+			}
+
+			assertWorkloads(t, workloads, tt.want)
+		})
+	}
+}
+
+func assertNamespaces(t *testing.T, got []Namespace, want []Namespace) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(namespaces) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("namespaces[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertWorkloads(t *testing.T, got []Workload, want []Workload) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(workloads) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("workloads[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func newTestCluster(objects ...runtime.Object) *KubernetesCluster {
+	cluster := NewKubernetesClusterWithClientset(fake.NewSimpleClientset(objects...))
+	cluster.now = func() time.Time {
+		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	}
+	return cluster
+}


### PR DESCRIPTION
### Summary

This PR replaces the placeholder cluster commands with Kubernetes-backed
cluster summaries. The CLI now reads live node, namespace, and workload state
from the Kubernetes API, including namespace filtering for workload views.

### List of Changes

- Added a Kubernetes-backed cluster provider for node readiness, namespace
  phase, and workload readiness.
- Implemented `hub-cli cluster status`, `hub-cli cluster namespaces`, and
  `hub-cli cluster workloads`.
- Added namespace filtering for `cluster workloads` with `--namespace` and `-n`.
- Added table-driven tests for cluster summaries and CLI command output.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

