### PR TITLE
docs(web): refresh platform positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It proves an end-to-end platform ownership loop: declarative infrastructure runs
 
 | Case Study | Problem | How it was diagnosed | Result |
 | :--- | :--- | :--- | :--- |
-| [Rust Telemetry Summarization Processor](./docs/decisions/021-rust-telemetry-summarization-processor.md) | Raw logs and metrics returned too much data for agent workflows | Added a Rust `obs-processor` to summarize Loki and Prometheus responses before returning them through MCP | Reduced token load while preserving investigation pivots |
+| [Rust Telemetry Summarization Processor](./docs/decisions/021-rust-telemetry-summarization-processor.md) | Raw logs and metrics returned too much data for agent workflows | Added a Rust `obs-processor` and validated the language choice with [ADR 023 benchmark evidence](./docs/decisions/023-benchmark-rust-obs-processor.md) | Reduced token load while preserving investigation pivots |
 | [Worker Ingestion Blocked from MongoDB Atlas](./docs/incidents/007-worker-ingestion-atlas-egress-block.md) | Scheduled ingestion could not reach Atlas | Used worker logs and Cilium policy review to identify blocked egress | Added Atlas egress policy and documented prevention |
 | [Loki Gateway DNS Timeout](./docs/incidents/006-loki-gateway-dns-timeout.md) | Grafana and agents could not reliably query logs | Traced the request path through gateway DNS resolution and Loki service routing | Fixed resolver config and added operational checks |
 | [SSH Lockout via Cilium IPAM Collision](./docs/incidents/004-ssh-lockout-cilium-ipam-collision.md) | Host access failed after networking drift | Correlated Cilium/IPAM state, pod readiness, and host reachability | Restored access and documented recovery path |

--- a/docs/decisions/019-hybrid-host-mcp-intelligence.md
+++ b/docs/decisions/019-hybrid-host-mcp-intelligence.md
@@ -1,6 +1,6 @@
 # ADR 019: Hybrid Host-MCP Intelligence Layer
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR 026](./026-unified-mcp-gateway-with-capability-accounting.md)
 - **Date:** 2026-03-12
 - **Author:** Victoria Cheng
 

--- a/docs/decisions/027-hub-cli-developer-experience.md
+++ b/docs/decisions/027-hub-cli-developer-experience.md
@@ -6,24 +6,31 @@
 
 ## Context and Problem Statement
 
-Observability Hub has operational surfaces across Kubernetes, telemetry, MCP
-tools, documentation, and host services. A local IDP CLI gives those surfaces a
-service-first developer interface for understanding runtime state, signals,
-ownership, and next steps.
+Observability Hub's active runtime surface is Kubernetes-backed: services map
+to pods, workloads, namespaces, logs, events, and health signals. A Hub
+internal developer platform CLI gives that surface a service-first interface
+for understanding runtime state, ownership, and service status.
 
-The first implementation should establish the command shape as a local Linux
-binary, with service-focused commands that can grow into Kubernetes service
-discovery, health summaries, logs, events, and developer helper commands.
+Without a shared command surface, the same investigation path can require
+switching between pod lists, workload status, service logs, cluster events, and
+ad hoc Kubernetes commands. The CLI should give those workflows a consistent
+vocabulary without hiding the underlying platform model.
+
+The first implementation should establish the command shape, with
+service-focused commands that cover Kubernetes service discovery, health
+summaries, logs, events, and developer helper commands.
 
 ## Decision Outcome
 
-Add a local Hub IDP CLI with the source entry point at `cmd/idp` and internal
-logic under `internal/idp`.
+Add a Hub internal developer platform CLI with the source entry point at
+`cmd/idp` and internal logic under `internal/idp`.
 
-- **Local Binary:** Build the CLI as a local Linux binary for day-to-day
-  development.
+- **CLI Entry Point:** Build the CLI as the repository's developer interface.
 - **Service-First UX:** Design commands around services before pods or raw
   Kubernetes objects.
+- **Workflow Vocabulary:** Use command groups that match recurring platform
+  workflows: service inspection, cluster state, Kubernetes catalog validation,
+  and environment discovery.
 - **Read-Only First:** Start with command routing and help text before adding
   Kubernetes access.
 
@@ -31,9 +38,9 @@ logic under `internal/idp`.
 
 ### Positive
 
-- **Fast Feedback:** The CLI shape can be tested locally as part of normal
+- **Fast Feedback:** The CLI shape can be tested as part of normal
   development.
-- **Simple Operations:** A single Linux binary keeps the local workflow direct.
+- **Simple Operations:** A single CLI keeps the developer workflow direct.
 - **Project Alignment:** The CLI follows the repository's `cmd/` and
   `internal/` boundaries.
 - **Clear Growth Path:** Catalog, Kubernetes, telemetry, and helper behavior
@@ -41,30 +48,30 @@ logic under `internal/idp`.
 
 ### Negative
 
-- **Linux-First Assumption:** The initial binary targets the local Linux
-  environment instead of proving cross-platform behavior.
+- **Implementation Scope:** The first version proves command routing before
+  deeper Kubernetes, telemetry, or remediation behavior.
 - **Command Names Become Sticky:** Once commands such as `service health` or
   `cluster status` are documented, changing them later can break habits,
   scripts, or notes.
 
 ## Verification
 
-- [ ] **Service Commands:**
-  - [ ] `service list` is routed.
-  - [ ] `service describe <service>` is routed.
-  - [ ] `service health <service>` is routed.
-  - [ ] `service logs <service>` is routed.
-  - [ ] `service events <service>` is routed.
-  - [ ] `service metrics <service>` is routed.
-  - [ ] `service traces <service>` is routed.
-  - [ ] `service ownership <service>` is routed.
-- [ ] **Cluster Commands:**
-  - [ ] `cluster status` is routed.
-  - [ ] `cluster namespaces` is routed.
-  - [ ] `cluster workloads` is routed.
-- [ ] **Catalog Commands:**
-  - [ ] `catalog list` is routed.
-  - [ ] `catalog validate` is routed.
-- [ ] **Environment Commands:**
-  - [ ] `env list` is routed.
-  - [ ] `env describe <env>` is routed.
+- [x] **Service Commands:**
+  - [x] `service list` is routed.
+  - [x] `service describe <service>` is routed.
+  - [x] `service health <service>` is routed.
+  - [x] `service logs <service>` is routed.
+  - [x] `service events <service>` is routed.
+  - [x] `service metrics <service>` is routed.
+  - [x] `service traces <service>` is routed.
+  - [x] `service ownership <service>` is routed.
+- [x] **Cluster Commands:**
+  - [x] `cluster status` is routed.
+  - [x] `cluster namespaces` is routed.
+  - [x] `cluster workloads` is routed.
+- [x] **Catalog Commands:**
+  - [x] `catalog list` is routed.
+  - [x] `catalog validate` is routed.
+- [x] **Environment Commands:**
+  - [x] `env list` is routed.
+  - [x] `env describe <env>` is routed.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,7 +16,7 @@ This directory serves as the **Institutional Memory** for the Observability Hub.
 | **022** | [Structured Summaries for Obs Processor](./022-obs-processor-structured-summaries.md) | 🔵 Accepted |
 | **021** | [Rust Telemetry Summarization Processor](./021-rust-telemetry-summarization-processor.md) | 🔵 Accepted |
 | **020** | [Cilium eBPF Foundation](./020-cilium-ebpf-foundation.md) | 🔵 Accepted |
-| **019** | [Hybrid Host-MCP Intelligence Layer](./019-hybrid-host-mcp-intelligence.md) | 🔵 Accepted |
+| **019** | [Hybrid Host-MCP Intelligence Layer](./019-hybrid-host-mcp-intelligence.md) | 🟡 Superseded |
 | **018** | [Domain-Isolated MCP Architecture](./018-domain-isolated-mcp-architecture.md) | 🟡 Superseded |
 | **017** | [Agentic Interface via MCP](./017-agentic-interface-mcp.md) | 🔵 Accepted |
 | **016** | [OpenTofu for K3s Service Management](./016-opentofu-k3s-migration.md) | 🔵 Accepted |

--- a/internal/web/templates/content/evolution.yaml
+++ b/internal/web/templates/content/evolution.yaml
@@ -1,5 +1,5 @@
 page_title: "System Logs & Milestones"
-intro_text: "A chronological view of how the Observability Hub evolved from a local lab into an infrastructure, Kubernetes, and observability platform with automation, incident response, and cost-aware telemetry analysis."
+intro_text: "A chronological view of how Observability Hub evolved from a local lab into a Kubernetes platform for observability, GitOps, infrastructure-as-code, incident response, and developer tooling."
 chapters:
   - title: "The Genesis"
     intro: "The foundation chapter: building a reliable local lab, choosing PostgreSQL for durable telemetry storage, and bridging cloud-generated events into a self-hosted observability path."
@@ -187,7 +187,7 @@ chapters:
         title: "Unified Host Telemetry Analytics & Grafana Alloy Retirement"
         artifacts:
           - name: "ADR 015: Unified Host Telemetry Analytics"
-            url: "docs/decisions/015-unified-host-telemetry-analytics.md"
+            url: "docs/decisions/015-unified-host-telemetry-collectors.md"
           - name: "RCA 003: Thanos Discovery and Retention Failure"
             url: "docs/incidents/003-thanos-discovery-and-retention-failure.md"
         description: |
@@ -211,7 +211,7 @@ chapters:
           - Improved drift detection, persistent workload recovery, and cross-service telemetry discovery.
 
   - title: "The MCP Era"
-    intro: "The agent-native operations chapter: building an MCP gateway for live telemetry, Kubernetes, and host state; reducing noisy observability payloads with Rust; and proving the design with Go-vs-Rust benchmarks for faster, lower-cost investigations."
+    intro: "The agent-native operations chapter: building an MCP gateway for live telemetry, Kubernetes, and network state; reducing noisy observability payloads with Rust; and proving the design with Go-vs-Rust benchmarks for faster, lower-cost investigations."
     timeline:
       - date: "2026-03-08"
         title: "MCP Telemetry and Infrastructure Intelligence"
@@ -220,17 +220,15 @@ chapters:
             url: "docs/decisions/017-agentic-interface-mcp.md"
           - name: "ADR 018: Domain-Isolated MCP Architecture"
             url: "docs/decisions/018-domain-isolated-mcp-architecture.md"
-          - name: "ADR 019: Hybrid Host-MCP Intelligence"
-            url: "docs/decisions/019-hybrid-host-mcp-intelligence.md"
         description: |
-          - Exposed metrics, semantic logs, distributed traces, Kubernetes events, and host state through MCP.
+          - Exposed metrics, semantic logs, distributed traces, Kubernetes events, and network flows through MCP.
           - Split capabilities into domain-isolated services to reduce blast radius and enforce least privilege.
-          - Connected telemetry, pod state, and host-level signals for focused cross-layer debugging.
+          - Connected telemetry, pod state, and network-level signals for focused cross-layer debugging.
           - Introduced `investigate_incident` for structured incident reports from live platform signals.
       - date: "2026-03-19"
         title: "mcp_obs_hub: Unified Agentic Gateway"
         description: |
-          - Consolidated telemetry, pods, and hub services into a single `mcp_obs_hub` binary to reduce management overhead.
+          - Consolidated telemetry, pods, and network capabilities into a single `mcp_obs_hub` binary to reduce management overhead.
       - date: "2026-04-06"
         title: "Rust Telemetry Summarization Processor"
         artifacts:
@@ -257,6 +255,14 @@ chapters:
         description: |
           - Benchmarked Go and Rust telemetry processors against the same 24-hour Loki and Prometheus payloads.
           - Established Rust as the faster reduction path, especially for metric summarization where numeric parsing and statistical aggregation dominate.
+      - date: "2026-04-27"
+        title: "Unified MCP Gateway Capability Accounting"
+        artifacts:
+          - name: "ADR 026: Unified MCP Gateway With Capability Accounting"
+            url: "docs/decisions/026-unified-mcp-gateway-with-capability-accounting.md"
+        description: |
+          - Reconciled the MCP architecture with the active unified gateway after stale host and platform tools were removed.
+          - Added runtime capability accounting so agents can inspect available and skipped MCP domains before running an operational workflow.
 
   - title: "eBPF-Native Efficiency & Networking"
     intro: "The kernel-visibility chapter: using Cilium, Hubble, and Kepler to inspect network flows, protocol behavior, and infrastructure efficiency below the application layer."
@@ -312,3 +318,14 @@ chapters:
         description: |
           - Established a Trivy-verified workload hardening baseline for platform-managed containers and Kubernetes manifests.
           - Strengthened the GitOps security posture by making container runtime controls part of the source of truth.
+
+  - title: "The Developer Platform Era"
+    intro: "The internal-tooling chapter: turning Kubernetes pods, workloads, namespaces, and service signals into a service-first developer interface."
+    timeline:
+      - date: "2026-04-28"
+        title: "Hub CLI Developer Experience"
+        artifacts:
+          - name: "ADR 027: Hub CLI Developer Experience"
+            url: "docs/decisions/027-hub-cli-developer-experience.md"
+        description: |
+          - Introduced a Hub CLI for inspecting Kubernetes-backed services, workloads, namespaces, logs, events, and health.

--- a/internal/web/templates/content/landing.yaml
+++ b/internal/web/templates/content/landing.yaml
@@ -3,18 +3,18 @@ header:
   site_url: "https://victoriacheng15.github.io/observability-hub"
 
 system_specification:
-  objective: "A self-hosted observability hub orchestrated via OpenTofu (Terraform) and ArgoCD (GitOps), demonstrating SRE and Platform Engineering principles through Go, eBPF-native Kubernetes (K3s/Cilium), and OpenTelemetry."
-  stack: "Go, OpenTelemetry, Model Context Protocol (MCP), Cilium (eBPF), Kepler (Energy Monitoring), ArgoCD (GitOps), Kubernetes (K3s), Helm, OpenTofu (Terraform), Grafana, Loki, Prometheus, Tempo, OpenBao, PostgreSQL, Azure Blob Storage"
+  objective: "A self-hosted observability hub orchestrated via Terraform and ArgoCD, demonstrating SRE and platform engineering principles through Go, eBPF-native Kubernetes (K3s/Cilium), OpenTelemetry, Model Context Protocol (MCP), and an internal Hub CLI."
+  stack: "Kubernetes (K3s), Go, Rust, Terraform, Prometheus, Grafana, OpenTelemetry, ArgoCD, Cilium (eBPF), PostgreSQL, Kepler, Azure Blob Storage, Model Context Protocol (MCP), Hub CLI"
   pattern: "Pure Wrapper / Hybrid Orchestration (Kubernetes + Systemd)"
   entry_point: "cmd/web/main.go"
   persistence_strategy: "PostgreSQL (CNPG) and tfstate on Azure Blob Storage; Logs, Metrics, and Traces on MinIO S3"
-  observability: "OpenTelemetry (OTLP/gRPC), eBPF (Cilium/Hubble/Kepler), and Agentic Intelligence (MCP) with Prometheus, Tempo, and Loki"
+  observability: "OpenTelemetry (OTLP/gRPC), eBPF (Cilium/Kepler), MCP-backed telemetry, pod, and network access, and Hub CLI inspection with Prometheus, Tempo, and Loki"
   machine_registry: "/api/evolution-registry.json"
 
 hero:
   headline: "A Laboratory for Observability"
   sub_headline: "Exploring SRE and Platform Engineering through a self-hosted telemetry stack."
-  brief_description: "Designed to eliminate configuration drift and optimize performance on a single-node rig using modern SRE principles."
+  brief_description: "A self-hosted platform engineering lab for Kubernetes operations, observability, and GitOps reliability."
   cta_text: "Explore on GitHub"
   cta_link: "https://github.com/victoriacheng15/observability-hub"
   secondary_cta_text: "See the Evolution"
@@ -27,38 +27,33 @@ hero:
 what_is_observability_hub:
   title: "Observability as an Engineering Discipline"
   content:
-    - "Explain the transition from passive monitoring to active observability using OpenTelemetry."
-    - "Position the hub as a blueprint for self-hosting critical telemetry infrastructure without the overhead of enterprise SaaS."
-    - "Highlight the integration of GitOps and Infrastructure-as-Code to maintain a reliable and reproducible environment."
-    - "Showcase the integration of Model Context Protocol (MCP) as a standardized gateway for AI agents to interact with telemetry data."
+    - "Observability Hub is a self-hosted platform engineering lab for operating Kubernetes services with clear visibility into health, traffic, and infrastructure state."
+    - "It demonstrates practical SRE work: service health, telemetry, GitOps, infrastructure-as-code, and RCA-backed improvement."
+    - "The project favors owned infrastructure and reproducible operations over black-box managed tooling."
 
 key_features:
-  title: "Core Principles"
+  title: "Platform Signals"
   features:
-    - name: "Signals over Noise"
-      description: "Standardizing on OpenTelemetry and eBPF (Cilium/Kepler) to provide immediate, high-fidelity clarity on service, network, and energy behavior across the entire stack."
-      icon: "chart-line"
-    - name: "Logic over Plumbing"
-      description: "Enforcing strict project encapsulation in the internal/ namespace to isolate core domain logic from infrastructure boilerplate."
-      icon: "layers-half"
-    - name: "Config as the Truth"
-      description: "Leveraging ArgoCD to ensure version control remains the ultimate source of truth, with an automated GitOps reconciliation loop."
-      icon: "shield-check"
-    - name: "Pragmatic Orchestration"
-      description: "Leveraging Kubernetes for the data platform, managed declaratively via OpenTofu (Terraform) to ensure consistent and scalable deployments."
+    - name: "Kubernetes Operations"
+      description: "Runs and inspects platform services on K3s with service health, workload state, logs, events, and network visibility."
       icon: "cpu"
-    - name: "Agentic Intelligence"
-      description: "Exposing system state via the Model Context Protocol (MCP) to enable autonomous diagnostics and AI-native operations."
-      icon: "robot"
+    - name: "Observability Stack"
+      description: "Uses Prometheus, Grafana, OpenTelemetry, and eBPF visibility to connect service behavior with operational signals."
+      icon: "chart-line"
+    - name: "Infrastructure as Code"
+      description: "Manages platform services declaratively with Terraform and GitOps workflows."
+      icon: "shield-check"
+    - name: "Go Platform Tooling"
+      description: "Keeps service entry points thin and moves reusable platform logic into internal Go packages."
+      icon: "layers-half"
 
 why_it_matters:
-  title: "Mastering the OpenTelemetry Stack"
+  title: "Why It Matters"
   points:
-    - "Full Ownership: Complete control over data retention and privacy through self-hosting."
-    - "Operational Excellence: Demonstrates real-world SRE practices in a constrained environment."
-    - "Cost Efficiency: Optimized for single-node performance, reducing infrastructure overhead."
-    - "Modern Tooling: Leverages industry standards like OpenTelemetry and OpenTofu."
-    - "Educational Value: Serves as a living laboratory for testing new observability patterns."
+    - "Shows hands-on ownership of Kubernetes, observability, infrastructure-as-code, and GitOps."
+    - "Demonstrates SRE judgment through incident reviews, operational hardening, and measurable platform improvements."
+    - "Uses Go to build platform tooling around real operational workflows."
+    - "Keeps the project understandable through ADRs, evolution history, and reproducible infrastructure."
 
 footer:
   author: "Victoria Cheng"

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -39,11 +39,14 @@
 <div class="grid gap-16">
     <section class="grid gap-6">
         <h2 class="text-2xl font-bold text-white border-l-4 border-cyan-400 pl-4">{{ .Landing.WhatIs.Title }}</h2>
-        <div class="grid gap-4 text-slate-300 leading-relaxed">
+        <ul class="grid gap-4">
             {{range .Landing.WhatIs.Content}}
-            <p>{{ . }}</p>
+            <li class="flex gap-3 text-slate-300 leading-relaxed">
+                <span class="text-cyan-400">▹</span>
+                <span>{{ . }}</span>
+            </li>
             {{end}}
-        </div>
+        </ul>
     </section>
 
     <section class="grid gap-8" aria-label="Key Features">


### PR DESCRIPTION
### Summary
Refresh the public-facing project narrative so the site and README better frame Observability Hub as an SRE, platform engineering, and backend infrastructure portfolio project. The update also reconciles the evolution timeline and ADR 027 with the current Kubernetes-backed Hub CLI and unified MCP gateway direction.

### List of Changes
- Refined the landing page and evolution timeline to describe the current Kubernetes, Go, Terraform, GitOps, observability, incident-response, and developer-tooling scope more clearly.
- Made the documentation trail easier to follow by linking the Rust processor case study to benchmark evidence, marking ADR 019 as superseded, and completing ADR 027 verification.

### Verification
- [x] `go test ./internal/web`

