### PR TITLE
feat(idp): add kubernetes-backed env commands

### DIFF
--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -10,6 +10,7 @@ import (
 
 	"observability-hub/internal/idp/catalog"
 	"observability-hub/internal/idp/cluster"
+	idpenv "observability-hub/internal/idp/env"
 )
 
 type catalogClient interface {
@@ -23,12 +24,21 @@ type clusterClient interface {
 	Workloads(context.Context, cluster.WorkloadOptions) ([]cluster.Workload, error)
 }
 
+type envClient interface {
+	List(context.Context, idpenv.ListOptions) ([]idpenv.Resource, error)
+	Describe(context.Context, idpenv.DescribeOptions) ([]idpenv.Details, error)
+}
+
 var newCatalog = func() (catalogClient, error) {
 	return catalog.NewKubernetesCatalog()
 }
 
 var newCluster = func() (clusterClient, error) {
 	return cluster.NewKubernetesCluster()
+}
+
+var newEnv = func() (envClient, error) {
+	return idpenv.NewKubernetesEnvironment()
 }
 
 const helpText = `Hub CLI (IDP)
@@ -57,7 +67,7 @@ Catalog commands:
 
 Environment commands:
   env list
-  env describe <env>
+  env describe <name>
 `
 
 // Run executes the local IDP CLI command dispatcher.
@@ -163,13 +173,21 @@ func runEnv(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	switch args[0] {
 	case "list":
-		return printCalled(stdout, "idp env list")
+		opts, ok := parseEnvListOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return listEnvironments(opts, stdout, stderr)
 	case "describe":
 		if len(args) < 2 {
 			fmt.Fprint(stderr, "missing environment name for idp env describe\n")
 			return 1
 		}
-		return printCalled(stdout, "idp env describe for "+args[1])
+		opts, ok := parseEnvDescribeOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return describeEnvironment(opts, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown env command: %s\n\n", args[0])
 		fmt.Fprint(stderr, envHelpText())
@@ -243,6 +261,57 @@ func listClusterWorkloads(opts cluster.WorkloadOptions, stdout io.Writer, stderr
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", workload.Name, workload.Namespace, workload.Kind, workload.Ready, workload.Age)
 	}
 	writer.Flush()
+	return 0
+}
+
+func listEnvironments(opts idpenv.ListOptions, stdout io.Writer, stderr io.Writer) int {
+	envClient, err := newEnv()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	resources, err := envClient.List(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tTYPE\tKEYS\tAGE")
+	for _, resource := range resources {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%d\t%s\n", resource.Name, resource.Namespace, resource.Kind, resource.Type, resource.DataCount, resource.Age)
+	}
+	writer.Flush()
+	return 0
+}
+
+func describeEnvironment(opts idpenv.DescribeOptions, stdout io.Writer, stderr io.Writer) int {
+	envClient, err := newEnv()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	details, err := envClient.Describe(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	for i, detail := range details {
+		if i > 0 {
+			fmt.Fprintln(stdout)
+		}
+		fmt.Fprintf(stdout, "Name: %s\n", detail.Name)
+		fmt.Fprintf(stdout, "Namespace: %s\n", detail.Namespace)
+		fmt.Fprintf(stdout, "Kind: %s\n", detail.Kind)
+		fmt.Fprintf(stdout, "Type: %s\n", detail.Type)
+		fmt.Fprintf(stdout, "Keys: %d\n", detail.DataCount)
+		for _, key := range detail.Keys {
+			fmt.Fprintf(stdout, "- %s\n", key)
+		}
+	}
 	return 0
 }
 
@@ -326,6 +395,51 @@ func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, 
 	return opts, true
 }
 
+func parseEnvListOptions(args []string, stderr io.Writer) (idpenv.ListOptions, bool) {
+	var opts idpenv.ListOptions
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown env list option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
+func parseEnvDescribeOptions(args []string, stderr io.Writer) (idpenv.DescribeOptions, bool) {
+	opts := idpenv.DescribeOptions{Name: args[0]}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		case "--kind":
+			if i+1 >= len(args) {
+				fmt.Fprint(stderr, "missing kind for --kind\n")
+				return opts, false
+			}
+			opts.Kind = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown env describe option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
 func sortedKinds(counts map[string]int) []string {
 	kinds := make([]string, 0, len(counts))
 	for kind := range counts {
@@ -366,6 +480,6 @@ func catalogHelpText() string {
 
 func envHelpText() string {
 	return strings.TrimSpace(`Usage:
-  hub-cli env list
-  hub-cli env describe <env>`) + "\n"
+  hub-cli env list [--namespace <namespace>]
+  hub-cli env describe <name> [--namespace <namespace>] [--kind <ConfigMap|Secret>]`) + "\n"
 }

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -8,6 +8,7 @@ import (
 
 	"observability-hub/internal/idp/catalog"
 	"observability-hub/internal/idp/cluster"
+	idpenv "observability-hub/internal/idp/env"
 )
 
 func TestRunPlaceholderCommands(t *testing.T) {
@@ -30,11 +31,6 @@ func TestRunPlaceholderCommands(t *testing.T) {
 			name: "service health",
 			args: []string{"service", "health", "tempo"},
 			want: "called idp service health for tempo\n",
-		},
-		{
-			name: "env describe",
-			args: []string{"env", "describe", "local"},
-			want: "called idp env describe for local\n",
 		},
 	}
 
@@ -302,6 +298,124 @@ func TestRunCatalogNamespaceOptionErrors(t *testing.T) {
 	}
 }
 
+func TestRunEnvCommands(t *testing.T) {
+	fake := &fakeEnv{
+		resources: []idpenv.Resource{
+			{Name: "grafana-env", Namespace: "observability", Kind: "ConfigMap", Type: "-", DataCount: 2, Age: "2h"},
+			{Name: "grafana-admin", Namespace: "observability", Kind: "Secret", Type: "Opaque", DataCount: 2, Age: "2h"},
+		},
+		details: []idpenv.Details{
+			{
+				Resource: idpenv.Resource{Name: "grafana-admin", Namespace: "observability", Kind: "Secret", Type: "Opaque", DataCount: 2, Age: "2h"},
+				Keys:     []string{"password", "username"},
+			},
+		},
+	}
+	restore := stubEnv(t, fake)
+	defer restore()
+
+	tests := []struct {
+		name     string
+		args     []string
+		want     string
+		wantList []idpenv.ListOptions
+		wantDesc []idpenv.DescribeOptions
+	}{
+		{
+			name: "env list",
+			args: []string{"env", "list"},
+			want: "NAME           NAMESPACE      KIND       TYPE    KEYS  AGE\n" +
+				"grafana-env    observability  ConfigMap  -       2     2h\n" +
+				"grafana-admin  observability  Secret     Opaque  2     2h\n",
+			wantList: []idpenv.ListOptions{{}},
+		},
+		{
+			name: "env list namespace",
+			args: []string{"env", "list", "--namespace", "observability"},
+			want: "NAME           NAMESPACE      KIND       TYPE    KEYS  AGE\n" +
+				"grafana-env    observability  ConfigMap  -       2     2h\n" +
+				"grafana-admin  observability  Secret     Opaque  2     2h\n",
+			wantList: []idpenv.ListOptions{{Namespace: "observability"}},
+		},
+		{
+			name: "env describe",
+			args: []string{"env", "describe", "grafana-admin", "-n", "observability", "--kind", "Secret"},
+			want: "Name: grafana-admin\n" +
+				"Namespace: observability\n" +
+				"Kind: Secret\n" +
+				"Type: Opaque\n" +
+				"Keys: 2\n" +
+				"- password\n" +
+				"- username\n",
+			wantDesc: []idpenv.DescribeOptions{{Name: "grafana-admin", Namespace: "observability", Kind: "Secret"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.listOpts = nil
+			fake.describeOpts = nil
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("Run() code = %d, want 0; stderr = %q", code, stderr.String())
+			}
+			if got := stdout.String(); got != tt.want {
+				t.Fatalf("stdout = %q, want %q", got, tt.want)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("stderr = %q, want empty", got)
+			}
+			assertEnvListOptions(t, fake.listOpts, tt.wantList)
+			assertEnvDescribeOptions(t, fake.describeOpts, tt.wantDesc)
+		})
+	}
+}
+
+func TestRunEnvOptionErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing namespace",
+			args: []string{"env", "list", "--namespace"},
+			want: "missing namespace for --namespace",
+		},
+		{
+			name: "unknown list option",
+			args: []string{"env", "list", "--team", "payments"},
+			want: "unknown env list option: --team",
+		},
+		{
+			name: "missing kind",
+			args: []string{"env", "describe", "grafana-admin", "--kind"},
+			want: "missing kind for --kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("Run() code = %d, want 1", code)
+			}
+			if got := stdout.String(); got != "" {
+				t.Fatalf("stdout = %q, want empty", got)
+			}
+			if got := stderr.String(); !strings.Contains(got, tt.want) {
+				t.Fatalf("stderr = %q, want containing %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunMissingRequiredArgument(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -316,6 +430,23 @@ func TestRunMissingRequiredArgument(t *testing.T) {
 	if got := stderr.String(); !strings.Contains(got, "missing service name") {
 		t.Fatalf("stderr missing required argument message: %q", got)
 	}
+}
+
+type fakeEnv struct {
+	resources    []idpenv.Resource
+	details      []idpenv.Details
+	listOpts     []idpenv.ListOptions
+	describeOpts []idpenv.DescribeOptions
+}
+
+func (f *fakeEnv) List(_ context.Context, opts idpenv.ListOptions) ([]idpenv.Resource, error) {
+	f.listOpts = append(f.listOpts, opts)
+	return f.resources, nil
+}
+
+func (f *fakeEnv) Describe(_ context.Context, opts idpenv.DescribeOptions) ([]idpenv.Details, error) {
+	f.describeOpts = append(f.describeOpts, opts)
+	return f.details, nil
 }
 
 type fakeCluster struct {
@@ -378,6 +509,44 @@ func assertWorkloadOptions(t *testing.T, got []cluster.WorkloadOptions, want []c
 		if got[i] != want[i] {
 			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func assertEnvListOptions(t *testing.T, got []idpenv.ListOptions, want []idpenv.ListOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertEnvDescribeOptions(t *testing.T, got []idpenv.DescribeOptions, want []idpenv.DescribeOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func stubEnv(t *testing.T, fake *fakeEnv) func() {
+	t.Helper()
+
+	original := newEnv
+	newEnv = func() (envClient, error) {
+		return fake, nil
+	}
+	return func() {
+		newEnv = original
 	}
 }
 

--- a/internal/idp/env/env.go
+++ b/internal/idp/env/env.go
@@ -1,0 +1,230 @@
+package env
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type KubernetesEnvironment struct {
+	clientset kubernetes.Interface
+	now       func() time.Time
+}
+
+type Resource struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Type      string
+	DataCount int
+	Age       string
+}
+
+type Details struct {
+	Resource
+	Keys []string
+}
+
+type ListOptions struct {
+	Namespace string
+}
+
+type DescribeOptions struct {
+	Name      string
+	Namespace string
+	Kind      string
+}
+
+func NewKubernetesEnvironment() (*KubernetesEnvironment, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			home, _ := os.UserHomeDir()
+			kubeconfig = filepath.Join(home, ".kube", "config")
+		}
+
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("load kubeconfig: %w", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	return NewKubernetesEnvironmentWithClientset(clientset), nil
+}
+
+func NewKubernetesEnvironmentWithClientset(clientset kubernetes.Interface) *KubernetesEnvironment {
+	return &KubernetesEnvironment{
+		clientset: clientset,
+		now:       time.Now,
+	}
+}
+
+func (e *KubernetesEnvironment) List(ctx context.Context, opts ListOptions) ([]Resource, error) {
+	namespace := opts.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceAll
+	}
+
+	resources := make([]Resource, 0)
+
+	configMaps, err := e.clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list configmaps: %w", err)
+	}
+	for _, configMap := range configMaps.Items {
+		resources = append(resources, e.configMapResource(configMap))
+	}
+
+	secrets, err := e.clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+	for _, secret := range secrets.Items {
+		resources = append(resources, e.secretResource(secret))
+	}
+
+	sortResources(resources)
+	return resources, nil
+}
+
+func (e *KubernetesEnvironment) Describe(ctx context.Context, opts DescribeOptions) ([]Details, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("missing environment resource name")
+	}
+
+	resources, err := e.List(ctx, ListOptions{Namespace: opts.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]Resource, 0)
+	for _, resource := range resources {
+		if resource.Name != opts.Name {
+			continue
+		}
+		if opts.Kind != "" && !strings.EqualFold(resource.Kind, opts.Kind) {
+			continue
+		}
+		matches = append(matches, resource)
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("environment resource not found: %s", opts.Name)
+	}
+
+	details := make([]Details, 0, len(matches))
+	for _, match := range matches {
+		detail, err := e.details(ctx, match)
+		if err != nil {
+			return nil, err
+		}
+		details = append(details, detail)
+	}
+
+	return details, nil
+}
+
+func (e *KubernetesEnvironment) details(ctx context.Context, resource Resource) (Details, error) {
+	switch resource.Kind {
+	case "ConfigMap":
+		configMap, err := e.clientset.CoreV1().ConfigMaps(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
+		if err != nil {
+			return Details{}, fmt.Errorf("get configmap: %w", err)
+		}
+		return Details{Resource: resource, Keys: sortedStringKeys(configMap.Data)}, nil
+	case "Secret":
+		secret, err := e.clientset.CoreV1().Secrets(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
+		if err != nil {
+			return Details{}, fmt.Errorf("get secret: %w", err)
+		}
+		return Details{Resource: resource, Keys: sortedByteKeys(secret.Data)}, nil
+	default:
+		return Details{}, fmt.Errorf("unsupported environment resource kind: %s", resource.Kind)
+	}
+}
+
+func (e *KubernetesEnvironment) configMapResource(configMap corev1.ConfigMap) Resource {
+	return Resource{
+		Name:      configMap.Name,
+		Namespace: configMap.Namespace,
+		Kind:      "ConfigMap",
+		Type:      "-",
+		DataCount: len(configMap.Data),
+		Age:       e.age(configMap.CreationTimestamp.Time),
+	}
+}
+
+func (e *KubernetesEnvironment) secretResource(secret corev1.Secret) Resource {
+	return Resource{
+		Name:      secret.Name,
+		Namespace: secret.Namespace,
+		Kind:      "Secret",
+		Type:      string(secret.Type),
+		DataCount: len(secret.Data),
+		Age:       e.age(secret.CreationTimestamp.Time),
+	}
+}
+
+func sortResources(resources []Resource) {
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].Namespace == resources[j].Namespace {
+			if resources[i].Kind == resources[j].Kind {
+				return resources[i].Name < resources[j].Name
+			}
+			return resources[i].Kind < resources[j].Kind
+		}
+		return resources[i].Namespace < resources[j].Namespace
+	})
+}
+
+func sortedStringKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedByteKeys(values map[string][]byte) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (e *KubernetesEnvironment) age(created time.Time) string {
+	if created.IsZero() {
+		return "unknown"
+	}
+
+	duration := e.now().Sub(created)
+	switch {
+	case duration < time.Minute:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	case duration < time.Hour:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	case duration < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(duration.Hours()/24))
+	}
+}

--- a/internal/idp/env/env_test.go
+++ b/internal/idp/env/env_test.go
@@ -1,0 +1,231 @@
+package env
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubernetesEnvironmentList(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    ListOptions
+		want    []Resource
+	}{
+		{
+			name: "lists configmaps and secrets",
+			objects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana-env", Namespace: "observability", CreationTimestamp: created},
+					Data:       map[string]string{"GF_SERVER_ROOT_URL": "http://grafana"},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana-admin", Namespace: "observability", CreationTimestamp: created},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"password": []byte("redacted")},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "payments-env", Namespace: "payments", CreationTimestamp: created},
+					Data:       map[string]string{"DATABASE_HOST": "postgres"},
+				},
+			},
+			want: []Resource{
+				{Name: "grafana-env", Namespace: "observability", Kind: "ConfigMap", Type: "-", DataCount: 1, Age: "2h"},
+				{Name: "grafana-admin", Namespace: "observability", Kind: "Secret", Type: "Opaque", DataCount: 1, Age: "2h"},
+				{Name: "payments-env", Namespace: "payments", Kind: "ConfigMap", Type: "-", DataCount: 1, Age: "2h"},
+			},
+		},
+		{
+			name: "filters by namespace",
+			objects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana-env", Namespace: "observability", CreationTimestamp: created},
+					Data:       map[string]string{"GF_SERVER_ROOT_URL": "http://grafana"},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "payments-token", Namespace: "payments", CreationTimestamp: created},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"token": []byte("redacted")},
+				},
+			},
+			opts: ListOptions{Namespace: "payments"},
+			want: []Resource{
+				{Name: "payments-token", Namespace: "payments", Kind: "Secret", Type: "Opaque", DataCount: 1, Age: "2h"},
+			},
+		},
+		{
+			name: "empty env resources",
+			want: []Resource{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			environment := newTestEnvironment(tt.objects...)
+
+			resources, err := environment.List(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("List() error = %v", err)
+			}
+
+			assertResources(t, resources, tt.want)
+		})
+	}
+}
+
+func TestKubernetesEnvironmentDescribe(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    DescribeOptions
+		want    []Details
+		wantErr string
+	}{
+		{
+			name: "describes configmap keys",
+			objects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana-env", Namespace: "observability", CreationTimestamp: created},
+					Data: map[string]string{
+						"GF_SECURITY_ADMIN_USER": "admin",
+						"GF_SERVER_ROOT_URL":     "http://grafana",
+					},
+				},
+			},
+			opts: DescribeOptions{Name: "grafana-env", Namespace: "observability"},
+			want: []Details{
+				{
+					Resource: Resource{Name: "grafana-env", Namespace: "observability", Kind: "ConfigMap", Type: "-", DataCount: 2, Age: "2h"},
+					Keys:     []string{"GF_SECURITY_ADMIN_USER", "GF_SERVER_ROOT_URL"},
+				},
+			},
+		},
+		{
+			name: "describes secret keys without values",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "grafana-admin", Namespace: "observability", CreationTimestamp: created},
+					Type:       corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"password": []byte("redacted"),
+						"username": []byte("admin"),
+					},
+				},
+			},
+			opts: DescribeOptions{Name: "grafana-admin", Kind: "Secret"},
+			want: []Details{
+				{
+					Resource: Resource{Name: "grafana-admin", Namespace: "observability", Kind: "Secret", Type: "Opaque", DataCount: 2, Age: "2h"},
+					Keys:     []string{"password", "username"},
+				},
+			},
+		},
+		{
+			name:    "missing resource",
+			opts:    DescribeOptions{Name: "missing"},
+			wantErr: "environment resource not found: missing",
+		},
+		{
+			name: "describes duplicate names across namespaces",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "observability", CreationTimestamp: created},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"password": []byte("redacted")},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "payments", CreationTimestamp: created},
+					Type:       corev1.SecretTypeOpaque,
+					Data:       map[string][]byte{"token": []byte("redacted")},
+				},
+			},
+			opts: DescribeOptions{Name: "shared"},
+			want: []Details{
+				{
+					Resource: Resource{Name: "shared", Namespace: "observability", Kind: "Secret", Type: "Opaque", DataCount: 1, Age: "2h"},
+					Keys:     []string{"password"},
+				},
+				{
+					Resource: Resource{Name: "shared", Namespace: "payments", Kind: "Secret", Type: "Opaque", DataCount: 1, Age: "2h"},
+					Keys:     []string{"token"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			environment := newTestEnvironment(tt.objects...)
+
+			details, err := environment.Describe(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Describe() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Describe() error = %v", err)
+			}
+			assertDetails(t, details, tt.want)
+		})
+	}
+}
+
+func assertResources(t *testing.T, got []Resource, want []Resource) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(resources) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resources[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertStringSlice(t *testing.T, got []string, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(slice) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("slice[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func assertDetails(t *testing.T, got []Details, want []Details) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(details) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Resource != want[i].Resource {
+			t.Fatalf("details[%d].Resource = %#v, want %#v", i, got[i].Resource, want[i].Resource)
+		}
+		assertStringSlice(t, got[i].Keys, want[i].Keys)
+	}
+}
+
+func newTestEnvironment(objects ...runtime.Object) *KubernetesEnvironment {
+	environment := NewKubernetesEnvironmentWithClientset(fake.NewSimpleClientset(objects...))
+	environment.now = func() time.Time {
+		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	}
+	return environment
+}


### PR DESCRIPTION
### Summary

This PR replaces the placeholder environment commands with Kubernetes-backed
ConfigMap and Secret discovery. The CLI now lists environment/config resources
from the cluster with namespace filtering and only shows Secret metadata and key
names, never Secret values.

### List of Changes

- Added a Kubernetes-backed environment provider under `internal/idp/env`.
- Implemented `hub-cli env list` with ConfigMap and Secret table output.
- Added `--namespace` and `-n` filtering for `env list`.
- Implemented `hub-cli env describe <name>` for ConfigMap and Secret key
  discovery without printing Secret values.
- Made `env describe <name>` print every matching resource across namespaces so
  duplicate Secret names are discoverable without knowing the namespace first.
- Added table-driven tests for environment resource discovery and CLI command
  output.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

