### PR TITLE
chore(observability): move loki and tempo to local pvc

### DIFF
--- a/k3s/base/infra/loki/values.yaml
+++ b/k3s/base/infra/loki/values.yaml
@@ -7,22 +7,15 @@ loki:
   commonConfig:
     replication_factor: 1
   storage:
-    type: s3
-    bucketNames:
-      chunks: loki-chunks
-      ruler: loki-ruler
-      admin: loki-admin
-    s3:
-      endpoint: minio.databases.svc.cluster.local:9000
-      secretAccessKey: ${rootPassword}
-      accessKeyId: ${rootUser}
-      s3ForcePathStyle: true
-      insecure: true
+    type: filesystem
+    filesystem:
+      chunks_directory: /var/loki/chunks
+      rules_directory: /var/loki/rules
   schemaConfig:
     configs:
       - from: 2024-01-01
         store: tsdb
-        object_store: s3
+        object_store: filesystem
         schema: v13
         index:
           prefix: index_
@@ -39,9 +32,10 @@ loki:
     retention_enabled: true
     retention_delete_delay: 2h
     retention_delete_worker_count: 150
-    delete_request_store: s3
+    delete_request_store: filesystem
   persistence:
     enabled: true
+    storageClass: local-path-retain
   sidecar:
     rules:
       resources:
@@ -57,13 +51,9 @@ deploymentMode: SingleBinary
 
 singleBinary:
   replicas: 1
-  extraArgs:
-    - -config.expand-env=true
-  extraEnvFrom:
-    - secretRef:
-        name: minio-secret
   persistence:
     enabled: true
+    storageClass: local-path-retain
 
 gateway:
   enabled: true

--- a/k3s/base/infra/tempo/values.yaml
+++ b/k3s/base/infra/tempo/values.yaml
@@ -1,26 +1,11 @@
 persistence:
   enabled: true
+  storageClassName: local-path-retain
 
 tempo:
   podLabels:
     app.kubernetes.io/feature: observability-traces
   replicas: 1
-
-  # Injected directly into the tempo container
-  extraEnv:
-    - name: rootUser
-      valueFrom:
-        secretKeyRef:
-          name: minio-secret
-          key: rootUser
-    - name: rootPassword
-      valueFrom:
-        secretKeyRef:
-          name: minio-secret
-          key: rootPassword
-
-  extraArgs:
-    config.expand-env: "true"
 
   multitenancy_enabled: false
 
@@ -73,14 +58,9 @@ config: |
     http_listen_port: 3200
   storage:
     trace:
-      backend: s3
-      s3:
-        bucket: tempo-traces
-        endpoint: minio.databases.svc.cluster.local:9000
-        access_key: ${rootUser}
-        secret_key: ${rootPassword}
-        insecure: true
-        forcepathstyle: true
+      backend: local
+      local:
+        path: /var/tempo/traces
       wal:
         path: /var/tempo/wal
   metrics_generator:


### PR DESCRIPTION
### Summary
Move Loki and Tempo off MinIO-backed object storage and onto local retained PVC storage. This is the first step toward removing MinIO from the observability stack while keeping log and trace retention local to the cluster.

### List of Changes
- Changed Loki and Tempo to use local filesystem storage backed by `local-path-retain` PVCs.
- Removed the Loki and Tempo runtime dependency on MinIO secrets, endpoints, and observability bucket names.

### Verification
- [x] Parsed Loki and Tempo values files as valid YAML
- [x] Confirmed Loki and Tempo config directories no longer reference MinIO or S3 bucket names
- [x] Confirmed live `storage-loki-0` and `storage-tempo-0` PVCs use `local-path-retain`
- [x] Confirmed live Loki and Tempo pods are running and ready

