### PR TITLE
feat(idp): add kubernetes-backed service health

### DIFF
--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -33,6 +33,7 @@ type envClient interface {
 type serviceClient interface {
 	List(context.Context, idpservice.ListOptions) ([]idpservice.Summary, error)
 	Describe(context.Context, idpservice.DescribeOptions) ([]idpservice.Details, error)
+	Health(context.Context, idpservice.HealthOptions) ([]idpservice.Health, error)
 }
 
 var newCatalog = func() (catalogClient, error) {
@@ -126,7 +127,17 @@ func runService(args []string, stdout io.Writer, stderr io.Writer) int {
 			return 1
 		}
 		return describeService(opts, stdout, stderr)
-	case "health", "logs", "events", "metrics", "traces", "ownership":
+	case "health":
+		if len(args) < 2 {
+			fmt.Fprint(stderr, "missing service name for idp service health\n")
+			return 1
+		}
+		opts, ok := parseServiceHealthOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return healthService(opts, stdout, stderr)
+	case "logs", "events", "metrics", "traces", "ownership":
 		if len(args) < 2 {
 			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
 			return 1
@@ -281,6 +292,53 @@ func describeService(opts idpservice.DescribeOptions, stdout io.Writer, stderr i
 			fmt.Fprintf(stdout, "- %s\n", selector)
 		}
 	}
+	return 0
+}
+
+func healthService(opts idpservice.HealthOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	health, err := serviceClient.Health(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tSTATUS\tREADY\tPODS\tRESTARTS\tSERVICES\tWARNINGS")
+	for _, item := range health {
+		fmt.Fprintf(
+			writer,
+			"%s\t%s\t%s\t%s\t%s\t%d/%d\t%d\t%d/%d\t%d\n",
+			item.Name,
+			item.Namespace,
+			item.Kind,
+			item.Status,
+			item.Ready,
+			item.ReadyPods,
+			item.PodCount,
+			item.Restarts,
+			item.ReadyServices,
+			item.ServiceCount,
+			item.WarningEventCount,
+		)
+	}
+	writer.Flush()
+
+	for _, item := range health {
+		if len(item.WarningEventReasons) == 0 {
+			continue
+		}
+		fmt.Fprintf(stdout, "%s/%s warning events:\n", item.Namespace, item.Name)
+		for _, reason := range item.WarningEventReasons {
+			fmt.Fprintf(stdout, "- %s\n", reason)
+		}
+	}
+
 	return 0
 }
 
@@ -498,6 +556,25 @@ func parseServiceDescribeOptions(args []string, stderr io.Writer) (idpservice.De
 	return opts, true
 }
 
+func parseServiceHealthOptions(args []string, stderr io.Writer) (idpservice.HealthOptions, bool) {
+	opts := idpservice.HealthOptions{Name: args[0]}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown service health option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
 func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, bool) {
 	var opts catalog.ListOptions
 	for i := 0; i < len(args); i++ {
@@ -579,7 +656,7 @@ func serviceHelpText() string {
 	return strings.TrimSpace(`Usage:
   hub-cli service list [--namespace <namespace>|-n <namespace>]
   hub-cli service describe <service> [--namespace <namespace>|-n <namespace>]
-  hub-cli service health <service>
+  hub-cli service health <service> [--namespace <namespace>|-n <namespace>]
   hub-cli service logs <service>
   hub-cli service events <service>
   hub-cli service metrics <service>

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -17,13 +17,7 @@ func TestRunPlaceholderCommands(t *testing.T) {
 		name string
 		args []string
 		want string
-	}{
-		{
-			name: "service health",
-			args: []string{"service", "health", "tempo"},
-			want: "called idp service health for tempo\n",
-		},
-	}
+	}{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,6 +68,17 @@ func TestRunServiceCommands(t *testing.T) {
 				Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
 			},
 		},
+		health: []idpservice.Health{
+			{
+				Summary:           idpservice.Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/1", Age: "2h"},
+				Status:            "healthy",
+				ReadyPods:         2,
+				PodCount:          2,
+				ReadyServices:     1,
+				ServiceCount:      1,
+				WarningEventCount: 0,
+			},
+		},
 	}
 	restore := stubService(t, fake)
 	defer restore()
@@ -84,6 +89,7 @@ func TestRunServiceCommands(t *testing.T) {
 		want     string
 		wantList []idpservice.ListOptions
 		wantDesc []idpservice.DescribeOptions
+		wantHeal []idpservice.HealthOptions
 	}{
 		{
 			name: "service list",
@@ -118,12 +124,20 @@ func TestRunServiceCommands(t *testing.T) {
 				"- app.kubernetes.io/name=grafana\n",
 			wantDesc: []idpservice.DescribeOptions{{Name: "grafana", Namespace: "observability"}},
 		},
+		{
+			name: "service health",
+			args: []string{"service", "health", "grafana", "-n", "observability"},
+			want: "NAME     NAMESPACE      KIND        STATUS   READY  PODS  RESTARTS  SERVICES  WARNINGS\n" +
+				"grafana  observability  Deployment  healthy  1/1    2/2   0         1/1       0\n",
+			wantHeal: []idpservice.HealthOptions{{Name: "grafana", Namespace: "observability"}},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fake.listOpts = nil
 			fake.describeOpts = nil
+			fake.healthOpts = nil
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 
@@ -139,6 +153,7 @@ func TestRunServiceCommands(t *testing.T) {
 			}
 			assertServiceListOptions(t, fake.listOpts, tt.wantList)
 			assertServiceDescribeOptions(t, fake.describeOpts, tt.wantDesc)
+			assertServiceHealthOptions(t, fake.healthOpts, tt.wantHeal)
 		})
 	}
 }
@@ -163,6 +178,11 @@ func TestRunServiceOptionErrors(t *testing.T) {
 			name: "unknown describe option",
 			args: []string{"service", "describe", "grafana", "--team", "payments"},
 			want: "unknown service describe option: --team",
+		},
+		{
+			name: "unknown health option",
+			args: []string{"service", "health", "grafana", "--team", "payments"},
+			want: "unknown service health option: --team",
 		},
 	}
 
@@ -568,8 +588,10 @@ func (f *fakeEnv) Describe(_ context.Context, opts idpenv.DescribeOptions) ([]id
 type fakeService struct {
 	summaries    []idpservice.Summary
 	details      []idpservice.Details
+	health       []idpservice.Health
 	listOpts     []idpservice.ListOptions
 	describeOpts []idpservice.DescribeOptions
+	healthOpts   []idpservice.HealthOptions
 }
 
 func (f *fakeService) List(_ context.Context, opts idpservice.ListOptions) ([]idpservice.Summary, error) {
@@ -580,6 +602,11 @@ func (f *fakeService) List(_ context.Context, opts idpservice.ListOptions) ([]id
 func (f *fakeService) Describe(_ context.Context, opts idpservice.DescribeOptions) ([]idpservice.Details, error) {
 	f.describeOpts = append(f.describeOpts, opts)
 	return f.details, nil
+}
+
+func (f *fakeService) Health(_ context.Context, opts idpservice.HealthOptions) ([]idpservice.Health, error) {
+	f.healthOpts = append(f.healthOpts, opts)
+	return f.health, nil
 }
 
 type fakeCluster struct {
@@ -685,6 +712,19 @@ func assertServiceListOptions(t *testing.T, got []idpservice.ListOptions, want [
 }
 
 func assertServiceDescribeOptions(t *testing.T, got []idpservice.DescribeOptions, want []idpservice.DescribeOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertServiceHealthOptions(t *testing.T, got []idpservice.HealthOptions, want []idpservice.HealthOptions) {
 	t.Helper()
 
 	if len(got) != len(want) {

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -45,6 +46,23 @@ type ListOptions struct {
 type DescribeOptions struct {
 	Name      string
 	Namespace string
+}
+
+type HealthOptions struct {
+	Name      string
+	Namespace string
+}
+
+type Health struct {
+	Summary
+	Status              string
+	ReadyPods           int
+	PodCount            int
+	Restarts            int32
+	ReadyServices       int
+	ServiceCount        int
+	WarningEventCount   int
+	WarningEventReasons []string
 }
 
 func NewKubernetesService() (*KubernetesService, error) {
@@ -125,6 +143,25 @@ func (s *KubernetesService) Describe(ctx context.Context, opts DescribeOptions) 
 	return matches, nil
 }
 
+func (s *KubernetesService) Health(ctx context.Context, opts HealthOptions) ([]Health, error) {
+	details, err := s.Describe(ctx, DescribeOptions{Name: opts.Name, Namespace: opts.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	health := make([]Health, 0, len(details))
+	for _, detail := range details {
+		result, err := s.health(ctx, detail)
+		if err != nil {
+			return nil, err
+		}
+		health = append(health, result)
+	}
+
+	sortHealth(health)
+	return health, nil
+}
+
 func (s *KubernetesService) workloads(ctx context.Context, namespace string) ([]Details, error) {
 	if namespace == "" {
 		namespace = metav1.NamespaceAll
@@ -174,6 +211,136 @@ func (s *KubernetesService) workloads(ctx context.Context, namespace string) ([]
 
 	sortDetails(workloads)
 	return workloads, nil
+}
+
+func (s *KubernetesService) health(ctx context.Context, detail Details) (Health, error) {
+	pods, err := s.podsFor(ctx, detail)
+	if err != nil {
+		return Health{}, err
+	}
+
+	readyPods := 0
+	var restarts int32
+	podNames := make(map[string]struct{}, len(pods))
+	for _, pod := range pods {
+		podNames[pod.Name] = struct{}{}
+		if podReady(pod) {
+			readyPods++
+		}
+		for _, status := range pod.Status.ContainerStatuses {
+			restarts += status.RestartCount
+		}
+	}
+
+	serviceCount, readyServices, err := s.serviceEndpointStatus(ctx, detail)
+	if err != nil {
+		return Health{}, err
+	}
+
+	warnings, err := s.warningEventReasons(ctx, detail, podNames)
+	if err != nil {
+		return Health{}, err
+	}
+
+	health := Health{
+		Summary:             detail.Summary,
+		ReadyPods:           readyPods,
+		PodCount:            len(pods),
+		Restarts:            restarts,
+		ReadyServices:       readyServices,
+		ServiceCount:        serviceCount,
+		WarningEventCount:   len(warnings),
+		WarningEventReasons: warnings,
+	}
+	health.Status = healthStatus(health)
+	return health, nil
+}
+
+func (s *KubernetesService) podsFor(ctx context.Context, detail Details) ([]corev1.Pod, error) {
+	if len(detail.Selector) == 0 {
+		return []corev1.Pod{}, nil
+	}
+
+	pods, err := s.clientset.CoreV1().Pods(detail.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelsSelector(detail.Selector),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+
+	return pods.Items, nil
+}
+
+func (s *KubernetesService) serviceEndpointStatus(ctx context.Context, detail Details) (int, int, error) {
+	if len(detail.Selector) == 0 {
+		return 0, 0, nil
+	}
+
+	services, err := s.clientset.CoreV1().Services(detail.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, 0, fmt.Errorf("list services: %w", err)
+	}
+
+	serviceCount := 0
+	readyServices := 0
+	for _, service := range services.Items {
+		if !selectorCovers(detail.Selector, service.Spec.Selector) {
+			continue
+		}
+		serviceCount++
+		ready, err := s.serviceHasReadyEndpointSlice(ctx, detail.Namespace, service.Name)
+		if err != nil {
+			return 0, 0, err
+		}
+		if ready {
+			readyServices++
+		}
+	}
+
+	return serviceCount, readyServices, nil
+}
+
+func (s *KubernetesService) serviceHasReadyEndpointSlice(ctx context.Context, namespace string, serviceName string) (bool, error) {
+	endpointSlices, err := s.clientset.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: discoveryv1.LabelServiceName + "=" + serviceName,
+	})
+	if err != nil {
+		return false, fmt.Errorf("list endpointslices: %w", err)
+	}
+
+	for _, endpointSlice := range endpointSlices.Items {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func (s *KubernetesService) warningEventReasons(ctx context.Context, detail Details, podNames map[string]struct{}) ([]string, error) {
+	events, err := s.clientset.CoreV1().Events(detail.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list events: %w", err)
+	}
+
+	reasons := make([]string, 0)
+	for _, event := range events.Items {
+		if event.Type != corev1.EventTypeWarning {
+			continue
+		}
+		if event.InvolvedObject.Name == detail.Name {
+			reasons = append(reasons, event.Reason)
+			continue
+		}
+		if _, ok := podNames[event.InvolvedObject.Name]; ok {
+			reasons = append(reasons, event.Reason)
+		}
+	}
+
+	sort.Strings(reasons)
+	return reasons, nil
 }
 
 func (s *KubernetesService) deploymentDetails(deployment appsv1.Deployment) Details {
@@ -327,6 +494,18 @@ func sortDetails(details []Details) {
 	})
 }
 
+func sortHealth(health []Health) {
+	sort.Slice(health, func(i, j int) bool {
+		if health[i].Namespace == health[j].Namespace {
+			if health[i].Kind == health[j].Kind {
+				return health[i].Name < health[j].Name
+			}
+			return health[i].Kind < health[j].Kind
+		}
+		return health[i].Namespace < health[j].Namespace
+	})
+}
+
 func SortedMapEntries(values map[string]string) []string {
 	entries := make([]string, 0, len(values))
 	for key, value := range values {
@@ -334,6 +513,64 @@ func SortedMapEntries(values map[string]string) []string {
 	}
 	sort.Strings(entries)
 	return entries
+}
+
+func labelsSelector(values map[string]string) string {
+	parts := make([]string, 0, len(values))
+	for key, value := range values {
+		parts = append(parts, key+"="+value)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func selectorCovers(workloadSelector map[string]string, serviceSelector map[string]string) bool {
+	if len(serviceSelector) == 0 {
+		return false
+	}
+	for key, value := range serviceSelector {
+		if workloadSelector[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func podReady(pod corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func healthStatus(health Health) string {
+	if health.WarningEventCount > 0 {
+		return "degraded"
+	}
+	if !readyRatioHealthy(health.Ready) {
+		return "degraded"
+	}
+	if health.PodCount > 0 && health.ReadyPods != health.PodCount {
+		return "degraded"
+	}
+	if health.ServiceCount > 0 && health.ReadyServices != health.ServiceCount {
+		return "degraded"
+	}
+	if health.PodCount == 0 && health.ServiceCount == 0 {
+		return "unknown"
+	}
+	return "healthy"
+}
+
+func readyRatioHealthy(ready string) bool {
+	var current int
+	var desired int
+	if _, err := fmt.Sscanf(ready, "%d/%d", &current, &desired); err != nil {
+		return true
+	}
+	return current == desired
 }
 
 func (s *KubernetesService) age(created time.Time) string {

--- a/internal/idp/service/service_test.go
+++ b/internal/idp/service/service_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -173,6 +174,114 @@ func TestKubernetesServiceDescribe(t *testing.T) {
 	}
 }
 
+func TestKubernetesServiceHealth(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    HealthOptions
+		want    []Health
+		wantErr string
+	}{
+		{
+			name: "healthy service",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 2),
+				pod("grafana-0", "observability", true, 0),
+				pod("grafana-1", "observability", true, 0),
+				kubernetesService("grafana", "observability"),
+				endpointSlice("grafana", "observability", true),
+			},
+			opts: HealthOptions{Name: "grafana"},
+			want: []Health{
+				{
+					Summary:             Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "2/2", Age: "2h"},
+					Status:              "healthy",
+					ReadyPods:           2,
+					PodCount:            2,
+					ReadyServices:       1,
+					ServiceCount:        1,
+					WarningEventReasons: []string{},
+				},
+			},
+		},
+		{
+			name: "restarted but currently ready service",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 2),
+				pod("grafana-0", "observability", true, 1),
+				pod("grafana-1", "observability", true, 0),
+				kubernetesService("grafana", "observability"),
+				endpointSlice("grafana", "observability", true),
+			},
+			opts: HealthOptions{Name: "grafana"},
+			want: []Health{
+				{
+					Summary:             Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "2/2", Age: "2h"},
+					Status:              "healthy",
+					ReadyPods:           2,
+					PodCount:            2,
+					Restarts:            1,
+					ReadyServices:       1,
+					ServiceCount:        1,
+					WarningEventReasons: []string{},
+				},
+			},
+		},
+		{
+			name: "degraded service",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 1),
+				pod("grafana-0", "observability", true, 1),
+				pod("grafana-1", "observability", false, 0),
+				kubernetesService("grafana", "observability"),
+				endpointSlice("grafana", "observability", false),
+				warningEvent("grafana-1", "observability", "BackOff"),
+			},
+			opts: HealthOptions{Name: "grafana"},
+			want: []Health{
+				{
+					Summary:             Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/2", Age: "2h"},
+					Status:              "degraded",
+					ReadyPods:           1,
+					PodCount:            2,
+					Restarts:            1,
+					ReadyServices:       0,
+					ServiceCount:        1,
+					WarningEventCount:   1,
+					WarningEventReasons: []string{"BackOff"},
+				},
+			},
+		},
+		{
+			name:    "missing service",
+			opts:    HealthOptions{Name: "missing"},
+			wantErr: "service not found: missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+
+			health, err := service.Health(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Health() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Health() error = %v", err)
+			}
+
+			assertHealth(t, health, tt.want)
+		})
+	}
+}
+
 func deployment(name string, namespace string, created metav1.Time, replicas int32, ready int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -214,6 +323,72 @@ func statefulSet(name string, namespace string, created metav1.Time, replicas in
 	}
 }
 
+func pod(name string, namespace string, ready bool, restarts int32) *corev1.Pod {
+	conditionStatus := corev1.ConditionFalse
+	if ready {
+		conditionStatus = corev1.ConditionTrue
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app.kubernetes.io/name": "grafana"},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: conditionStatus},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", RestartCount: restarts},
+			},
+		},
+	}
+}
+
+func kubernetesService(name string, namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app.kubernetes.io/name": "grafana"},
+		},
+	}
+}
+
+func endpointSlice(name string, namespace string, ready bool) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: name,
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"10.0.0.1"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: &ready,
+				},
+			},
+		},
+	}
+}
+
+func warningEvent(name string, namespace string, reason string) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "." + reason, Namespace: namespace},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type:   corev1.EventTypeWarning,
+		Reason: reason,
+	}
+}
+
 func assertSummaries(t *testing.T, got []Summary, want []Summary) {
 	t.Helper()
 
@@ -224,6 +399,29 @@ func assertSummaries(t *testing.T, got []Summary, want []Summary) {
 		if got[i] != want[i] {
 			t.Fatalf("summaries[%d] = %#v, want %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func assertHealth(t *testing.T, got []Health, want []Health) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(health) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Summary != want[i].Summary {
+			t.Fatalf("health[%d].Summary = %#v, want %#v", i, got[i].Summary, want[i].Summary)
+		}
+		if got[i].Status != want[i].Status ||
+			got[i].ReadyPods != want[i].ReadyPods ||
+			got[i].PodCount != want[i].PodCount ||
+			got[i].Restarts != want[i].Restarts ||
+			got[i].ReadyServices != want[i].ReadyServices ||
+			got[i].ServiceCount != want[i].ServiceCount ||
+			got[i].WarningEventCount != want[i].WarningEventCount {
+			t.Fatalf("health[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+		assertStringSlice(t, got[i].WarningEventReasons, want[i].WarningEventReasons)
 	}
 }
 


### PR DESCRIPTION
### Summary

This PR makes `service health` report live Kubernetes health signals instead of
printing a placeholder message. Developers can now see current readiness,
EndpointSlice availability, warning events, and restart counts from one command.

### List of Changes

- Added Kubernetes-backed service health summarization across workloads, pods,
  Services, EndpointSlices, and warning Events.
- Made health lookup follow the same service resolution model as describe,
  including namespace filters and multiple matching workloads.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

