### PR TITLE
fix(cnpg): restore argocd image selector

### DIFF
--- a/k3s/base/infra/cnpg/cluster/kustomization.yaml
+++ b/k3s/base/infra/cnpg/cluster/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - postgres-image-catalog.yaml
   - postgres-cluster.yaml
   - postgres-backup-schedule.yaml
   - postgres-host-access.yaml

--- a/k3s/base/infra/cnpg/cluster/postgres-cluster.yaml
+++ b/k3s/base/infra/cnpg/cluster/postgres-cluster.yaml
@@ -5,11 +5,7 @@ metadata:
   namespace: databases
 spec:
   instances: 3
-  imageCatalogRef:
-    apiGroup: postgresql.cnpg.io
-    kind: ImageCatalog
-    name: postgres-cnpg
-    major: 17
+  imageName: localhost/postgres-cnpg:17
   imagePullPolicy: IfNotPresent
   imagePullSecrets:
     - name: ghcr-auth

--- a/k3s/base/infra/cnpg/cluster/postgres-image-catalog.yaml
+++ b/k3s/base/infra/cnpg/cluster/postgres-image-catalog.yaml
@@ -1,9 +1,0 @@
-apiVersion: postgresql.cnpg.io/v1
-kind: ImageCatalog
-metadata:
-  name: postgres-cnpg
-  namespace: databases
-spec:
-  images:
-    - major: 17
-      image: ghcr.io/victoriacheng15/observability-hub/postgres-cnpg:sha-f8b2a4a


### PR DESCRIPTION
### Summary
Restore the CNPG database app to the known-good local Postgres image selector so ArgoCD can reconcile the existing cluster cleanly. This keeps the live cluster and Git desired state aligned while the GHCR tag format is handled separately.

### List of Changes
- Switched the CNPG cluster manifest back to `imageName: localhost/postgres-cnpg:17`.
- Removed the CNPG image catalog resource from the database kustomization.

### Verification
- [x] `kubectl kustomize k3s/base/infra/cnpg/cluster`
- [x] Confirmed CNPG reports `postgres-hub` as healthy with 3 ready instances

