### PR TITLE
refactor(mcp): query prometheus for metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # --- Standardized NodePort URIs (Host-to-Cluster Bridge) ---
-# Used by cmd/mcp-telemetry and cmd/proxy
+# Used by cmd/mcp-obs-hub, cmd/worker, cmd/idp, and cmd/proxy
+PROMETHEUS_URL=
 THANOS_URL=
 LOKI_URL=
 TEMPO_URL=

--- a/cmd/mcp-obs-hub/main.go
+++ b/cmd/mcp-obs-hub/main.go
@@ -72,16 +72,19 @@ func main() {
 	}
 
 	// --- Telemetry Provider ---
-	thanosURL := os.Getenv("THANOS_URL")
+	prometheusURL := os.Getenv("PROMETHEUS_URL")
+	if prometheusURL == "" {
+		prometheusURL = os.Getenv("THANOS_URL")
+	}
 	lokiURL := os.Getenv("LOKI_URL")
 	tempoURL := os.Getenv("TEMPO_URL")
 
-	if thanosURL == "" || lokiURL == "" || tempoURL == "" {
-		reason := "THANOS_URL, LOKI_URL, or TEMPO_URL is missing"
+	if prometheusURL == "" || lokiURL == "" || tempoURL == "" {
+		reason := "PROMETHEUS_URL, LOKI_URL, or TEMPO_URL is missing"
 		capabilities.AddSkipped("mcp.telemetry", reason)
 		telemetry.Warn("mcp_telemetry_init_failed_missing_env_skipping_tools", "reason", reason)
 	} else {
-		telemetryProv := providers.NewTelemetryProvider(thanosURL, lokiURL, tempoURL)
+		telemetryProv := providers.NewTelemetryProvider(prometheusURL, lokiURL, tempoURL)
 		if telemetryProv != nil {
 			defer telemetryProv.Close()
 			internalmcp.RegisterTelemetryTools(server, telemetryProv, "mcp.telemetry")

--- a/docs/notes/mcp-gateway-deployment.md
+++ b/docs/notes/mcp-gateway-deployment.md
@@ -24,7 +24,7 @@ This command compiles `cmd/mcp-obs-hub` → `bin/mcp_obs_hub`
 AI Agent (Gemini CLI / Copilot / obs)
 └── Spawn Gateway (bin/mcp_obs_hub)
     └── Sequential Provider Initialization:
-        ├── Telemetry (Thanos, Loki, Tempo)
+        ├── Telemetry (Prometheus, Loki, Tempo)
         ├── Kubernetes (K3s API)
         └── Host (Systemd / D-Bus)
 ```
@@ -32,7 +32,7 @@ AI Agent (Gemini CLI / Copilot / obs)
 ### Service Lifecycle
 
 1. **Initialization**:
-   - Reads `.env` (loads `THANOS_URL`, `LOKI_URL`, `TEMPO_URL`).
+   - Reads `.env` (loads `PROMETHEUS_URL`, `LOKI_URL`, `TEMPO_URL`).
    - Initializes OTel telemetry (traces, metrics, logs → OTLP gRPC @ localhost:30317).
    - **Soft-Fail Registration**: Sequential initialization of Hub, Pods, and Telemetry providers. The gateway remains operational even if a specific backend is unreachable.
 
@@ -52,10 +52,12 @@ AI Agent (Gemini CLI / Copilot / obs)
 
 | Variable | Example | Purpose |
 | :--- | :--- | :--- |
-| `THANOS_URL` | `http://localhost:30090` | Metrics via Thanos Query |
+| `PROMETHEUS_URL` | `http://localhost:30091` | Metrics via Prometheus |
 | `LOKI_URL` | `http://localhost:30100` | Logs via Loki |
 | `TEMPO_URL` | `http://localhost:30200` | Traces via Tempo |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:30317` | Service observability destination |
+
+`THANOS_URL` is still accepted as a temporary fallback for metrics during rollout, but new MCP configurations should use `PROMETHEUS_URL`.
 
 ---
 
@@ -65,10 +67,10 @@ AI Agent (Gemini CLI / Copilot / obs)
 
 ```bash
 # Verify K3s services
-kubectl get svc -n observability | grep -E "loki|thanos|tempo"
+kubectl get svc -n observability | grep -E "prometheus-server|loki|tempo"
 
 # Test Telemetry Backends
-curl http://localhost:30090/api/v1/query?query=up
+curl http://localhost:30091/api/v1/query?query=up
 curl http://localhost:30100/loki/api/v1/query?query='{job="prometheus"}'
 curl http://localhost:30200/api/search
 ```
@@ -103,7 +105,7 @@ Add to `~/.gemini/settings.json` under the `mcpServers` key:
     "obs": {
       "command": "/[your path]/mcp_obs_hub",
       "env": {
-        "THANOS_URL": "http://localhost:30090",
+        "PROMETHEUS_URL": "http://localhost:30091",
         "LOKI_URL": "http://localhost:30100",
         "TEMPO_URL": "http://localhost:30200",
         "OTEL_EXPORTER_OTLP_ENDPOINT": "localhost:30317"

--- a/internal/mcp/providers/telemetry.go
+++ b/internal/mcp/providers/telemetry.go
@@ -12,42 +12,42 @@ import (
 	"observability-hub/internal/telemetry"
 )
 
-// TelemetryProvider manages connections to Thanos, Loki, and Tempo and exposes telemetry tools.
+// TelemetryProvider manages connections to Prometheus, Loki, and Tempo and exposes telemetry tools.
 type TelemetryProvider struct {
-	thanosURL  string
-	lokiURL    string
-	tempoURL   string
-	httpClient *http.Client
+	prometheusURL string
+	lokiURL       string
+	tempoURL      string
+	httpClient    *http.Client
 }
 
-// NewTelemetryProvider creates a new telemetry provider connected to Thanos, Loki, and Tempo.
-func NewTelemetryProvider(thanosURL, lokiURL, tempoURL string) *TelemetryProvider {
-	return NewTelemetryProviderWithClient(thanosURL, lokiURL, tempoURL, nil)
+// NewTelemetryProvider creates a new telemetry provider connected to Prometheus, Loki, and Tempo.
+func NewTelemetryProvider(prometheusURL, lokiURL, tempoURL string) *TelemetryProvider {
+	return NewTelemetryProviderWithClient(prometheusURL, lokiURL, tempoURL, nil)
 }
 
 // NewTelemetryProviderWithClient creates a new telemetry provider, allowing injection of a custom HTTP client.
 // Passing a nil client will create a default client with a 30s timeout.
-func NewTelemetryProviderWithClient(thanosURL, lokiURL, tempoURL string, client *http.Client) *TelemetryProvider {
-	telemetry.Info("creating new telemetry provider", "thanos_url", thanosURL, "loki_url", lokiURL, "tempo_url", tempoURL)
+func NewTelemetryProviderWithClient(prometheusURL, lokiURL, tempoURL string, client *http.Client) *TelemetryProvider {
+	telemetry.Info("creating new telemetry provider", "prometheus_url", prometheusURL, "loki_url", lokiURL, "tempo_url", tempoURL)
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &TelemetryProvider{
-		thanosURL:  thanosURL,
-		lokiURL:    lokiURL,
-		tempoURL:   tempoURL,
-		httpClient: client,
+		prometheusURL: prometheusURL,
+		lokiURL:       lokiURL,
+		tempoURL:      tempoURL,
+		httpClient:    client,
 	}
 }
 
-// QueryMetrics executes a PromQL query against Thanos.
+// QueryMetrics executes a PromQL query against Prometheus.
 // Returns raw Prometheus API response (query result).
 //
 // Limits:
 //   - Uses instant query endpoint (/api/v1/query) — returns current value only, no time range.
 //   - Time windows are expressed inline in PromQL (e.g. rate(...[24h])), not as a parameter.
-//   - Query length: max 5,000 chars (our safety cap, not a Thanos limit).
-//   - No result count cap — Thanos returns all matching series.
+//   - Query length: max 5,000 chars (our safety cap, not a Prometheus limit).
+//   - No result count cap — Prometheus returns all matching series.
 func (tp *TelemetryProvider) QueryMetrics(ctx context.Context, query string) (interface{}, error) {
 	if query == "" {
 		telemetry.Error("query metrics called with empty query")
@@ -61,7 +61,7 @@ func (tp *TelemetryProvider) QueryMetrics(ctx context.Context, query string) (in
 	}
 
 	// Build URL with query parameters
-	endpoint := fmt.Sprintf("%s/api/v1/query", tp.thanosURL)
+	endpoint := fmt.Sprintf("%s/api/v1/query", tp.prometheusURL)
 	params := url.Values{}
 	params.Add("query", query)
 
@@ -74,14 +74,14 @@ func (tp *TelemetryProvider) QueryMetrics(ctx context.Context, query string) (in
 	telemetry.Info("executing PromQL query", "query", query[:min(len(query), 100)])
 	resp, err := tp.httpClient.Do(req)
 	if err != nil {
-		telemetry.Error("failed to query Thanos", "error", err)
-		return nil, fmt.Errorf("failed to query Thanos: %w", err)
+		telemetry.Error("failed to query Prometheus", "error", err)
+		return nil, fmt.Errorf("failed to query Prometheus: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		telemetry.Error("Thanos returned non-OK status", "status", resp.StatusCode)
-		return nil, fmt.Errorf("Thanos returned status %d", resp.StatusCode)
+		telemetry.Error("Prometheus returned non-OK status", "status", resp.StatusCode)
+		return nil, fmt.Errorf("Prometheus returned status %d", resp.StatusCode)
 	}
 
 	// Return raw body for now; in production, parse JSON and structure response

--- a/internal/mcp/providers/telemetry_test.go
+++ b/internal/mcp/providers/telemetry_test.go
@@ -40,30 +40,30 @@ func newInMemoryHTTPClient(h http.Handler) *http.Client {
 
 func TestTelemetryProvider_NewAndInitialization(t *testing.T) {
 	tests := []struct {
-		name      string
-		thanosURL string
-		lokiURL   string
-		tempoURL  string
+		name          string
+		prometheusURL string
+		lokiURL       string
+		tempoURL      string
 	}{
 		{
-			name:      "valid localhost URLs",
-			thanosURL: "http://localhost:30090",
-			lokiURL:   "http://localhost:30100",
-			tempoURL:  "http://localhost:30200",
+			name:          "valid localhost URLs",
+			prometheusURL: "http://localhost:30091",
+			lokiURL:       "http://localhost:30100",
+			tempoURL:      "http://localhost:30200",
 		},
 		{
-			name:      "valid https URLs",
-			thanosURL: "https://thanos.example.com",
-			lokiURL:   "https://loki.example.com",
-			tempoURL:  "https://tempo.example.com",
+			name:          "valid https URLs",
+			prometheusURL: "https://prometheus.example.com",
+			lokiURL:       "https://loki.example.com",
+			tempoURL:      "https://tempo.example.com",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := NewTelemetryProvider(tt.thanosURL, tt.lokiURL, tt.tempoURL)
-			if provider.thanosURL != tt.thanosURL {
-				t.Errorf("expected thanosURL %q, got %q", tt.thanosURL, provider.thanosURL)
+			provider := NewTelemetryProvider(tt.prometheusURL, tt.lokiURL, tt.tempoURL)
+			if provider.prometheusURL != tt.prometheusURL {
+				t.Errorf("expected prometheusURL %q, got %q", tt.prometheusURL, provider.prometheusURL)
 			}
 			if provider.lokiURL != tt.lokiURL {
 				t.Errorf("expected lokiURL %q, got %q", tt.lokiURL, provider.lokiURL)
@@ -134,7 +134,7 @@ func TestTelemetryProvider_QueryMetrics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.HandlerFunc(tt.setupServer)
 
-			provider := NewTelemetryProvider("http://thanos", "http://loki", "http://tempo")
+			provider := NewTelemetryProvider("http://prometheus", "http://loki", "http://tempo")
 			provider.httpClient = newInMemoryHTTPClient(h)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
@@ -177,7 +177,7 @@ func TestTelemetryProvider_RequestTimeout(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			provider := NewTelemetryProvider("http://thanos", "http://loki", "http://tempo")
+			provider := NewTelemetryProvider("http://prometheus", "http://loki", "http://tempo")
 			provider.httpClient = newInMemoryHTTPClient(h)
 			provider.httpClient.Timeout = tt.timeout
 			ctx := context.Background()
@@ -294,7 +294,7 @@ func TestTelemetryProvider_QueryLogs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.HandlerFunc(tt.setupServer)
 
-			provider := NewTelemetryProvider("http://thanos", "http://loki", "http://tempo")
+			provider := NewTelemetryProvider("http://prometheus", "http://loki", "http://tempo")
 			provider.httpClient = newInMemoryHTTPClient(h)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
@@ -383,7 +383,7 @@ func TestTelemetryProvider_QueryTraces(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := http.HandlerFunc(tt.setupServer)
 
-			provider := NewTelemetryProvider("http://thanos", "http://loki", "http://tempo")
+			provider := NewTelemetryProvider("http://prometheus", "http://loki", "http://tempo")
 			provider.httpClient = newInMemoryHTTPClient(h)
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -15,11 +15,11 @@ import (
 
 // --- Telemetry Tools ---
 
-// RegisterTelemetryTools registers all telemetry-related tools (Thanos, Loki, Tempo) to the MCP server.
+// RegisterTelemetryTools registers all telemetry-related tools (Prometheus, Loki, Tempo) to the MCP server.
 func RegisterTelemetryTools(server *mcp.Server, provider *providers.TelemetryProvider, serviceName string) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "query_metrics",
-		Description: "Execute PromQL queries against Thanos/Prometheus for metrics analysis (See skills/telemetry/SKILL.md for guidance)",
+		Description: "Execute PromQL queries against Prometheus for metrics analysis (See skills/telemetry/SKILL.md for guidance)",
 	}, handleQueryMetrics(provider, serviceName))
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -77,7 +77,7 @@ func TestRegistryHandlers_Telemetry(t *testing.T) {
 		}
 	})
 
-	tp := providers.NewTelemetryProviderWithClient("http://thanos", "http://loki", "http://tempo", newInMemoryHTTPClient(h))
+	tp := providers.NewTelemetryProviderWithClient("http://prometheus", "http://loki", "http://tempo", newInMemoryHTTPClient(h))
 	ctx := context.Background()
 
 	tests := []struct {
@@ -147,7 +147,7 @@ func TestRegistryHandlers_Telemetry(t *testing.T) {
 
 func TestRegisterTools_DoesNotPanic(t *testing.T) {
 	srv := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
-	RegisterTelemetryTools(srv, providers.NewTelemetryProvider("http://thanos", "http://loki", "http://tempo"), "svc")
+	RegisterTelemetryTools(srv, providers.NewTelemetryProvider("http://prometheus", "http://loki", "http://tempo"), "svc")
 	RegisterPodsTools(srv, (*providers.PodsProvider)(nil), "svc")
 	RegisterNetworkTools(srv, (*providers.NetworkProvider)(nil), "svc")
 }

--- a/k3s/base/infra/prometheus/values.yaml
+++ b/k3s/base/infra/prometheus/values.yaml
@@ -39,6 +39,9 @@ server:
   retention: null # Disable default chart retention to avoid argument duplication
   persistentVolume:
     enabled: true
+  service:
+    type: NodePort
+    nodePort: 30091
 
   extraServices:
     - name: prometheus-thanos-grpc


### PR DESCRIPTION
### Summary
Move MCP metrics queries from the Thanos Query endpoint to Prometheus directly. This keeps the MCP telemetry tools working while reducing the future dependency path that blocks Thanos removal.

### List of Changes
- Updated the MCP telemetry provider to prefer `PROMETHEUS_URL` while keeping `THANOS_URL` as a temporary fallback during rollout.
- Exposed Prometheus on a dedicated NodePort for host-side MCP access and updated MCP docs/tests to describe Prometheus as the metrics backend.

### Verification
- [x] Parsed Prometheus, Loki, and Tempo values files as valid YAML
- [x] `go test ./cmd/mcp-obs-hub ./internal/mcp/...`
- [x] Queried metrics through the obs MCP server with `up`

