### PR TITLE
feat(idp): add kubernetes-backed service logs and events

### DIFF
--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"observability-hub/internal/idp/catalog"
 	"observability-hub/internal/idp/cluster"
@@ -34,6 +36,8 @@ type serviceClient interface {
 	List(context.Context, idpservice.ListOptions) ([]idpservice.Summary, error)
 	Describe(context.Context, idpservice.DescribeOptions) ([]idpservice.Details, error)
 	Health(context.Context, idpservice.HealthOptions) ([]idpservice.Health, error)
+	Logs(context.Context, idpservice.LogsOptions) ([]idpservice.LogLine, error)
+	Events(context.Context, idpservice.EventsOptions) ([]idpservice.Event, error)
 }
 
 var newCatalog = func() (catalogClient, error) {
@@ -137,7 +141,27 @@ func runService(args []string, stdout io.Writer, stderr io.Writer) int {
 			return 1
 		}
 		return healthService(opts, stdout, stderr)
-	case "logs", "events", "metrics", "traces", "ownership":
+	case "logs":
+		if len(args) < 2 {
+			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
+			return 1
+		}
+		opts, ok := parseServiceLogsOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return logsService(opts, stdout, stderr)
+	case "events":
+		if len(args) < 2 {
+			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
+			return 1
+		}
+		opts, ok := parseServiceEventsOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return eventsService(opts, stdout, stderr)
+	case "metrics", "traces", "ownership":
 		if len(args) < 2 {
 			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
 			return 1
@@ -339,6 +363,55 @@ func healthService(opts idpservice.HealthOptions, stdout io.Writer, stderr io.Wr
 		}
 	}
 
+	return 0
+}
+
+func logsService(opts idpservice.LogsOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	logs, err := serviceClient.Logs(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	if len(logs) == 0 {
+		fmt.Fprintf(stdout, "no logs found for %s\n", opts.Name)
+		return 0
+	}
+
+	for _, line := range logs {
+		fmt.Fprintf(stdout, "%s/%s %s %s\n", line.Namespace, line.Pod, line.Name, line.Line)
+	}
+	return 0
+}
+
+func eventsService(opts idpservice.EventsOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	events, err := serviceClient.Events(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	if len(events) == 0 {
+		fmt.Fprintf(stdout, "no events found for %s\n", opts.Name)
+		return 0
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "TYPE\tREASON\tAGE\tOBJECT\tMESSAGE")
+	for _, event := range events {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", event.Type, event.Reason, event.Age, event.Object, event.Message)
+	}
+	writer.Flush()
 	return 0
 }
 
@@ -575,6 +648,81 @@ func parseServiceHealthOptions(args []string, stderr io.Writer) (idpservice.Heal
 	return opts, true
 }
 
+func parseServiceLogsOptions(args []string, stderr io.Writer) (idpservice.LogsOptions, bool) {
+	opts := idpservice.LogsOptions{Name: args[0], Tail: 100}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		case "--container", "-c":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing container for %s\n", args[i])
+				return opts, false
+			}
+			opts.Container = args[i+1]
+			i++
+		case "--tail":
+			tail, ok := parsePositiveInt64(args, i, "tail", stderr)
+			if !ok {
+				return opts, false
+			}
+			opts.Tail = tail
+			i++
+		case "--since":
+			since, ok := parseDurationOption(args, i, "since", stderr)
+			if !ok {
+				return opts, false
+			}
+			opts.Since = since
+			i++
+		case "--previous":
+			opts.Previous = true
+		default:
+			fmt.Fprintf(stderr, "unknown service logs option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
+func parseServiceEventsOptions(args []string, stderr io.Writer) (idpservice.EventsOptions, bool) {
+	opts := idpservice.EventsOptions{Name: args[0], Tail: 25}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		case "--tail":
+			tail, ok := parsePositiveInt(args, i, "tail", stderr)
+			if !ok {
+				return opts, false
+			}
+			opts.Tail = tail
+			i++
+		case "--since":
+			since, ok := parseDurationOption(args, i, "since", stderr)
+			if !ok {
+				return opts, false
+			}
+			opts.Since = since
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown service events option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
 func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, bool) {
 	var opts catalog.ListOptions
 	for i := 0; i < len(args); i++ {
@@ -652,13 +800,44 @@ func isHelp(arg string) bool {
 	return arg == "-h" || arg == "--help" || arg == "help"
 }
 
+func parsePositiveInt(args []string, index int, name string, stderr io.Writer) (int, bool) {
+	value, ok := parsePositiveInt64(args, index, name, stderr)
+	return int(value), ok
+}
+
+func parsePositiveInt64(args []string, index int, name string, stderr io.Writer) (int64, bool) {
+	if index+1 >= len(args) {
+		fmt.Fprintf(stderr, "missing %s for %s\n", name, args[index])
+		return 0, false
+	}
+	value, err := strconv.ParseInt(args[index+1], 10, 64)
+	if err != nil || value < 1 {
+		fmt.Fprintf(stderr, "invalid %s for %s: %s\n", name, args[index], args[index+1])
+		return 0, false
+	}
+	return value, true
+}
+
+func parseDurationOption(args []string, index int, name string, stderr io.Writer) (time.Duration, bool) {
+	if index+1 >= len(args) {
+		fmt.Fprintf(stderr, "missing %s for %s\n", name, args[index])
+		return 0, false
+	}
+	value, err := time.ParseDuration(args[index+1])
+	if err != nil || value <= 0 {
+		fmt.Fprintf(stderr, "invalid %s for %s: %s\n", name, args[index], args[index+1])
+		return 0, false
+	}
+	return value, true
+}
+
 func serviceHelpText() string {
 	return strings.TrimSpace(`Usage:
   hub-cli service list [--namespace <namespace>|-n <namespace>]
   hub-cli service describe <service> [--namespace <namespace>|-n <namespace>]
   hub-cli service health <service> [--namespace <namespace>|-n <namespace>]
-  hub-cli service logs <service>
-  hub-cli service events <service>
+  hub-cli service logs <service> [--namespace <namespace>|-n <namespace>] [--container <container>|-c <container>] [--tail <lines>] [--since <duration>] [--previous]
+  hub-cli service events <service> [--namespace <namespace>|-n <namespace>] [--tail <count>] [--since <duration>]
   hub-cli service metrics <service>
   hub-cli service traces <service>
   hub-cli service ownership <service>`) + "\n"

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"observability-hub/internal/idp/catalog"
 	"observability-hub/internal/idp/cluster"
@@ -79,6 +80,12 @@ func TestRunServiceCommands(t *testing.T) {
 				WarningEventCount: 0,
 			},
 		},
+		logs: []idpservice.LogLine{
+			{Name: "grafana", Namespace: "observability", Kind: "Deployment", Pod: "grafana-0", Line: "ready"},
+		},
+		events: []idpservice.Event{
+			{Type: "Warning", Reason: "BackOff", Age: "1m", Object: "Pod/grafana-0", Message: "back-off restarting failed container"},
+		},
 	}
 	restore := stubService(t, fake)
 	defer restore()
@@ -90,6 +97,8 @@ func TestRunServiceCommands(t *testing.T) {
 		wantList []idpservice.ListOptions
 		wantDesc []idpservice.DescribeOptions
 		wantHeal []idpservice.HealthOptions
+		wantLogs []idpservice.LogsOptions
+		wantEvts []idpservice.EventsOptions
 	}{
 		{
 			name: "service list",
@@ -131,6 +140,19 @@ func TestRunServiceCommands(t *testing.T) {
 				"grafana  observability  Deployment  healthy  1/1    2/2   0         1/1       0\n",
 			wantHeal: []idpservice.HealthOptions{{Name: "grafana", Namespace: "observability"}},
 		},
+		{
+			name:     "service logs",
+			args:     []string{"service", "logs", "grafana", "-n", "observability", "--container", "app", "--tail", "10", "--since", "5m", "--previous"},
+			want:     "observability/grafana-0 grafana ready\n",
+			wantLogs: []idpservice.LogsOptions{{Name: "grafana", Namespace: "observability", Container: "app", Tail: 10, Since: 5 * time.Minute, Previous: true}},
+		},
+		{
+			name: "service events",
+			args: []string{"service", "events", "grafana", "-n", "observability", "--tail", "5", "--since", "10m"},
+			want: "TYPE     REASON   AGE  OBJECT         MESSAGE\n" +
+				"Warning  BackOff  1m   Pod/grafana-0  back-off restarting failed container\n",
+			wantEvts: []idpservice.EventsOptions{{Name: "grafana", Namespace: "observability", Tail: 5, Since: 10 * time.Minute}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -138,6 +160,8 @@ func TestRunServiceCommands(t *testing.T) {
 			fake.listOpts = nil
 			fake.describeOpts = nil
 			fake.healthOpts = nil
+			fake.logsOpts = nil
+			fake.eventsOpts = nil
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 
@@ -154,8 +178,31 @@ func TestRunServiceCommands(t *testing.T) {
 			assertServiceListOptions(t, fake.listOpts, tt.wantList)
 			assertServiceDescribeOptions(t, fake.describeOpts, tt.wantDesc)
 			assertServiceHealthOptions(t, fake.healthOpts, tt.wantHeal)
+			assertServiceLogsOptions(t, fake.logsOpts, tt.wantLogs)
+			assertServiceEventsOptions(t, fake.eventsOpts, tt.wantEvts)
 		})
 	}
+}
+
+func TestRunServiceEventsEmpty(t *testing.T) {
+	fake := &fakeService{}
+	restore := stubService(t, fake)
+	defer restore()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := Run([]string{"service", "events", "grafana"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Run() code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+	if got := stdout.String(); got != "no events found for grafana\n" {
+		t.Fatalf("stdout = %q, want empty event message", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	assertServiceEventsOptions(t, fake.eventsOpts, []idpservice.EventsOptions{{Name: "grafana", Tail: 25}})
 }
 
 func TestRunServiceOptionErrors(t *testing.T) {
@@ -183,6 +230,16 @@ func TestRunServiceOptionErrors(t *testing.T) {
 			name: "unknown health option",
 			args: []string{"service", "health", "grafana", "--team", "payments"},
 			want: "unknown service health option: --team",
+		},
+		{
+			name: "invalid logs tail",
+			args: []string{"service", "logs", "grafana", "--tail", "zero"},
+			want: "invalid tail for --tail: zero",
+		},
+		{
+			name: "unknown events option",
+			args: []string{"service", "events", "grafana", "--container", "app"},
+			want: "unknown service events option: --container",
 		},
 	}
 
@@ -589,9 +646,13 @@ type fakeService struct {
 	summaries    []idpservice.Summary
 	details      []idpservice.Details
 	health       []idpservice.Health
+	logs         []idpservice.LogLine
+	events       []idpservice.Event
 	listOpts     []idpservice.ListOptions
 	describeOpts []idpservice.DescribeOptions
 	healthOpts   []idpservice.HealthOptions
+	logsOpts     []idpservice.LogsOptions
+	eventsOpts   []idpservice.EventsOptions
 }
 
 func (f *fakeService) List(_ context.Context, opts idpservice.ListOptions) ([]idpservice.Summary, error) {
@@ -607,6 +668,16 @@ func (f *fakeService) Describe(_ context.Context, opts idpservice.DescribeOption
 func (f *fakeService) Health(_ context.Context, opts idpservice.HealthOptions) ([]idpservice.Health, error) {
 	f.healthOpts = append(f.healthOpts, opts)
 	return f.health, nil
+}
+
+func (f *fakeService) Logs(_ context.Context, opts idpservice.LogsOptions) ([]idpservice.LogLine, error) {
+	f.logsOpts = append(f.logsOpts, opts)
+	return f.logs, nil
+}
+
+func (f *fakeService) Events(_ context.Context, opts idpservice.EventsOptions) ([]idpservice.Event, error) {
+	f.eventsOpts = append(f.eventsOpts, opts)
+	return f.events, nil
 }
 
 type fakeCluster struct {
@@ -725,6 +796,32 @@ func assertServiceDescribeOptions(t *testing.T, got []idpservice.DescribeOptions
 }
 
 func assertServiceHealthOptions(t *testing.T, got []idpservice.HealthOptions, want []idpservice.HealthOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertServiceLogsOptions(t *testing.T, got []idpservice.LogsOptions, want []idpservice.LogsOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertServiceEventsOptions(t *testing.T, got []idpservice.EventsOptions, want []idpservice.EventsOptions) {
 	t.Helper()
 
 	if len(got) != len(want) {

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -22,6 +23,7 @@ import (
 type KubernetesService struct {
 	clientset kubernetes.Interface
 	now       func() time.Time
+	podLogs   func(context.Context, corev1.Pod, string, LogsOptions) ([]string, error)
 }
 
 type Summary struct {
@@ -53,6 +55,22 @@ type HealthOptions struct {
 	Namespace string
 }
 
+type LogsOptions struct {
+	Name      string
+	Namespace string
+	Container string
+	Tail      int64
+	Since     time.Duration
+	Previous  bool
+}
+
+type EventsOptions struct {
+	Name      string
+	Namespace string
+	Tail      int
+	Since     time.Duration
+}
+
 type Health struct {
 	Summary
 	Status              string
@@ -63,6 +81,27 @@ type Health struct {
 	ServiceCount        int
 	WarningEventCount   int
 	WarningEventReasons []string
+}
+
+type LogLine struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Pod       string
+	Container string
+	Line      string
+}
+
+type Event struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Type      string
+	Reason    string
+	Message   string
+	Object    string
+	Age       string
+	Time      time.Time
 }
 
 func NewKubernetesService() (*KubernetesService, error) {
@@ -92,6 +131,7 @@ func NewKubernetesServiceWithClientset(clientset kubernetes.Interface) *Kubernet
 	return &KubernetesService{
 		clientset: clientset,
 		now:       time.Now,
+		podLogs:   defaultPodLogs(clientset),
 	}
 }
 
@@ -160,6 +200,119 @@ func (s *KubernetesService) Health(ctx context.Context, opts HealthOptions) ([]H
 
 	sortHealth(health)
 	return health, nil
+}
+
+func (s *KubernetesService) Logs(ctx context.Context, opts LogsOptions) ([]LogLine, error) {
+	details, err := s.Describe(ctx, DescribeOptions{Name: opts.Name, Namespace: opts.Namespace})
+	if err != nil {
+		if err.Error() != "service not found: "+opts.Name {
+			return nil, err
+		}
+		return s.logsForPodName(ctx, opts)
+	}
+
+	lines := make([]LogLine, 0)
+	for _, detail := range details {
+		pods, err := s.podsFor(ctx, detail)
+		if err != nil {
+			return nil, err
+		}
+		sortPods(pods)
+
+		for _, pod := range pods {
+			lines, err = appendPodLogs(ctx, s, lines, detail.Name, detail.Namespace, detail.Kind, pod, opts)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return lines, nil
+}
+
+func (s *KubernetesService) logsForPodName(ctx context.Context, opts LogsOptions) ([]LogLine, error) {
+	namespace := opts.Namespace
+	name := opts.Name
+	if strings.Contains(opts.Name, "/") {
+		parts := strings.SplitN(opts.Name, "/", 2)
+		namespace = parts[0]
+		name = parts[1]
+	}
+	if namespace == "" {
+		namespace = metav1.NamespaceAll
+	}
+
+	pods, err := s.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+
+	matches := make([]corev1.Pod, 0)
+	for _, pod := range pods.Items {
+		if pod.Name == name {
+			matches = append(matches, pod)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("service not found: %s", opts.Name)
+	}
+	sortPods(matches)
+
+	lines := make([]LogLine, 0)
+	for _, pod := range matches {
+		var err error
+		lines, err = appendPodLogs(ctx, s, lines, pod.Name, pod.Namespace, "Pod", pod, opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return lines, nil
+}
+
+func (s *KubernetesService) Events(ctx context.Context, opts EventsOptions) ([]Event, error) {
+	details, err := s.Describe(ctx, DescribeOptions{Name: opts.Name, Namespace: opts.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]Event, 0)
+	for _, detail := range details {
+		pods, err := s.podsFor(ctx, detail)
+		if err != nil {
+			return nil, err
+		}
+		podNames := make(map[string]struct{}, len(pods))
+		for _, pod := range pods {
+			podNames[pod.Name] = struct{}{}
+		}
+
+		kubeEvents, err := s.clientset.CoreV1().Events(detail.Namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("list events: %w", err)
+		}
+		for _, event := range kubeEvents.Items {
+			if !eventMatches(detail, podNames, event) || eventOlderThan(event, opts.Since, s.now()) {
+				continue
+			}
+			events = append(events, Event{
+				Name:      detail.Name,
+				Namespace: detail.Namespace,
+				Kind:      detail.Kind,
+				Type:      event.Type,
+				Reason:    event.Reason,
+				Message:   event.Message,
+				Object:    event.InvolvedObject.Kind + "/" + event.InvolvedObject.Name,
+				Age:       s.age(eventTime(event)),
+				Time:      eventTime(event),
+			})
+		}
+	}
+
+	sortEvents(events)
+	if opts.Tail > 0 && len(events) > opts.Tail {
+		events = events[:opts.Tail]
+	}
+	return events, nil
 }
 
 func (s *KubernetesService) workloads(ctx context.Context, namespace string) ([]Details, error) {
@@ -317,6 +470,79 @@ func (s *KubernetesService) serviceHasReadyEndpointSlice(ctx context.Context, na
 	}
 
 	return false, nil
+}
+
+func appendPodLogs(ctx context.Context, service *KubernetesService, lines []LogLine, name string, namespace string, kind string, pod corev1.Pod, opts LogsOptions) ([]LogLine, error) {
+	for _, container := range logContainers(pod, opts.Container) {
+		podLines, err := service.podLogs(ctx, pod, container, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, line := range podLines {
+			lines = append(lines, LogLine{
+				Name:      name,
+				Namespace: namespace,
+				Kind:      kind,
+				Pod:       pod.Name,
+				Container: container,
+				Line:      line,
+			})
+		}
+	}
+	return lines, nil
+}
+
+func defaultPodLogs(clientset kubernetes.Interface) func(context.Context, corev1.Pod, string, LogsOptions) ([]string, error) {
+	return func(ctx context.Context, pod corev1.Pod, container string, opts LogsOptions) ([]string, error) {
+		return readPodLogs(ctx, clientset, pod, container, opts)
+	}
+}
+
+func readPodLogs(ctx context.Context, clientset kubernetes.Interface, pod corev1.Pod, container string, opts LogsOptions) ([]string, error) {
+	podLogOptions := &corev1.PodLogOptions{
+		Container: container,
+		Previous:  opts.Previous,
+	}
+	if opts.Tail > 0 {
+		podLogOptions.TailLines = &opts.Tail
+	}
+	if opts.Since > 0 {
+		sinceSeconds := int64(opts.Since.Seconds())
+		podLogOptions.SinceSeconds = &sinceSeconds
+	}
+
+	stream, err := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, podLogOptions).Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read logs for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	defer stream.Close()
+
+	lines := make([]string, 0)
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan logs for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+
+	return lines, nil
+}
+
+func logContainers(pod corev1.Pod, requested string) []string {
+	if requested != "" {
+		return []string{requested}
+	}
+
+	containers := make([]string, 0, len(pod.Spec.Containers))
+	for _, container := range pod.Spec.Containers {
+		containers = append(containers, container.Name)
+	}
+	if len(containers) == 0 {
+		return []string{""}
+	}
+	sort.Strings(containers)
+	return containers
 }
 
 func (s *KubernetesService) warningEventReasons(ctx context.Context, detail Details, podNames map[string]struct{}) ([]string, error) {
@@ -543,6 +769,49 @@ func podReady(pod corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+func eventMatches(detail Details, podNames map[string]struct{}, event corev1.Event) bool {
+	if event.InvolvedObject.Namespace != "" && event.InvolvedObject.Namespace != detail.Namespace {
+		return false
+	}
+	if event.InvolvedObject.Name == detail.Name {
+		return true
+	}
+	_, ok := podNames[event.InvolvedObject.Name]
+	return ok
+}
+
+func eventOlderThan(event corev1.Event, since time.Duration, now time.Time) bool {
+	if since <= 0 {
+		return false
+	}
+	return now.Sub(eventTime(event)) > since
+}
+
+func eventTime(event corev1.Event) time.Time {
+	if !event.LastTimestamp.IsZero() {
+		return event.LastTimestamp.Time
+	}
+	if !event.EventTime.IsZero() {
+		return event.EventTime.Time
+	}
+	if !event.FirstTimestamp.IsZero() {
+		return event.FirstTimestamp.Time
+	}
+	return event.CreationTimestamp.Time
+}
+
+func sortEvents(events []Event) {
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Time.After(events[j].Time)
+	})
+}
+
+func sortPods(pods []corev1.Pod) {
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
 }
 
 func healthStatus(health Health) string {

--- a/internal/idp/service/service_test.go
+++ b/internal/idp/service/service_test.go
@@ -282,6 +282,176 @@ func TestKubernetesServiceHealth(t *testing.T) {
 	}
 }
 
+func TestKubernetesServiceLogs(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    LogsOptions
+		logs    map[string][]string
+		want    []LogLine
+		wantErr string
+	}{
+		{
+			name: "reads logs for resolved service pods",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 2),
+				pod("grafana-0", "observability", true, 0),
+				pod("grafana-1", "observability", true, 0),
+			},
+			opts: LogsOptions{Name: "grafana", Namespace: "observability", Container: "app", Tail: 10, Since: time.Minute},
+			logs: map[string][]string{
+				"observability/grafana-0/app": {"ready"},
+				"observability/grafana-1/app": {"serving"},
+			},
+			want: []LogLine{
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Pod: "grafana-0", Container: "app", Line: "ready"},
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Pod: "grafana-1", Container: "app", Line: "serving"},
+			},
+		},
+		{
+			name: "reads logs for pod name fallback",
+			objects: []runtime.Object{
+				pod("loki-0", "observability", true, 0),
+			},
+			opts: LogsOptions{Name: "loki-0", Tail: 5},
+			logs: map[string][]string{
+				"observability/loki-0": {"compactor ready"},
+			},
+			want: []LogLine{
+				{Name: "loki-0", Namespace: "observability", Kind: "Pod", Pod: "loki-0", Line: "compactor ready"},
+			},
+		},
+		{
+			name: "reads all pod containers when container is not provided",
+			objects: []runtime.Object{
+				multiContainerPod("loki-0", "observability", "loki", "loki-sc-rules"),
+			},
+			opts: LogsOptions{Name: "loki-0", Tail: 5},
+			logs: map[string][]string{
+				"observability/loki-0/loki":          {"loki ready"},
+				"observability/loki-0/loki-sc-rules": {"rules ready"},
+			},
+			want: []LogLine{
+				{Name: "loki-0", Namespace: "observability", Kind: "Pod", Pod: "loki-0", Container: "loki", Line: "loki ready"},
+				{Name: "loki-0", Namespace: "observability", Kind: "Pod", Pod: "loki-0", Container: "loki-sc-rules", Line: "rules ready"},
+			},
+		},
+		{
+			name: "reads logs for namespace qualified pod name fallback",
+			objects: []runtime.Object{
+				pod("loki-0", "observability", true, 0),
+				pod("loki-0", "logging", true, 0),
+			},
+			opts: LogsOptions{Name: "logging/loki-0", Tail: 5},
+			logs: map[string][]string{
+				"logging/loki-0": {"querier ready"},
+			},
+			want: []LogLine{
+				{Name: "loki-0", Namespace: "logging", Kind: "Pod", Pod: "loki-0", Line: "querier ready"},
+			},
+		},
+		{
+			name:    "missing service",
+			opts:    LogsOptions{Name: "missing"},
+			wantErr: "service not found: missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+			service.podLogs = func(_ context.Context, pod corev1.Pod, container string, _ LogsOptions) ([]string, error) {
+				if container == "" {
+					return tt.logs[pod.Namespace+"/"+pod.Name], nil
+				}
+				return tt.logs[pod.Namespace+"/"+pod.Name+"/"+container], nil
+			}
+
+			logs, err := service.Logs(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Logs() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Logs() error = %v", err)
+			}
+
+			assertLogLines(t, logs, tt.want)
+		})
+	}
+}
+
+func TestKubernetesServiceEvents(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    EventsOptions
+		want    []Event
+		wantErr string
+	}{
+		{
+			name: "returns recent workload and pod events",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 2),
+				pod("grafana-0", "observability", true, 0),
+				event("grafana", "Deployment", "observability", corev1.EventTypeNormal, "Scaled", "scaled up", time.Date(2026, 4, 28, 11, 55, 0, 0, time.UTC)),
+				event("grafana-0", "Pod", "observability", corev1.EventTypeWarning, "BackOff", "back-off restarting failed container", time.Date(2026, 4, 28, 11, 59, 0, 0, time.UTC)),
+				event("other", "Pod", "observability", corev1.EventTypeWarning, "Failed", "ignored", time.Date(2026, 4, 28, 11, 59, 0, 0, time.UTC)),
+			},
+			opts: EventsOptions{Name: "grafana", Namespace: "observability", Tail: 10, Since: 10 * time.Minute},
+			want: []Event{
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Type: corev1.EventTypeWarning, Reason: "BackOff", Message: "back-off restarting failed container", Object: "Pod/grafana-0", Age: "1m", Time: time.Date(2026, 4, 28, 11, 59, 0, 0, time.UTC)},
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Type: corev1.EventTypeNormal, Reason: "Scaled", Message: "scaled up", Object: "Deployment/grafana", Age: "5m", Time: time.Date(2026, 4, 28, 11, 55, 0, 0, time.UTC)},
+			},
+		},
+		{
+			name: "limits events",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 2),
+				pod("grafana-0", "observability", true, 0),
+				event("grafana", "Deployment", "observability", corev1.EventTypeNormal, "Old", "old", time.Date(2026, 4, 28, 11, 50, 0, 0, time.UTC)),
+				event("grafana-0", "Pod", "observability", corev1.EventTypeWarning, "New", "new", time.Date(2026, 4, 28, 11, 59, 0, 0, time.UTC)),
+			},
+			opts: EventsOptions{Name: "grafana", Namespace: "observability", Tail: 1},
+			want: []Event{
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Type: corev1.EventTypeWarning, Reason: "New", Message: "new", Object: "Pod/grafana-0", Age: "1m", Time: time.Date(2026, 4, 28, 11, 59, 0, 0, time.UTC)},
+			},
+		},
+		{
+			name:    "missing service",
+			opts:    EventsOptions{Name: "missing"},
+			wantErr: "service not found: missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+
+			events, err := service.Events(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Events() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Events() error = %v", err)
+			}
+
+			assertEvents(t, events, tt.want)
+		})
+	}
+}
+
 func deployment(name string, namespace string, created metav1.Time, replicas int32, ready int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -346,6 +516,15 @@ func pod(name string, namespace string, ready bool, restarts int32) *corev1.Pod 
 	}
 }
 
+func multiContainerPod(name string, namespace string, containers ...string) *corev1.Pod {
+	pod := pod(name, namespace, true, 0)
+	pod.Spec.Containers = make([]corev1.Container, 0, len(containers))
+	for _, container := range containers {
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: container})
+	}
+	return pod
+}
+
 func kubernetesService(name string, namespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -389,6 +568,21 @@ func warningEvent(name string, namespace string, reason string) *corev1.Event {
 	}
 }
 
+func event(name string, kind string, namespace string, eventType string, reason string, message string, lastSeen time.Time) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "." + reason, Namespace: namespace},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      kind,
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type:          eventType,
+		Reason:        reason,
+		Message:       message,
+		LastTimestamp: metav1.NewTime(lastSeen),
+	}
+}
+
 func assertSummaries(t *testing.T, got []Summary, want []Summary) {
 	t.Helper()
 
@@ -422,6 +616,32 @@ func assertHealth(t *testing.T, got []Health, want []Health) {
 			t.Fatalf("health[%d] = %#v, want %#v", i, got[i], want[i])
 		}
 		assertStringSlice(t, got[i].WarningEventReasons, want[i].WarningEventReasons)
+	}
+}
+
+func assertLogLines(t *testing.T, got []LogLine, want []LogLine) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(logs) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("logs[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertEvents(t *testing.T, got []Event, want []Event) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(events) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("events[%d] = %#v, want %#v", i, got[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
### Summary

This PR makes `service logs` and `service events` read from the Kubernetes API
for the resolved service. Developers can inspect pod logs and recent workload or
pod events without manually finding the matching pods first.

### List of Changes

- Added Kubernetes-backed `service logs` with namespace, container, tail,
  since, and previous-log options.
- Added Kubernetes-backed `service events` with namespace, tail, and since
  options, sorted by most recent event first.
- Reused the existing service resolution model, so duplicate names across
  namespaces are shown through the same lookup path as describe and health.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

