### PR TITLE
feat(idp): add kubernetes-backed service ownership

### DIFF
--- a/internal/idp/cli.go
+++ b/internal/idp/cli.go
@@ -40,6 +40,7 @@ type serviceClient interface {
 	Events(context.Context, idpservice.EventsOptions) ([]idpservice.Event, error)
 	Metrics(context.Context, idpservice.MetricsOptions) ([]idpservice.Metric, error)
 	Traces(context.Context, idpservice.TracesOptions) ([]idpservice.Trace, error)
+	Ownership(context.Context, idpservice.OwnershipOptions) ([]idpservice.Ownership, error)
 }
 
 var newCatalog = func() (catalogClient, error) {
@@ -188,7 +189,11 @@ func runService(args []string, stdout io.Writer, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "missing service name for idp service %s\n", args[0])
 			return 1
 		}
-		return printCalled(stdout, "idp service "+args[0]+" for "+args[1])
+		opts, ok := parseServiceOwnershipOptions(args[1:], stderr)
+		if !ok {
+			return 1
+		}
+		return ownershipService(opts, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown service command: %s\n\n", args[0])
 		fmt.Fprint(stderr, serviceHelpText())
@@ -484,6 +489,28 @@ func tracesService(opts idpservice.TracesOptions, stdout io.Writer, stderr io.Wr
 	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tTRACE_ID\tROOT_SERVICE\tSTART\tDURATION")
 	for _, trace := range traces {
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", trace.Name, trace.Namespace, trace.Kind, trace.TraceID, trace.RootServiceName, trace.StartTime, trace.Duration)
+	}
+	writer.Flush()
+	return 0
+}
+
+func ownershipService(opts idpservice.OwnershipOptions, stdout io.Writer, stderr io.Writer) int {
+	serviceClient, err := newService()
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	ownership, err := serviceClient.Ownership(context.Background(), opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tNAMESPACE\tKIND\tOWNER\tTIER\tSOURCE\tDOCS\tSOURCE_OBJECT")
+	for _, item := range ownership {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", item.Name, item.Namespace, item.Kind, item.Owner, item.Tier, item.Source, strings.Join(item.Docs, ","), item.SourceObject)
 	}
 	writer.Flush()
 	return 0
@@ -856,6 +883,25 @@ func parseServiceTracesOptions(args []string, stderr io.Writer) (idpservice.Trac
 	return opts, true
 }
 
+func parseServiceOwnershipOptions(args []string, stderr io.Writer) (idpservice.OwnershipOptions, bool) {
+	opts := idpservice.OwnershipOptions{Name: args[0]}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--namespace", "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "missing namespace for %s\n", args[i])
+				return opts, false
+			}
+			opts.Namespace = args[i+1]
+			i++
+		default:
+			fmt.Fprintf(stderr, "unknown service ownership option: %s\n", args[i])
+			return opts, false
+		}
+	}
+	return opts, true
+}
+
 func parseCatalogOptions(args []string, stderr io.Writer) (catalog.ListOptions, bool) {
 	var opts catalog.ListOptions
 	for i := 0; i < len(args); i++ {
@@ -973,7 +1019,7 @@ func serviceHelpText() string {
   hub-cli service events <service> [--namespace <namespace>|-n <namespace>] [--tail <count>] [--since <duration>]
   hub-cli service metrics <service> [--namespace <namespace>|-n <namespace>] [--window <duration>]
   hub-cli service traces <service> [--namespace <namespace>|-n <namespace>] [--hours <hours>] [--limit <count>]
-  hub-cli service ownership <service>`) + "\n"
+  hub-cli service ownership <service> [--namespace <namespace>|-n <namespace>]`) + "\n"
 }
 
 func clusterHelpText() string {

--- a/internal/idp/cli_test.go
+++ b/internal/idp/cli_test.go
@@ -92,6 +92,16 @@ func TestRunServiceCommands(t *testing.T) {
 		traces: []idpservice.Trace{
 			{Name: "grafana", Namespace: "observability", Kind: "Deployment", TraceID: "abc123", RootServiceName: "grafana", StartTime: "2026-04-28T12:00:00Z", Duration: "25ms"},
 		},
+		ownership: []idpservice.Ownership{
+			{
+				Summary:      idpservice.Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "1/1", Age: "2h"},
+				Owner:        "platform",
+				Tier:         "frontend",
+				Source:       "https://github.com/example/grafana",
+				Docs:         []string{"runbook=docs/runbooks/grafana.md"},
+				SourceObject: "Deployment observability/grafana",
+			},
+		},
 	}
 	restore := stubService(t, fake)
 	defer restore()
@@ -107,6 +117,7 @@ func TestRunServiceCommands(t *testing.T) {
 		wantEvts []idpservice.EventsOptions
 		wantMets []idpservice.MetricsOptions
 		wantTrcs []idpservice.TracesOptions
+		wantOwn  []idpservice.OwnershipOptions
 	}{
 		{
 			name: "service list",
@@ -175,6 +186,13 @@ func TestRunServiceCommands(t *testing.T) {
 				"grafana  observability  Deployment  abc123    grafana       2026-04-28T12:00:00Z  25ms\n",
 			wantTrcs: []idpservice.TracesOptions{{Name: "grafana", Namespace: "observability", Hours: 2, Limit: 5}},
 		},
+		{
+			name: "service ownership",
+			args: []string{"service", "ownership", "grafana", "-n", "observability"},
+			want: "NAME     NAMESPACE      KIND        OWNER     TIER      SOURCE                              DOCS                              SOURCE_OBJECT\n" +
+				"grafana  observability  Deployment  platform  frontend  https://github.com/example/grafana  runbook=docs/runbooks/grafana.md  Deployment observability/grafana\n",
+			wantOwn: []idpservice.OwnershipOptions{{Name: "grafana", Namespace: "observability"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -186,6 +204,7 @@ func TestRunServiceCommands(t *testing.T) {
 			fake.eventsOpts = nil
 			fake.metricsOpts = nil
 			fake.tracesOpts = nil
+			fake.ownershipOpts = nil
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 
@@ -206,6 +225,7 @@ func TestRunServiceCommands(t *testing.T) {
 			assertServiceEventsOptions(t, fake.eventsOpts, tt.wantEvts)
 			assertServiceMetricsOptions(t, fake.metricsOpts, tt.wantMets)
 			assertServiceTracesOptions(t, fake.tracesOpts, tt.wantTrcs)
+			assertServiceOwnershipOptions(t, fake.ownershipOpts, tt.wantOwn)
 		})
 	}
 }
@@ -276,6 +296,11 @@ func TestRunServiceOptionErrors(t *testing.T) {
 			name: "unknown traces option",
 			args: []string{"service", "traces", "grafana", "--window", "5m"},
 			want: "unknown service traces option: --window",
+		},
+		{
+			name: "unknown ownership option",
+			args: []string{"service", "ownership", "grafana", "--owner", "platform"},
+			want: "unknown service ownership option: --owner",
 		},
 	}
 
@@ -679,20 +704,22 @@ func (f *fakeEnv) Describe(_ context.Context, opts idpenv.DescribeOptions) ([]id
 }
 
 type fakeService struct {
-	summaries    []idpservice.Summary
-	details      []idpservice.Details
-	health       []idpservice.Health
-	logs         []idpservice.LogLine
-	events       []idpservice.Event
-	metrics      []idpservice.Metric
-	traces       []idpservice.Trace
-	listOpts     []idpservice.ListOptions
-	describeOpts []idpservice.DescribeOptions
-	healthOpts   []idpservice.HealthOptions
-	logsOpts     []idpservice.LogsOptions
-	eventsOpts   []idpservice.EventsOptions
-	metricsOpts  []idpservice.MetricsOptions
-	tracesOpts   []idpservice.TracesOptions
+	summaries     []idpservice.Summary
+	details       []idpservice.Details
+	health        []idpservice.Health
+	logs          []idpservice.LogLine
+	events        []idpservice.Event
+	metrics       []idpservice.Metric
+	traces        []idpservice.Trace
+	ownership     []idpservice.Ownership
+	listOpts      []idpservice.ListOptions
+	describeOpts  []idpservice.DescribeOptions
+	healthOpts    []idpservice.HealthOptions
+	logsOpts      []idpservice.LogsOptions
+	eventsOpts    []idpservice.EventsOptions
+	metricsOpts   []idpservice.MetricsOptions
+	tracesOpts    []idpservice.TracesOptions
+	ownershipOpts []idpservice.OwnershipOptions
 }
 
 func (f *fakeService) List(_ context.Context, opts idpservice.ListOptions) ([]idpservice.Summary, error) {
@@ -728,6 +755,11 @@ func (f *fakeService) Metrics(_ context.Context, opts idpservice.MetricsOptions)
 func (f *fakeService) Traces(_ context.Context, opts idpservice.TracesOptions) ([]idpservice.Trace, error) {
 	f.tracesOpts = append(f.tracesOpts, opts)
 	return f.traces, nil
+}
+
+func (f *fakeService) Ownership(_ context.Context, opts idpservice.OwnershipOptions) ([]idpservice.Ownership, error) {
+	f.ownershipOpts = append(f.ownershipOpts, opts)
+	return f.ownership, nil
 }
 
 type fakeCluster struct {
@@ -898,6 +930,19 @@ func assertServiceMetricsOptions(t *testing.T, got []idpservice.MetricsOptions, 
 }
 
 func assertServiceTracesOptions(t *testing.T, got []idpservice.TracesOptions, want []idpservice.TracesOptions) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(options) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func assertServiceOwnershipOptions(t *testing.T, got []idpservice.OwnershipOptions, want []idpservice.OwnershipOptions) {
 	t.Helper()
 
 	if len(got) != len(want) {

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -45,9 +45,10 @@ type Summary struct {
 
 type Details struct {
 	Summary
-	Images   []string
-	Labels   map[string]string
-	Selector map[string]string
+	Images      []string
+	Labels      map[string]string
+	Annotations map[string]string
+	Selector    map[string]string
 }
 
 type ListOptions struct {
@@ -91,6 +92,11 @@ type TracesOptions struct {
 	Namespace string
 	Hours     int
 	Limit     int
+}
+
+type OwnershipOptions struct {
+	Name      string
+	Namespace string
 }
 
 type Health struct {
@@ -142,6 +148,15 @@ type Trace struct {
 	RootServiceName string
 	StartTime       string
 	Duration        string
+}
+
+type Ownership struct {
+	Summary
+	Owner        string
+	Tier         string
+	Source       string
+	Docs         []string
+	SourceObject string
 }
 
 func NewKubernetesService() (*KubernetesService, error) {
@@ -457,6 +472,21 @@ func (s *KubernetesService) Traces(ctx context.Context, opts TracesOptions) ([]T
 	return traces, nil
 }
 
+func (s *KubernetesService) Ownership(ctx context.Context, opts OwnershipOptions) ([]Ownership, error) {
+	details, err := s.Describe(ctx, DescribeOptions{Name: opts.Name, Namespace: opts.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	ownership := make([]Ownership, 0, len(details))
+	for _, detail := range details {
+		ownership = append(ownership, ownershipFor(detail))
+	}
+
+	sortOwnership(ownership)
+	return ownership, nil
+}
+
 func (s *KubernetesService) workloads(ctx context.Context, namespace string) ([]Details, error) {
 	if namespace == "" {
 		namespace = metav1.NamespaceAll
@@ -741,9 +771,10 @@ func (s *KubernetesService) deploymentDetails(deployment appsv1.Deployment) Deta
 			Ready:     fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
 			Age:       s.age(deployment.CreationTimestamp.Time),
 		},
-		Images:   containerImages(deployment.Spec.Template.Spec),
-		Labels:   copyMap(deployment.Labels),
-		Selector: deployment.Spec.Selector.MatchLabels,
+		Images:      containerImages(deployment.Spec.Template.Spec),
+		Labels:      copyMap(deployment.Labels),
+		Annotations: copyMap(deployment.Annotations),
+		Selector:    deployment.Spec.Selector.MatchLabels,
 	}
 }
 
@@ -761,9 +792,10 @@ func (s *KubernetesService) statefulSetDetails(statefulSet appsv1.StatefulSet) D
 			Ready:     fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
 			Age:       s.age(statefulSet.CreationTimestamp.Time),
 		},
-		Images:   containerImages(statefulSet.Spec.Template.Spec),
-		Labels:   copyMap(statefulSet.Labels),
-		Selector: statefulSet.Spec.Selector.MatchLabels,
+		Images:      containerImages(statefulSet.Spec.Template.Spec),
+		Labels:      copyMap(statefulSet.Labels),
+		Annotations: copyMap(statefulSet.Annotations),
+		Selector:    statefulSet.Spec.Selector.MatchLabels,
 	}
 }
 
@@ -776,9 +808,10 @@ func (s *KubernetesService) daemonSetDetails(daemonSet appsv1.DaemonSet) Details
 			Ready:     fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
 			Age:       s.age(daemonSet.CreationTimestamp.Time),
 		},
-		Images:   containerImages(daemonSet.Spec.Template.Spec),
-		Labels:   copyMap(daemonSet.Labels),
-		Selector: daemonSet.Spec.Selector.MatchLabels,
+		Images:      containerImages(daemonSet.Spec.Template.Spec),
+		Labels:      copyMap(daemonSet.Labels),
+		Annotations: copyMap(daemonSet.Annotations),
+		Selector:    daemonSet.Spec.Selector.MatchLabels,
 	}
 }
 
@@ -796,9 +829,10 @@ func (s *KubernetesService) jobDetails(job batchv1.Job) Details {
 			Ready:     fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
 			Age:       s.age(job.CreationTimestamp.Time),
 		},
-		Images:   containerImages(job.Spec.Template.Spec),
-		Labels:   copyMap(job.Labels),
-		Selector: map[string]string{},
+		Images:      containerImages(job.Spec.Template.Spec),
+		Labels:      copyMap(job.Labels),
+		Annotations: copyMap(job.Annotations),
+		Selector:    map[string]string{},
 	}
 }
 
@@ -811,9 +845,10 @@ func (s *KubernetesService) cronJobDetails(cronJob batchv1.CronJob) Details {
 			Ready:     fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
 			Age:       s.age(cronJob.CreationTimestamp.Time),
 		},
-		Images:   containerImages(cronJob.Spec.JobTemplate.Spec.Template.Spec),
-		Labels:   copyMap(cronJob.Labels),
-		Selector: map[string]string{},
+		Images:      containerImages(cronJob.Spec.JobTemplate.Spec.Template.Spec),
+		Labels:      copyMap(cronJob.Labels),
+		Annotations: copyMap(cronJob.Annotations),
+		Selector:    map[string]string{},
 	}
 }
 
@@ -908,6 +943,18 @@ func sortTraces(traces []Trace) {
 	})
 }
 
+func sortOwnership(ownership []Ownership) {
+	sort.Slice(ownership, func(i, j int) bool {
+		if ownership[i].Namespace == ownership[j].Namespace {
+			if ownership[i].Kind == ownership[j].Kind {
+				return ownership[i].Name < ownership[j].Name
+			}
+			return ownership[i].Kind < ownership[j].Kind
+		}
+		return ownership[i].Namespace < ownership[j].Namespace
+	})
+}
+
 func SortedMapEntries(values map[string]string) []string {
 	entries := make([]string, 0, len(values))
 	for key, value := range values {
@@ -988,6 +1035,46 @@ func sortPods(pods []corev1.Pod) {
 	sort.Slice(pods, func(i, j int) bool {
 		return pods[i].Name < pods[j].Name
 	})
+}
+
+func ownershipFor(detail Details) Ownership {
+	return Ownership{
+		Summary:      detail.Summary,
+		Owner:        metadataValue(detail, []string{"platform.observability-hub.io/owner", "app.kubernetes.io/owner", "owner", "team"}),
+		Tier:         metadataValue(detail, []string{"platform.observability-hub.io/tier", "tier", "app.kubernetes.io/component", "app.kubernetes.io/part-of"}),
+		Source:       metadataValue(detail, []string{"platform.observability-hub.io/source", "platform.observability-hub.io/repo", "app.kubernetes.io/source", "repository", "repo", "source"}),
+		Docs:         metadataValues(detail, []string{"platform.observability-hub.io/docs", "platform.observability-hub.io/runbook", "platform.observability-hub.io/dashboard", "docs", "documentation", "runbook", "dashboard"}),
+		SourceObject: detail.Kind + " " + detail.Namespace + "/" + detail.Name,
+	}
+}
+
+func metadataValue(detail Details, keys []string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(detail.Labels[key]); value != "" {
+			return value
+		}
+		if value := strings.TrimSpace(detail.Annotations[key]); value != "" {
+			return value
+		}
+	}
+	return "unknown"
+}
+
+func metadataValues(detail Details, keys []string) []string {
+	values := make([]string, 0)
+	for _, key := range keys {
+		if value := strings.TrimSpace(detail.Labels[key]); value != "" {
+			values = append(values, key+"="+value)
+		}
+		if value := strings.TrimSpace(detail.Annotations[key]); value != "" {
+			values = append(values, key+"="+value)
+		}
+	}
+	if len(values) == 0 {
+		return []string{"unknown"}
+	}
+	sort.Strings(values)
+	return values
 }
 
 func healthStatus(health Health) string {

--- a/internal/idp/service/service_test.go
+++ b/internal/idp/service/service_test.go
@@ -608,6 +608,78 @@ func TestKubernetesServiceTraces(t *testing.T) {
 	}
 }
 
+func TestKubernetesServiceOwnership(t *testing.T) {
+	created := metav1.NewTime(time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC))
+	replicas := int32(2)
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		opts    OwnershipOptions
+		want    []Ownership
+		wantErr string
+	}{
+		{
+			name: "reads ownership metadata from labels and annotations",
+			objects: []runtime.Object{
+				ownedDeployment("grafana", "observability", created, replicas),
+			},
+			opts: OwnershipOptions{Name: "grafana", Namespace: "observability"},
+			want: []Ownership{
+				{
+					Summary:      Summary{Name: "grafana", Namespace: "observability", Kind: "Deployment", Ready: "2/2", Age: "2h"},
+					Owner:        "platform",
+					Tier:         "frontend",
+					Source:       "https://github.com/example/grafana",
+					Docs:         []string{"platform.observability-hub.io/dashboard=https://grafana.example/d/grafana", "platform.observability-hub.io/runbook=docs/runbooks/grafana.md"},
+					SourceObject: "Deployment observability/grafana",
+				},
+			},
+		},
+		{
+			name: "returns unknown ownership when metadata is absent",
+			objects: []runtime.Object{
+				statefulSet("loki", "observability", created, replicas, 2),
+			},
+			opts: OwnershipOptions{Name: "loki", Namespace: "observability"},
+			want: []Ownership{
+				{
+					Summary:      Summary{Name: "loki", Namespace: "observability", Kind: "StatefulSet", Ready: "2/2", Age: "2h"},
+					Owner:        "unknown",
+					Tier:         "unknown",
+					Source:       "unknown",
+					Docs:         []string{"unknown"},
+					SourceObject: "StatefulSet observability/loki",
+				},
+			},
+		},
+		{
+			name:    "missing service",
+			opts:    OwnershipOptions{Name: "missing"},
+			wantErr: "service not found: missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newTestService(tt.objects...)
+
+			ownership, err := service.Ownership(context.Background(), tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Ownership() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Ownership() error = %v", err)
+			}
+
+			assertOwnership(t, ownership, tt.want)
+		})
+	}
+}
+
 func deployment(name string, namespace string, created metav1.Time, replicas int32, ready int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -629,6 +701,18 @@ func deployment(name string, namespace string, created metav1.Time, replicas int
 		},
 		Status: appsv1.DeploymentStatus{ReadyReplicas: ready},
 	}
+}
+
+func ownedDeployment(name string, namespace string, created metav1.Time, replicas int32) *appsv1.Deployment {
+	deployment := deployment(name, namespace, created, replicas, replicas)
+	deployment.Labels["app.kubernetes.io/owner"] = "platform"
+	deployment.Labels["tier"] = "frontend"
+	deployment.Annotations = map[string]string{
+		"platform.observability-hub.io/repo":      "https://github.com/example/grafana",
+		"platform.observability-hub.io/runbook":   "docs/runbooks/grafana.md",
+		"platform.observability-hub.io/dashboard": "https://grafana.example/d/grafana",
+	}
+	return deployment
 }
 
 func statefulSet(name string, namespace string, created metav1.Time, replicas int32, ready int32) *appsv1.StatefulSet {
@@ -824,6 +908,24 @@ func assertTraces(t *testing.T, got []Trace, want []Trace) {
 		if got[i] != want[i] {
 			t.Fatalf("traces[%d] = %#v, want %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func assertOwnership(t *testing.T, got []Ownership, want []Ownership) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(ownership) = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Summary != want[i].Summary ||
+			got[i].Owner != want[i].Owner ||
+			got[i].Tier != want[i].Tier ||
+			got[i].Source != want[i].Source ||
+			got[i].SourceObject != want[i].SourceObject {
+			t.Fatalf("ownership[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+		assertStringSlice(t, got[i].Docs, want[i].Docs)
 	}
 }
 


### PR DESCRIPTION
### Summary

This PR adds `service ownership` to the IDP CLI. The command resolves the
service through Kubernetes and reports ownership metadata from the workload
object that matched the request.

### List of Changes

- Added Kubernetes-backed `service ownership` with namespace filtering.
- Derived owner, tier, source, docs, runbook, and dashboard hints from workload
  labels and annotations.
- Returned explicit `unknown` values when ownership metadata is absent while
  still showing the Kubernetes object that supplied the result.

### Verification

- [x] `GOCACHE=/tmp/observability-hub-go-build go test ./internal/idp/...`
- [x] `GOCACHE=/tmp/observability-hub-go-build go build -o ./bin/hub-cli ./cmd/idp`

