### PR TITLE
feat(idp): add kubernetes-backed service signals

### DIFF
--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -38,6 +38,8 @@ type serviceClient interface {
 	Health(context.Context, idpservice.HealthOptions) ([]idpservice.Health, error)
 	Logs(context.Context, idpservice.LogsOptions) ([]idpservice.LogLine, error)
 	Events(context.Context, idpservice.EventsOptions) ([]idpservice.Event, error)
+	Metrics(context.Context, idpservice.MetricsOptions) ([]idpservice.Metric, error)
+	Traces(context.Context, idpservice.TracesOptions) ([]idpservice.Trace, error)
 }
 
 var newCatalog = func() (catalogClient, error) {
@@ -161,7 +163,27 @@ func runService(args []string, stdout io.Writer, stderr io.Writer) int {
 			return 1
 		}
 		return eventsService(opts, stdout, stderr)
-	case "metrics", "traces", "ownership":
+	case "metrics":
+		if len(args) < 2 {
+			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
+			return 1
+		}
+		opts, ok := parseServiceMetricsOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return metricsService(opts, stdout, stderr)
+	case "traces":
+		if len(args) < 2 {
+			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
+			return 1
+		}
+		opts, ok := parseServiceTracesOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return tracesService(opts, stdout, stderr)
+	case "ownership":
 		if len(args) < 2 {
 			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
 			return 1
@@ -410,6 +432,58 @@ func eventsService(opts idpservice.EventsOptions, stdout io.Writer, stderr io.Wr
 	fmt.Fprintln(writer, "TYPE\tREASON\tAGE\tOBJECT\tMESSAGE")
 	for _, event := range events {
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", event.Type, event.Reason, event.Age, event.Object, event.Message)
+	}
+	writer.Flush()
+	return 0
+}
+
+func metricsService(opts idpservice.MetricsOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	metrics, err := serviceClient.Metrics(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	if len(metrics) == 0 {
+		fmt.Fprintf(stdout, "no metrics found for %s\n", opts.Name)
+		return 0
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tSIGNAL\tVALUE")
+	for _, metric := range metrics {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", metric.Name, metric.Namespace, metric.Kind, metric.Signal, metric.Value)
+	}
+	writer.Flush()
+	return 0
+}
+
+func tracesService(opts idpservice.TracesOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	traces, err := serviceClient.Traces(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	if len(traces) == 0 {
+		fmt.Fprintf(stdout, "no traces found for %s\n", opts.Name)
+		return 0
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tTRACE_ID\tROOT_SERVICE\tSTART\tDURATION")
+	for _, trace := range traces {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", trace.Name, trace.Namespace, trace.Kind, trace.TraceID, trace.RootServiceName, trace.StartTime, trace.Duration)
 	}
 	writer.Flush()
 	return 0
@@ -723,6 +797,65 @@ func parseServiceEventsOptions(args []string, stderr io.Writer) (idpservice.Even
 	return opts, true
 }
 
+func parseServiceMetricsOptions(args []string, stderr io.Writer) (idpservice.MetricsOptions, bool) {
+	opts := idpservice.MetricsOptions{Name: args[0], Window: 5 * time.Minute}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		case "--window":
+			window, ok := parseDurationOption(args, i, "window", stderr)
+			if !ok {
+				return opts, false
+			}
+			opts.Window = window
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown service metrics option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
+func parseServiceTracesOptions(args []string, stderr io.Writer) (idpservice.TracesOptions, bool) {
+	opts := idpservice.TracesOptions{Name: args[0], Hours: 1, Limit: 20}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		case "--hours":
+			hours, ok := parsePositiveInt(args, i, "hours", stderr)
+			if !ok {
+				return opts, false
+			}
+			opts.Hours = hours
+			i++
+		case "--limit":
+			limit, ok := parsePositiveInt(args, i, "limit", stderr)
+			if !ok {
+				return opts, false
+			}
+			opts.Limit = limit
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown service traces option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
 func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, bool) {
 	var opts catalog.ListOptions
 	for i := 0; i < len(args); i++ {
@@ -838,8 +971,8 @@ func serviceHelpText() string {
   hub-cli service health <service> [--namespace <namespace>|-n <namespace>]
   hub-cli service logs <service> [--namespace <namespace>|-n <namespace>] [--container <container>|-c <container>] [--tail <lines>] [--since <duration>] [--previous]
   hub-cli service events <service> [--namespace <namespace>|-n <namespace>] [--tail <count>] [--since <duration>]
-  hub-cli service metrics <service>
-  hub-cli service traces <service>
+  hub-cli service metrics <service> [--namespace <namespace>|-n <namespace>] [--window <duration>]
+  hub-cli service traces <service> [--namespace <namespace>|-n <namespace>] [--hours <hours>] [--limit <count>]
   hub-cli service ownership <service>`) + "\n"
 }
 

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -86,6 +86,12 @@ func TestRunServiceCommands(t *testing.T) {
 		events: []idpservice.Event{
 			{Type: "Warning", Reason: "BackOff", Age: "1m", Object: "Pod/grafana-0", Message: "back-off restarting failed container"},
 		},
+		metrics: []idpservice.Metric{
+			{Name: "grafana", Namespace: "observability", Kind: "Deployment", Signal: "cpu_cores", Value: "0.12"},
+		},
+		traces: []idpservice.Trace{
+			{Name: "grafana", Namespace: "observability", Kind: "Deployment", TraceID: "abc123", RootServiceName: "grafana", StartTime: "2026-04-28T12:00:00Z", Duration: "25ms"},
+		},
 	}
 	restore := stubService(t, fake)
 	defer restore()
@@ -99,6 +105,8 @@ func TestRunServiceCommands(t *testing.T) {
 		wantHeal []idpservice.HealthOptions
 		wantLogs []idpservice.LogsOptions
 		wantEvts []idpservice.EventsOptions
+		wantMets []idpservice.MetricsOptions
+		wantTrcs []idpservice.TracesOptions
 	}{
 		{
 			name: "service list",
@@ -153,6 +161,20 @@ func TestRunServiceCommands(t *testing.T) {
 				"Warning  BackOff  1m   Pod/grafana-0  back-off restarting failed container\n",
 			wantEvts: []idpservice.EventsOptions{{Name: "grafana", Namespace: "observability", Tail: 5, Since: 10 * time.Minute}},
 		},
+		{
+			name: "service metrics",
+			args: []string{"service", "metrics", "grafana", "-n", "observability", "--window", "10m"},
+			want: "NAME     NAMESPACE      KIND        SIGNAL     VALUE\n" +
+				"grafana  observability  Deployment  cpu_cores  0.12\n",
+			wantMets: []idpservice.MetricsOptions{{Name: "grafana", Namespace: "observability", Window: 10 * time.Minute}},
+		},
+		{
+			name: "service traces",
+			args: []string{"service", "traces", "grafana", "-n", "observability", "--hours", "2", "--limit", "5"},
+			want: "NAME     NAMESPACE      KIND        TRACE_ID  ROOT_SERVICE  START                 DURATION\n" +
+				"grafana  observability  Deployment  abc123    grafana       2026-04-28T12:00:00Z  25ms\n",
+			wantTrcs: []idpservice.TracesOptions{{Name: "grafana", Namespace: "observability", Hours: 2, Limit: 5}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -162,6 +184,8 @@ func TestRunServiceCommands(t *testing.T) {
 			fake.healthOpts = nil
 			fake.logsOpts = nil
 			fake.eventsOpts = nil
+			fake.metricsOpts = nil
+			fake.tracesOpts = nil
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 
@@ -180,6 +204,8 @@ func TestRunServiceCommands(t *testing.T) {
 			assertServiceHealthOptions(t, fake.healthOpts, tt.wantHeal)
 			assertServiceLogsOptions(t, fake.logsOpts, tt.wantLogs)
 			assertServiceEventsOptions(t, fake.eventsOpts, tt.wantEvts)
+			assertServiceMetricsOptions(t, fake.metricsOpts, tt.wantMets)
+			assertServiceTracesOptions(t, fake.tracesOpts, tt.wantTrcs)
 		})
 	}
 }
@@ -240,6 +266,16 @@ func TestRunServiceOptionErrors(t *testing.T) {
 			name: "unknown events option",
 			args: []string{"service", "events", "grafana", "--container", "app"},
 			want: "unknown service events option: --container",
+		},
+		{
+			name: "invalid metrics window",
+			args: []string{"service", "metrics", "grafana", "--window", "soon"},
+			want: "invalid window for --window: soon",
+		},
+		{
+			name: "unknown traces option",
+			args: []string{"service", "traces", "grafana", "--window", "5m"},
+			want: "unknown service traces option: --window",
 		},
 	}
 
@@ -648,11 +684,15 @@ type fakeService struct {
 	health       []idpservice.Health
 	logs         []idpservice.LogLine
 	events       []idpservice.Event
+	metrics      []idpservice.Metric
+	traces       []idpservice.Trace
 	listOpts     []idpservice.ListOptions
 	describeOpts []idpservice.DescribeOptions
 	healthOpts   []idpservice.HealthOptions
 	logsOpts     []idpservice.LogsOptions
 	eventsOpts   []idpservice.EventsOptions
+	metricsOpts  []idpservice.MetricsOptions
+	tracesOpts   []idpservice.TracesOptions
 }
 
 func (f *fakeService) List(_ context.Context, opts idpservice.ListOptions) ([]idpservice.Summary, error) {
@@ -678,6 +718,16 @@ func (f *fakeService) Logs(_ context.Context, opts idpservice.LogsOptions) ([]id
 func (f *fakeService) Events(_ context.Context, opts idpservice.EventsOptions) ([]idpservice.Event, error) {
 	f.eventsOpts = append(f.eventsOpts, opts)
 	return f.events, nil
+}
+
+func (f *fakeService) Metrics(_ context.Context, opts idpservice.MetricsOptions) ([]idpservice.Metric, error) {
+	f.metricsOpts = append(f.metricsOpts, opts)
+	return f.metrics, nil
+}
+
+func (f *fakeService) Traces(_ context.Context, opts idpservice.TracesOptions) ([]idpservice.Trace, error) {
+	f.tracesOpts = append(f.tracesOpts, opts)
+	return f.traces, nil
 }
 
 type fakeCluster struct {
@@ -822,6 +872,32 @@ func assertServiceLogsOptions(t *testing.T, got []idpservice.LogsOptions, want [
 }
 
 func assertServiceEventsOptions(t *testing.T, got []idpservice.EventsOptions, want []idpservice.EventsOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertServiceMetricsOptions(t *testing.T, got []idpservice.MetricsOptions, want []idpservice.MetricsOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertServiceTracesOptions(t *testing.T, got []idpservice.TracesOptions, want []idpservice.TracesOptions) {
 	t.Helper()
 
 	if len(got) != len(want) {

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -3,10 +3,16 @@ package service
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,12 +24,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"observability-hub/internal/env"
 )
 
 type KubernetesService struct {
 	clientset kubernetes.Interface
 	now       func() time.Time
 	podLogs   func(context.Context, corev1.Pod, string, LogsOptions) ([]string, error)
+	signals   *signalClient
 }
 
 type Summary struct {
@@ -71,6 +80,19 @@ type EventsOptions struct {
 	Since     time.Duration
 }
 
+type MetricsOptions struct {
+	Name      string
+	Namespace string
+	Window    time.Duration
+}
+
+type TracesOptions struct {
+	Name      string
+	Namespace string
+	Hours     int
+	Limit     int
+}
+
 type Health struct {
 	Summary
 	Status              string
@@ -104,7 +126,27 @@ type Event struct {
 	Time      time.Time
 }
 
+type Metric struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Signal    string
+	Value     string
+}
+
+type Trace struct {
+	Name            string
+	Namespace       string
+	Kind            string
+	TraceID         string
+	RootServiceName string
+	StartTime       string
+	Duration        string
+}
+
 func NewKubernetesService() (*KubernetesService, error) {
+	env.Load()
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		kubeconfig := os.Getenv("KUBECONFIG")
@@ -132,6 +174,7 @@ func NewKubernetesServiceWithClientset(clientset kubernetes.Interface) *Kubernet
 		clientset: clientset,
 		now:       time.Now,
 		podLogs:   defaultPodLogs(clientset),
+		signals:   newSignalClient(os.Getenv("THANOS_URL"), os.Getenv("TEMPO_URL"), nil),
 	}
 }
 
@@ -313,6 +356,105 @@ func (s *KubernetesService) Events(ctx context.Context, opts EventsOptions) ([]E
 		events = events[:opts.Tail]
 	}
 	return events, nil
+}
+
+func (s *KubernetesService) Metrics(ctx context.Context, opts MetricsOptions) ([]Metric, error) {
+	if s.signals == nil || s.signals.thanosURL == "" {
+		return nil, fmt.Errorf("THANOS_URL is required for service metrics")
+	}
+	if opts.Window <= 0 {
+		opts.Window = 5 * time.Minute
+	}
+
+	details, err := s.Describe(ctx, DescribeOptions{Name: opts.Name, Namespace: opts.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := make([]Metric, 0)
+	for _, detail := range details {
+		pods, err := s.podsFor(ctx, detail)
+		if err != nil {
+			return nil, err
+		}
+		if len(pods) == 0 {
+			continue
+		}
+
+		podMatcher := podRegex(pods)
+		queries := []struct {
+			signal string
+			query  string
+		}{
+			{
+				signal: "cpu_cores",
+				query:  fmt.Sprintf(`sum(rate(container_cpu_usage_seconds_total{namespace=%q,pod=~%q,container!="",container!="POD"}[%s]))`, detail.Namespace, podMatcher, promDuration(opts.Window)),
+			},
+			{
+				signal: "memory_bytes",
+				query:  fmt.Sprintf(`sum(container_memory_working_set_bytes{namespace=%q,pod=~%q,container!="",container!="POD"})`, detail.Namespace, podMatcher),
+			},
+			{
+				signal: "restarts",
+				query:  fmt.Sprintf(`sum(kube_pod_container_status_restarts_total{namespace=%q,pod=~%q})`, detail.Namespace, podMatcher),
+			},
+		}
+
+		for _, query := range queries {
+			value, err := s.signals.queryMetric(ctx, query.query)
+			if err != nil {
+				return nil, err
+			}
+			metrics = append(metrics, Metric{
+				Name:      detail.Name,
+				Namespace: detail.Namespace,
+				Kind:      detail.Kind,
+				Signal:    query.signal,
+				Value:     value,
+			})
+		}
+	}
+
+	sortMetrics(metrics)
+	return metrics, nil
+}
+
+func (s *KubernetesService) Traces(ctx context.Context, opts TracesOptions) ([]Trace, error) {
+	if s.signals == nil || s.signals.tempoURL == "" {
+		return nil, fmt.Errorf("TEMPO_URL is required for service traces")
+	}
+	if opts.Hours <= 0 {
+		opts.Hours = 1
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 20
+	}
+
+	details, err := s.Describe(ctx, DescribeOptions{Name: opts.Name, Namespace: opts.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	traces := make([]Trace, 0)
+	for _, detail := range details {
+		query := fmt.Sprintf(`{resource.service.name=%q}`, detail.Name)
+		found, err := s.signals.searchTraces(ctx, query, opts.Hours, opts.Limit)
+		if err != nil {
+			return nil, err
+		}
+		for _, trace := range found {
+			trace.Name = detail.Name
+			trace.Namespace = detail.Namespace
+			trace.Kind = detail.Kind
+			traces = append(traces, trace)
+		}
+	}
+
+	sortTraces(traces)
+	if opts.Limit > 0 && len(traces) > opts.Limit {
+		traces = traces[:opts.Limit]
+	}
+	return traces, nil
 }
 
 func (s *KubernetesService) workloads(ctx context.Context, namespace string) ([]Details, error) {
@@ -545,6 +687,22 @@ func logContainers(pod corev1.Pod, requested string) []string {
 	return containers
 }
 
+func podRegex(pods []corev1.Pod) string {
+	names := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		names = append(names, regexp.QuoteMeta(pod.Name))
+	}
+	sort.Strings(names)
+	return strings.Join(names, "|")
+}
+
+func promDuration(duration time.Duration) string {
+	if duration < time.Second {
+		duration = time.Second
+	}
+	return fmt.Sprintf("%ds", int(duration.Seconds()))
+}
+
 func (s *KubernetesService) warningEventReasons(ctx context.Context, detail Details, podNames map[string]struct{}) ([]string, error) {
 	events, err := s.clientset.CoreV1().Events(detail.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -732,6 +890,24 @@ func sortHealth(health []Health) {
 	})
 }
 
+func sortMetrics(metrics []Metric) {
+	sort.Slice(metrics, func(i, j int) bool {
+		if metrics[i].Namespace == metrics[j].Namespace {
+			if metrics[i].Name == metrics[j].Name {
+				return metrics[i].Signal < metrics[j].Signal
+			}
+			return metrics[i].Name < metrics[j].Name
+		}
+		return metrics[i].Namespace < metrics[j].Namespace
+	})
+}
+
+func sortTraces(traces []Trace) {
+	sort.Slice(traces, func(i, j int) bool {
+		return traces[i].StartTime > traces[j].StartTime
+	})
+}
+
 func SortedMapEntries(values map[string]string) []string {
 	entries := make([]string, 0, len(values))
 	for key, value := range values {
@@ -831,6 +1007,154 @@ func healthStatus(health Health) string {
 		return "unknown"
 	}
 	return "healthy"
+}
+
+type signalClient struct {
+	thanosURL  string
+	tempoURL   string
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+type promQueryResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		Result []struct {
+			Value []interface{} `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+type tempoSearchResponse struct {
+	Traces []tempoTrace `json:"traces"`
+}
+
+type tempoTrace struct {
+	TraceID           string `json:"traceID"`
+	RootServiceName   string `json:"rootServiceName"`
+	StartTimeUnixNano string `json:"startTimeUnixNano"`
+	DurationMs        int64  `json:"durationMs"`
+}
+
+func newSignalClient(thanosURL string, tempoURL string, httpClient *http.Client) *signalClient {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &signalClient{
+		thanosURL:  strings.TrimRight(thanosURL, "/"),
+		tempoURL:   strings.TrimRight(tempoURL, "/"),
+		httpClient: httpClient,
+		now:        time.Now,
+	}
+}
+
+func (c *signalClient) queryMetric(ctx context.Context, query string) (string, error) {
+	params := url.Values{}
+	params.Set("query", query)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.thanosURL+"/api/v1/query?"+params.Encode(), nil)
+	if err != nil {
+		return "", fmt.Errorf("create metrics request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("query metrics: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return "", fmt.Errorf("query metrics: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var decoded promQueryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return "", fmt.Errorf("decode metrics response: %w", err)
+	}
+	if decoded.Status != "success" {
+		return "", fmt.Errorf("query metrics: prometheus status %q", decoded.Status)
+	}
+	if len(decoded.Data.Result) == 0 || len(decoded.Data.Result[0].Value) < 2 {
+		return "n/a", nil
+	}
+
+	value, ok := decoded.Data.Result[0].Value[1].(string)
+	if !ok || value == "" {
+		return "n/a", nil
+	}
+	return value, nil
+}
+
+func (c *signalClient) searchTraces(ctx context.Context, query string, hours int, limit int) ([]Trace, error) {
+	if hours <= 0 {
+		hours = 1
+	}
+	if hours > 168 {
+		hours = 168
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	now := c.now()
+	params := url.Values{}
+	params.Set("q", query)
+	params.Set("limit", strconv.Itoa(limit))
+	params.Set("start", strconv.FormatInt(now.Add(-time.Duration(hours)*time.Hour).Unix(), 10))
+	params.Set("end", strconv.FormatInt(now.Unix(), 10))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.tempoURL+"/api/search?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create traces request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("query traces: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("query traces: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var decoded tempoSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("decode traces response: %w", err)
+	}
+
+	traces := make([]Trace, 0, len(decoded.Traces))
+	for _, item := range decoded.Traces {
+		traces = append(traces, Trace{
+			TraceID:         item.TraceID,
+			RootServiceName: item.RootServiceName,
+			StartTime:       formatUnixNano(item.StartTimeUnixNano),
+			Duration:        formatDurationMs(item.DurationMs),
+		})
+	}
+	return traces, nil
+}
+
+func formatUnixNano(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	nanos, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return value
+	}
+	return time.Unix(0, nanos).UTC().Format(time.RFC3339)
+}
+
+func formatDurationMs(value int64) string {
+	if value <= 0 {
+		return "unknown"
+	}
+	return (time.Duration(value) * time.Millisecond).String()
 }
 
 func readyRatioHealthy(ready string) bool {

--- a/internal/idp/service/service_test.go
+++ b/internal/idp/service/service_test.go
@@ -2,6 +2,10 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -452,6 +456,158 @@ func TestKubernetesServiceEvents(t *testing.T) {
 	}
 }
 
+func TestKubernetesServiceMetrics(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+
+	tests := []struct {
+		name        string
+		objects     []runtime.Object
+		opts        MetricsOptions
+		handler     http.Handler
+		thanosURL   string
+		want        []Metric
+		wantErr     string
+		wantQueries int
+	}{
+		{
+			name: "queries service metrics for resolved pods",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 2),
+				pod("grafana-0", "observability", true, 0),
+				pod("grafana-1", "observability", true, 0),
+			},
+			opts:      MetricsOptions{Name: "grafana", Namespace: "observability", Window: 10 * time.Minute},
+			thanosURL: "http://thanos",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v1/query" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				query := r.URL.Query().Get("query")
+				value := "0"
+				switch {
+				case strings.Contains(query, "container_cpu_usage_seconds_total"):
+					value = "0.12"
+				case strings.Contains(query, "container_memory_working_set_bytes"):
+					value = "1048576"
+				case strings.Contains(query, "kube_pod_container_status_restarts_total"):
+					value = "1"
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"status":"success","data":{"result":[{"value":[1714291200,"` + value + `"]}]}}`))
+			}),
+			want: []Metric{
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Signal: "cpu_cores", Value: "0.12"},
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Signal: "memory_bytes", Value: "1048576"},
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", Signal: "restarts", Value: "1"},
+			},
+			wantQueries: 3,
+		},
+		{
+			name:    "requires thanos url",
+			opts:    MetricsOptions{Name: "grafana"},
+			wantErr: "THANOS_URL is required for service metrics",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+			var client *http.Client
+			if tt.handler != nil {
+				client = newInMemoryHTTPClient(tt.handler)
+			}
+			service.signals = newSignalClient(tt.thanosURL, "http://tempo", client)
+
+			metrics, err := service.Metrics(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Metrics() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Metrics() error = %v", err)
+			}
+
+			assertMetrics(t, metrics, tt.want)
+		})
+	}
+}
+
+func TestKubernetesServiceTraces(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+	start := time.Date(2026, 4, 28, 11, 59, 0, 0, time.UTC).UnixNano()
+
+	tests := []struct {
+		name     string
+		objects  []runtime.Object
+		opts     TracesOptions
+		handler  http.Handler
+		tempoURL string
+		want     []Trace
+		wantErr  string
+	}{
+		{
+			name: "searches traces for resolved service",
+			objects: []runtime.Object{
+				deployment("grafana", "observability", created, replicas, 2),
+			},
+			opts:     TracesOptions{Name: "grafana", Namespace: "observability", Hours: 2, Limit: 5},
+			tempoURL: "http://tempo",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/search" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if r.URL.Query().Get("q") != `{resource.service.name="grafana"}` {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(fmt.Sprintf(`{"traces":[{"traceID":"abc123","rootServiceName":"grafana","startTimeUnixNano":"%d","durationMs":25}]}`, start)))
+			}),
+			want: []Trace{
+				{Name: "grafana", Namespace: "observability", Kind: "Deployment", TraceID: "abc123", RootServiceName: "grafana", StartTime: "2026-04-28T11:59:00Z", Duration: "25ms"},
+			},
+		},
+		{
+			name:    "requires tempo url",
+			opts:    TracesOptions{Name: "grafana"},
+			wantErr: "TEMPO_URL is required for service traces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+			var client *http.Client
+			if tt.handler != nil {
+				client = newInMemoryHTTPClient(tt.handler)
+			}
+			service.signals = newSignalClient("http://thanos", tt.tempoURL, client)
+			service.signals.now = func() time.Time {
+				return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+			}
+
+			traces, err := service.Traces(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Traces() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Traces() error = %v", err)
+			}
+
+			assertTraces(t, traces, tt.want)
+		})
+	}
+}
+
 func deployment(name string, namespace string, created metav1.Time, replicas int32, ready int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -645,6 +801,32 @@ func assertEvents(t *testing.T, got []Event, want []Event) {
 	}
 }
 
+func assertMetrics(t *testing.T, got []Metric, want []Metric) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(metrics) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("metrics[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertTraces(t *testing.T, got []Trace, want []Trace) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(traces) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("traces[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
 func assertDetails(t *testing.T, got []Details, want []Details) {
 	t.Helper()
 
@@ -693,4 +875,24 @@ func newTestService(objects ...runtime.Object) *KubernetesService {
 		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 	}
 	return service
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func newInMemoryHTTPClient(handler http.Handler) *http.Client {
+	return &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			recorder := httptest.NewRecorder()
+			cloned := req.Clone(req.Context())
+			cloned.RequestURI = cloned.URL.RequestURI()
+			handler.ServeHTTP(recorder, cloned)
+			response := recorder.Result()
+			response.Request = req
+			return response, nil
+		}),
+	}
 }


### PR DESCRIPTION
### Summary

This PR adds observability-backed service signals to the IDP CLI. The commands
still resolve the service through Kubernetes first, then query the configured
metrics or trace backend for that workload.

### List of Changes

- Added `service metrics` with `THANOS_URL`, namespace filtering, and a window
  option for service-level CPU, memory, and restart signals.
- Added `service traces` with `TEMPO_URL`, namespace filtering, hours, and
  limit options for recent workload traces.
- Loaded the project `.env` in the IDP service domain before reading
  Kubernetes and observability backend environment variables.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

