### PR TITLE
feat(idp): add kubernetes-backed service commands

### DIFF
--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -11,6 +11,7 @@ import (
 	"observability-hub/internal/idp/catalog"
 	"observability-hub/internal/idp/cluster"
 	idpenv "observability-hub/internal/idp/env"
+	idpservice "observability-hub/internal/idp/service"
 )
 
 type catalogClient interface {
@@ -29,6 +30,11 @@ type envClient interface {
 	Describe(context.Context, idpenv.DescribeOptions) ([]idpenv.Details, error)
 }
 
+type serviceClient interface {
+	List(context.Context, idpservice.ListOptions) ([]idpservice.Summary, error)
+	Describe(context.Context, idpservice.DescribeOptions) ([]idpservice.Details, error)
+}
+
 var newCatalog = func() (catalogClient, error) {
 	return catalog.NewKubernetesCatalog()
 }
@@ -39,6 +45,10 @@ var newCluster = func() (clusterClient, error) {
 
 var newEnv = func() (envClient, error) {
 	return idpenv.NewKubernetesEnvironment()
+}
+
+var newService = func() (serviceClient, error) {
+	return idpservice.NewKubernetesService()
 }
 
 const helpText = `Hub CLI (IDP)
@@ -101,8 +111,22 @@ func runService(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	switch args[0] {
 	case "list":
-		return printCalled(stdout, "idp service list")
-	case "describe", "health", "logs", "events", "metrics", "traces", "ownership":
+		opts, ok := parseServiceListOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return listServices(opts, stdout, stderr)
+	case "describe":
+		if len(args) < 2 {
+			fmt.Fprint(stderr, "missing service name for idp service describe\n")
+			return 1
+		}
+		opts, ok := parseServiceDescribeOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return describeService(opts, stdout, stderr)
+	case "health", "logs", "events", "metrics", "traces", "ownership":
 		if len(args) < 2 {
 			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
 			return 1
@@ -197,6 +221,66 @@ func runEnv(args []string, stdout io.Writer, stderr io.Writer) int {
 
 func printCalled(stdout io.Writer, command string) int {
 	fmt.Fprintf(stdout, "called %s\n", command)
+	return 0
+}
+
+func listServices(opts idpservice.ListOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	services, err := serviceClient.List(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tREADY\tAGE")
+	for _, service := range services {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", service.Name, service.Namespace, service.Kind, service.Ready, service.Age)
+	}
+	writer.Flush()
+	return 0
+}
+
+func describeService(opts idpservice.DescribeOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	services, err := serviceClient.Describe(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	for i, service := range services {
+		if i > 0 {
+			fmt.Fprintln(stdout)
+		}
+		fmt.Fprintf(stdout, "Name: %s\n", service.Name)
+		fmt.Fprintf(stdout, "Namespace: %s\n", service.Namespace)
+		fmt.Fprintf(stdout, "Kind: %s\n", service.Kind)
+		fmt.Fprintf(stdout, "Ready: %s\n", service.Ready)
+		fmt.Fprintf(stdout, "Age: %s\n", service.Age)
+		fmt.Fprintln(stdout, "Images:")
+		for _, image := range service.Images {
+			fmt.Fprintf(stdout, "- %s\n", image)
+		}
+		fmt.Fprintln(stdout, "Labels:")
+		for _, label := range idpservice.SortedMapEntries(service.Labels) {
+			fmt.Fprintf(stdout, "- %s\n", label)
+		}
+		fmt.Fprintln(stdout, "Selectors:")
+		for _, selector := range idpservice.SortedMapEntries(service.Selector) {
+			fmt.Fprintf(stdout, "- %s\n", selector)
+		}
+	}
 	return 0
 }
 
@@ -376,6 +460,44 @@ func parseClusterWorkloadOptions(args []string, stderr io.Writer) (cluster.Workl
 	return opts, true
 }
 
+func parseServiceListOptions(args []string, stderr io.Writer) (idpservice.ListOptions, bool) {
+	var opts idpservice.ListOptions
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown service list option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
+func parseServiceDescribeOptions(args []string, stderr io.Writer) (idpservice.DescribeOptions, bool) {
+	opts := idpservice.DescribeOptions{Name: args[0]}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown service describe option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
 func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, bool) {
 	var opts catalog.ListOptions
 	for i := 0; i < len(args); i++ {
@@ -455,8 +577,8 @@ func isHelp(arg string) bool {
 
 func serviceHelpText() string {
 	return strings.TrimSpace(`Usage:
-  hub-cli service list
-  hub-cli service describe <service>
+  hub-cli service list [--namespace <namespace>|-n <namespace>]
+  hub-cli service describe <service> [--namespace <namespace>|-n <namespace>]
   hub-cli service health <service>
   hub-cli service logs <service>
   hub-cli service events <service>

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"observability-hub/internal/idp/catalog"
 	"observability-hub/internal/idp/cluster"
 	idpenv "observability-hub/internal/idp/env"
+	idpservice "observability-hub/internal/idp/service"
 )
 
 func TestRunPlaceholderCommands(t *testing.T) {
@@ -17,16 +18,6 @@ func TestRunPlaceholderCommands(t *testing.T) {
 		args []string
 		want string
 	}{
-		{
-			name: "service list",
-			args: []string{"service", "list"},
-			want: "called idp service list\n",
-		},
-		{
-			name: "service describe",
-			args: []string{"service", "describe", "loki"},
-			want: "called idp service describe for loki\n",
-		},
 		{
 			name: "service health",
 			args: []string{"service", "health", "tempo"},
@@ -66,6 +57,131 @@ func TestRunHelp(t *testing.T) {
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
+func TestRunServiceCommands(t *testing.T) {
+	fake := &fakeService{
+		summaries: []idpservice.Summary{
+			{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/1", Age: "2h"},
+			{Name: "loki", Namespace: "observability", Kind: "StatefulSet", Ready: "1/1", Age: "2h"},
+		},
+		details: []idpservice.Details{
+			{
+				Summary:  idpservice.Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/1", Age: "2h"},
+				Images:   []string{"grafana/grafana:latest"},
+				Labels:   map[string]string{"app.kubernetes.io/name": "grafana", "tier": "frontend"},
+				Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
+			},
+		},
+	}
+	restore := stubService(t, fake)
+	defer restore()
+
+	tests := []struct {
+		name     string
+		args     []string
+		want     string
+		wantList []idpservice.ListOptions
+		wantDesc []idpservice.DescribeOptions
+	}{
+		{
+			name: "service list",
+			args: []string{"service", "list"},
+			want: "NAME     NAMESPACE      KIND         READY  AGE\n" +
+				"grafana  observability  Deployment   1/1    2h\n" +
+				"loki     observability  StatefulSet  1/1    2h\n",
+			wantList: []idpservice.ListOptions{{}},
+		},
+		{
+			name: "service list namespace",
+			args: []string{"service", "list", "-n", "observability"},
+			want: "NAME     NAMESPACE      KIND         READY  AGE\n" +
+				"grafana  observability  Deployment   1/1    2h\n" +
+				"loki     observability  StatefulSet  1/1    2h\n",
+			wantList: []idpservice.ListOptions{{Namespace: "observability"}},
+		},
+		{
+			name: "service describe",
+			args: []string{"service", "describe", "grafana", "--namespace", "observability"},
+			want: "Name: grafana\n" +
+				"Namespace: observability\n" +
+				"Kind: Deployment\n" +
+				"Ready: 1/1\n" +
+				"Age: 2h\n" +
+				"Images:\n" +
+				"- grafana/grafana:latest\n" +
+				"Labels:\n" +
+				"- app.kubernetes.io/name=grafana\n" +
+				"- tier=frontend\n" +
+				"Selectors:\n" +
+				"- app.kubernetes.io/name=grafana\n",
+			wantDesc: []idpservice.DescribeOptions{{Name: "grafana", Namespace: "observability"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.listOpts = nil
+			fake.describeOpts = nil
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("Run() code = %d, want 0; stderr = %q", code, stderr.String())
+			}
+			if got := stdout.String(); got != tt.want {
+				t.Fatalf("stdout = %q, want %q", got, tt.want)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("stderr = %q, want empty", got)
+			}
+			assertServiceListOptions(t, fake.listOpts, tt.wantList)
+			assertServiceDescribeOptions(t, fake.describeOpts, tt.wantDesc)
+		})
+	}
+}
+
+func TestRunServiceOptionErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing namespace",
+			args: []string{"service", "list", "--namespace"},
+			want: "missing namespace for --namespace",
+		},
+		{
+			name: "unknown list option",
+			args: []string{"service", "list", "--team", "payments"},
+			want: "unknown service list option: --team",
+		},
+		{
+			name: "unknown describe option",
+			args: []string{"service", "describe", "grafana", "--team", "payments"},
+			want: "unknown service describe option: --team",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := Run(tt.args, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("Run() code = %d, want 1", code)
+			}
+			if got := stdout.String(); got != "" {
+				t.Fatalf("stdout = %q, want empty", got)
+			}
+			if got := stderr.String(); !strings.Contains(got, tt.want) {
+				t.Fatalf("stderr = %q, want containing %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -449,6 +565,23 @@ func (f *fakeEnv) Describe(_ context.Context, opts idpenv.DescribeOptions) ([]id
 	return f.details, nil
 }
 
+type fakeService struct {
+	summaries    []idpservice.Summary
+	details      []idpservice.Details
+	listOpts     []idpservice.ListOptions
+	describeOpts []idpservice.DescribeOptions
+}
+
+func (f *fakeService) List(_ context.Context, opts idpservice.ListOptions) ([]idpservice.Summary, error) {
+	f.listOpts = append(f.listOpts, opts)
+	return f.summaries, nil
+}
+
+func (f *fakeService) Describe(_ context.Context, opts idpservice.DescribeOptions) ([]idpservice.Details, error) {
+	f.describeOpts = append(f.describeOpts, opts)
+	return f.details, nil
+}
+
 type fakeCluster struct {
 	status       cluster.Status
 	namespaces   []cluster.Namespace
@@ -535,6 +668,44 @@ func assertEnvDescribeOptions(t *testing.T, got []idpenv.DescribeOptions, want [
 		if got[i] != want[i] {
 			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func assertServiceListOptions(t *testing.T, got []idpservice.ListOptions, want []idpservice.ListOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertServiceDescribeOptions(t *testing.T, got []idpservice.DescribeOptions, want []idpservice.DescribeOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func stubService(t *testing.T, fake *fakeService) func() {
+	t.Helper()
+
+	original := newService
+	newService = func() (serviceClient, error) {
+		return fake, nil
+	}
+	return func() {
+		newService = original
 	}
 }
 

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -1,0 +1,355 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type KubernetesService struct {
+	clientset kubernetes.Interface
+	now       func() time.Time
+}
+
+type Summary struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Ready     string
+	Age       string
+}
+
+type Details struct {
+	Summary
+	Images   []string
+	Labels   map[string]string
+	Selector map[string]string
+}
+
+type ListOptions struct {
+	Namespace string
+}
+
+type DescribeOptions struct {
+	Name      string
+	Namespace string
+}
+
+func NewKubernetesService() (*KubernetesService, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			home, _ := os.UserHomeDir()
+			kubeconfig = filepath.Join(home, ".kube", "config")
+		}
+
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("load kubeconfig: %w", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	return NewKubernetesServiceWithClientset(clientset), nil
+}
+
+func NewKubernetesServiceWithClientset(clientset kubernetes.Interface) *KubernetesService {
+	return &KubernetesService{
+		clientset: clientset,
+		now:       time.Now,
+	}
+}
+
+func (s *KubernetesService) List(ctx context.Context, opts ListOptions) ([]Summary, error) {
+	details, err := s.workloads(ctx, opts.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	summaries := make([]Summary, 0, len(details))
+	for _, detail := range details {
+		summaries = append(summaries, detail.Summary)
+	}
+
+	sortSummaries(summaries)
+	return summaries, nil
+}
+
+func (s *KubernetesService) Describe(ctx context.Context, opts DescribeOptions) ([]Details, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("missing service name")
+	}
+
+	namespace := opts.Namespace
+	name := opts.Name
+	if strings.Contains(opts.Name, "/") {
+		parts := strings.SplitN(opts.Name, "/", 2)
+		namespace = parts[0]
+		name = parts[1]
+	}
+
+	workloads, err := s.workloads(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]Details, 0)
+	for _, workload := range workloads {
+		if serviceMatches(workload, name) {
+			matches = append(matches, workload)
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("service not found: %s", opts.Name)
+	}
+
+	sortDetails(matches)
+	return matches, nil
+}
+
+func (s *KubernetesService) workloads(ctx context.Context, namespace string) ([]Details, error) {
+	if namespace == "" {
+		namespace = metav1.NamespaceAll
+	}
+
+	workloads := make([]Details, 0)
+
+	deployments, err := s.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list deployments: %w", err)
+	}
+	for _, deployment := range deployments.Items {
+		workloads = append(workloads, s.deploymentDetails(deployment))
+	}
+
+	statefulSets, err := s.clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list statefulsets: %w", err)
+	}
+	for _, statefulSet := range statefulSets.Items {
+		workloads = append(workloads, s.statefulSetDetails(statefulSet))
+	}
+
+	daemonSets, err := s.clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list daemonsets: %w", err)
+	}
+	for _, daemonSet := range daemonSets.Items {
+		workloads = append(workloads, s.daemonSetDetails(daemonSet))
+	}
+
+	jobs, err := s.clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list jobs: %w", err)
+	}
+	for _, job := range jobs.Items {
+		workloads = append(workloads, s.jobDetails(job))
+	}
+
+	cronJobs, err := s.clientset.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list cronjobs: %w", err)
+	}
+	for _, cronJob := range cronJobs.Items {
+		workloads = append(workloads, s.cronJobDetails(cronJob))
+	}
+
+	sortDetails(workloads)
+	return workloads, nil
+}
+
+func (s *KubernetesService) deploymentDetails(deployment appsv1.Deployment) Details {
+	desired := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desired = *deployment.Spec.Replicas
+	}
+
+	return Details{
+		Summary: Summary{
+			Name:      deployment.Name,
+			Namespace: deployment.Namespace,
+			Kind:      "Deployment",
+			Ready:     fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
+			Age:       s.age(deployment.CreationTimestamp.Time),
+		},
+		Images:   containerImages(deployment.Spec.Template.Spec),
+		Labels:   copyMap(deployment.Labels),
+		Selector: deployment.Spec.Selector.MatchLabels,
+	}
+}
+
+func (s *KubernetesService) statefulSetDetails(statefulSet appsv1.StatefulSet) Details {
+	desired := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		desired = *statefulSet.Spec.Replicas
+	}
+
+	return Details{
+		Summary: Summary{
+			Name:      statefulSet.Name,
+			Namespace: statefulSet.Namespace,
+			Kind:      "StatefulSet",
+			Ready:     fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
+			Age:       s.age(statefulSet.CreationTimestamp.Time),
+		},
+		Images:   containerImages(statefulSet.Spec.Template.Spec),
+		Labels:   copyMap(statefulSet.Labels),
+		Selector: statefulSet.Spec.Selector.MatchLabels,
+	}
+}
+
+func (s *KubernetesService) daemonSetDetails(daemonSet appsv1.DaemonSet) Details {
+	return Details{
+		Summary: Summary{
+			Name:      daemonSet.Name,
+			Namespace: daemonSet.Namespace,
+			Kind:      "DaemonSet",
+			Ready:     fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
+			Age:       s.age(daemonSet.CreationTimestamp.Time),
+		},
+		Images:   containerImages(daemonSet.Spec.Template.Spec),
+		Labels:   copyMap(daemonSet.Labels),
+		Selector: daemonSet.Spec.Selector.MatchLabels,
+	}
+}
+
+func (s *KubernetesService) jobDetails(job batchv1.Job) Details {
+	desired := int32(1)
+	if job.Spec.Completions != nil {
+		desired = *job.Spec.Completions
+	}
+
+	return Details{
+		Summary: Summary{
+			Name:      job.Name,
+			Namespace: job.Namespace,
+			Kind:      "Job",
+			Ready:     fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
+			Age:       s.age(job.CreationTimestamp.Time),
+		},
+		Images:   containerImages(job.Spec.Template.Spec),
+		Labels:   copyMap(job.Labels),
+		Selector: map[string]string{},
+	}
+}
+
+func (s *KubernetesService) cronJobDetails(cronJob batchv1.CronJob) Details {
+	return Details{
+		Summary: Summary{
+			Name:      cronJob.Name,
+			Namespace: cronJob.Namespace,
+			Kind:      "CronJob",
+			Ready:     fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
+			Age:       s.age(cronJob.CreationTimestamp.Time),
+		},
+		Images:   containerImages(cronJob.Spec.JobTemplate.Spec.Template.Spec),
+		Labels:   copyMap(cronJob.Labels),
+		Selector: map[string]string{},
+	}
+}
+
+func serviceMatches(detail Details, name string) bool {
+	if detail.Name == name {
+		return true
+	}
+
+	for _, key := range []string{"app.kubernetes.io/name", "app", "name"} {
+		if detail.Labels[key] == name {
+			return true
+		}
+		if detail.Selector[key] == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containerImages(spec corev1.PodSpec) []string {
+	images := make([]string, 0, len(spec.InitContainers)+len(spec.Containers))
+	for _, container := range spec.InitContainers {
+		images = append(images, container.Image)
+	}
+	for _, container := range spec.Containers {
+		images = append(images, container.Image)
+	}
+	sort.Strings(images)
+	return images
+}
+
+func copyMap(values map[string]string) map[string]string {
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
+}
+
+func sortSummaries(summaries []Summary) {
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Namespace == summaries[j].Namespace {
+			if summaries[i].Kind == summaries[j].Kind {
+				return summaries[i].Name < summaries[j].Name
+			}
+			return summaries[i].Kind < summaries[j].Kind
+		}
+		return summaries[i].Namespace < summaries[j].Namespace
+	})
+}
+
+func sortDetails(details []Details) {
+	sort.Slice(details, func(i, j int) bool {
+		if details[i].Namespace == details[j].Namespace {
+			if details[i].Kind == details[j].Kind {
+				return details[i].Name < details[j].Name
+			}
+			return details[i].Kind < details[j].Kind
+		}
+		return details[i].Namespace < details[j].Namespace
+	})
+}
+
+func SortedMapEntries(values map[string]string) []string {
+	entries := make([]string, 0, len(values))
+	for key, value := range values {
+		entries = append(entries, key+"="+value)
+	}
+	sort.Strings(entries)
+	return entries
+}
+
+func (s *KubernetesService) age(created time.Time) string {
+	if created.IsZero() {
+		return "unknown"
+	}
+
+	duration := s.now().Sub(created)
+	switch {
+	case duration < time.Minute:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	case duration < time.Hour:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	case duration < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(duration.Hours()/24))
+	}
+}

--- a/internal/idp/service/service_test.go
+++ b/internal/idp/service/service_test.go
@@ -1,0 +1,278 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubernetesServiceList(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    ListOptions
+		want    []Summary
+	}{
+		{
+			name: "lists workload services",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 1),
+				statefulSet("loki", "observability", created, replicas, 2),
+				&batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "jobs", CreationTimestamp: created}},
+			},
+			want: []Summary{
+				{Name: "backup", Namespace: "jobs", Kind: "CronJob", Ready: "active:0", Age: "2h"},
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/2", Age: "2h"},
+				{Name: "loki", Namespace: "observability", Kind: "StatefulSet", Ready: "2/2", Age: "2h"},
+			},
+		},
+		{
+			name: "filters services by namespace",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 1),
+				deployment("payments-api", "payments", created, replicas, 2),
+			},
+			opts: ListOptions{Namespace: "payments"},
+			want: []Summary{
+				{Name: "payments-api", Namespace: "payments", Kind: "Deployment", Ready: "2/2", Age: "2h"},
+			},
+		},
+		{
+			name: "empty service list",
+			want: []Summary{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+
+			summaries, err := service.List(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("List() error = %v", err)
+			}
+
+			assertSummaries(t, summaries, tt.want)
+		})
+	}
+}
+
+func TestKubernetesServiceDescribe(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    DescribeOptions
+		want    []Details
+		wantErr string
+	}{
+		{
+			name: "describes service by workload name",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 1),
+			},
+			opts: DescribeOptions{Name: "grafana"},
+			want: []Details{
+				{
+					Summary:  Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/2", Age: "2h"},
+					Images:   []string{"grafana/grafana:latest"},
+					Labels:   map[string]string{"app.kubernetes.io/name": "grafana", "tier": "frontend"},
+					Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
+				},
+			},
+		},
+		{
+			name: "describes service by label",
+			objects: []runtime.Object{
+				deployment("grafana-web", "observability", created, replicas, 1),
+			},
+			opts: DescribeOptions{Name: "grafana"},
+			want: []Details{
+				{
+					Summary:  Summary{Name: "grafana-web", Namespace: "observability", Kind: "Deployment", Ready: "1/2", Age: "2h"},
+					Images:   []string{"grafana/grafana:latest"},
+					Labels:   map[string]string{"app.kubernetes.io/name": "grafana", "tier": "frontend"},
+					Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
+				},
+			},
+		},
+		{
+			name: "describes namespace qualified service",
+			objects: []runtime.Object{
+				deployment("api", "payments", created, replicas, 2),
+				deployment("api", "observability", created, replicas, 1),
+			},
+			opts: DescribeOptions{Name: "payments/api"},
+			want: []Details{
+				{
+					Summary:  Summary{Name: "api", Namespace: "payments", Kind: "Deployment", Ready: "2/2", Age: "2h"},
+					Images:   []string{"grafana/grafana:latest"},
+					Labels:   map[string]string{"app.kubernetes.io/name": "grafana", "tier": "frontend"},
+					Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
+				},
+			},
+		},
+		{
+			name: "returns all duplicate service names across namespaces",
+			objects: []runtime.Object{
+				deployment("api", "payments", created, replicas, 2),
+				deployment("api", "observability", created, replicas, 1),
+			},
+			opts: DescribeOptions{Name: "api"},
+			want: []Details{
+				{
+					Summary:  Summary{Name: "api", Namespace: "observability", Kind: "Deployment", Ready: "1/2", Age: "2h"},
+					Images:   []string{"grafana/grafana:latest"},
+					Labels:   map[string]string{"app.kubernetes.io/name": "grafana", "tier": "frontend"},
+					Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
+				},
+				{
+					Summary:  Summary{Name: "api", Namespace: "payments", Kind: "Deployment", Ready: "2/2", Age: "2h"},
+					Images:   []string{"grafana/grafana:latest"},
+					Labels:   map[string]string{"app.kubernetes.io/name": "grafana", "tier": "frontend"},
+					Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
+				},
+			},
+		},
+		{
+			name:    "missing service",
+			opts:    DescribeOptions{Name: "missing"},
+			wantErr: "service not found: missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+
+			details, err := service.Describe(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Describe() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Describe() error = %v", err)
+			}
+
+			assertDetails(t, details, tt.want)
+		})
+	}
+}
+
+func deployment(name string, namespace string, created metav1.Time, replicas int32, ready int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: created,
+			Labels:            map[string]string{"app.kubernetes.io/name": "grafana", "tier": "frontend"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "grafana",
+			}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "grafana/grafana:latest"}},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: ready},
+	}
+}
+
+func statefulSet(name string, namespace string, created metav1.Time, replicas int32, ready int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, CreationTimestamp: created},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"app.kubernetes.io/name": name,
+			}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "grafana/loki:latest"}},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{ReadyReplicas: ready},
+	}
+}
+
+func assertSummaries(t *testing.T, got []Summary, want []Summary) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(summaries) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("summaries[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertDetails(t *testing.T, got []Details, want []Details) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(details) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Summary != want[i].Summary {
+			t.Fatalf("details[%d].Summary = %#v, want %#v", i, got[i].Summary, want[i].Summary)
+		}
+		assertStringSlice(t, got[i].Images, want[i].Images)
+		assertStringMap(t, got[i].Labels, want[i].Labels)
+		assertStringMap(t, got[i].Selector, want[i].Selector)
+	}
+}
+
+func assertStringSlice(t *testing.T, got []string, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(slice) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("slice[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func assertStringMap(t *testing.T, got map[string]string, want map[string]string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(map) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("map[%q] = %q, want %q", key, got[key], value)
+		}
+	}
+}
+
+func newTestService(objects ...runtime.Object) *KubernetesService {
+	service := NewKubernetesServiceWithClientset(fake.NewSimpleClientset(objects...))
+	service.now = func() time.Time {
+		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	}
+	return service
+}


### PR DESCRIPTION
### Summary

This PR makes the service commands read live Kubernetes workloads instead of
printing placeholder messages. Developers can now list service-like workloads
and inspect a service by workload name, `namespace/name`, or common app labels.

### List of Changes

- Added Kubernetes-backed service discovery for workload listing and service
  inspection, including readiness, images, labels, selectors, and age.
- Made service lookup usable across namespaces by supporting namespace filters,
  `namespace/name`, label-based matching, and multiple matching results.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

