### PR TITLE
refactor(observability): use prometheus metrics endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
 # --- Standardized NodePort URIs (Host-to-Cluster Bridge) ---
-# Used by cmd/mcp-obs-hub, cmd/worker, cmd/idp, and cmd/proxy
 PROMETHEUS_URL=
-THANOS_URL=
 LOKI_URL=
 TEMPO_URL=
 DATABASE_URL=

--- a/cmd/mcp-obs-hub/main.go
+++ b/cmd/mcp-obs-hub/main.go
@@ -73,9 +73,6 @@ func main() {
 
 	// --- Telemetry Provider ---
 	prometheusURL := os.Getenv("PROMETHEUS_URL")
-	if prometheusURL == "" {
-		prometheusURL = os.Getenv("THANOS_URL")
-	}
 	lokiURL := os.Getenv("LOKI_URL")
 	tempoURL := os.Getenv("TEMPO_URL")
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -82,12 +82,12 @@ func main() {
 
 func runAnalytics(ctx context.Context, deps *worker.Dependencies) error {
 	// 1. Setup Analytics specific clients
-	thanosClient := analytics.NewThanosClient(deps.GetThanosURL())
-	thanosProvider := analytics.NewThanosResourceProvider(thanosClient)
+	prometheusClient := analytics.NewPrometheusClient(deps.GetPrometheusURL())
+	prometheusProvider := analytics.NewPrometheusResourceProvider(prometheusClient)
 
 	service := &analytics.Service{
 		Store:     deps.Store,
-		Resources: thanosProvider,
+		Resources: prometheusProvider,
 	}
 
 	// 2. Execute one-shot batch

--- a/docs/notes/mcp-gateway-deployment.md
+++ b/docs/notes/mcp-gateway-deployment.md
@@ -57,8 +57,6 @@ AI Agent (Gemini CLI / Copilot / obs)
 | `TEMPO_URL` | `http://localhost:30200` | Traces via Tempo |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:30317` | Service observability destination |
 
-`THANOS_URL` is still accepted as a temporary fallback for metrics during rollout, but new MCP configurations should use `PROMETHEUS_URL`.
-
 ---
 
 ## Troubleshooting

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -189,8 +189,12 @@ func NewKubernetesServiceWithClientset(clientset kubernetes.Interface) *Kubernet
 		clientset: clientset,
 		now:       time.Now,
 		podLogs:   defaultPodLogs(clientset),
-		signals:   newSignalClient(os.Getenv("THANOS_URL"), os.Getenv("TEMPO_URL"), nil),
+		signals:   newSignalClient(prometheusURLFromEnv(), os.Getenv("TEMPO_URL"), nil),
 	}
+}
+
+func prometheusURLFromEnv() string {
+	return os.Getenv("PROMETHEUS_URL")
 }
 
 func (s *KubernetesService) List(ctx context.Context, opts ListOptions) ([]Summary, error) {
@@ -374,8 +378,8 @@ func (s *KubernetesService) Events(ctx context.Context, opts EventsOptions) ([]E
 }
 
 func (s *KubernetesService) Metrics(ctx context.Context, opts MetricsOptions) ([]Metric, error) {
-	if s.signals == nil || s.signals.thanosURL == "" {
-		return nil, fmt.Errorf("THANOS_URL is required for service metrics")
+	if s.signals == nil || s.signals.prometheusURL == "" {
+		return nil, fmt.Errorf("PROMETHEUS_URL is required for service metrics")
 	}
 	if opts.Window <= 0 {
 		opts.Window = 5 * time.Minute
@@ -1097,10 +1101,10 @@ func healthStatus(health Health) string {
 }
 
 type signalClient struct {
-	thanosURL  string
-	tempoURL   string
-	httpClient *http.Client
-	now        func() time.Time
+	prometheusURL string
+	tempoURL      string
+	httpClient    *http.Client
+	now           func() time.Time
 }
 
 type promQueryResponse struct {
@@ -1123,15 +1127,15 @@ type tempoTrace struct {
 	DurationMs        int64  `json:"durationMs"`
 }
 
-func newSignalClient(thanosURL string, tempoURL string, httpClient *http.Client) *signalClient {
+func newSignalClient(prometheusURL string, tempoURL string, httpClient *http.Client) *signalClient {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &signalClient{
-		thanosURL:  strings.TrimRight(thanosURL, "/"),
-		tempoURL:   strings.TrimRight(tempoURL, "/"),
-		httpClient: httpClient,
-		now:        time.Now,
+		prometheusURL: strings.TrimRight(prometheusURL, "/"),
+		tempoURL:      strings.TrimRight(tempoURL, "/"),
+		httpClient:    httpClient,
+		now:           time.Now,
 	}
 }
 
@@ -1139,7 +1143,7 @@ func (c *signalClient) queryMetric(ctx context.Context, query string) (string, e
 	params := url.Values{}
 	params.Set("query", query)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.thanosURL+"/api/v1/query?"+params.Encode(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.prometheusURL+"/api/v1/query?"+params.Encode(), nil)
 	if err != nil {
 		return "", fmt.Errorf("create metrics request: %w", err)
 	}

--- a/internal/idp/service/service_test.go
+++ b/internal/idp/service/service_test.go
@@ -461,14 +461,14 @@ func TestKubernetesServiceMetrics(t *testing.T) {
 	replicas := int32(2)
 
 	tests := []struct {
-		name        string
-		objects     []runtime.Object
-		opts        MetricsOptions
-		handler     http.Handler
-		thanosURL   string
-		want        []Metric
-		wantErr     string
-		wantQueries int
+		name          string
+		objects       []runtime.Object
+		opts          MetricsOptions
+		handler       http.Handler
+		prometheusURL string
+		want          []Metric
+		wantErr       string
+		wantQueries   int
 	}{
 		{
 			name: "queries service metrics for resolved pods",
@@ -477,8 +477,8 @@ func TestKubernetesServiceMetrics(t *testing.T) {
 				pod("grafana-0", "observability", true, 0),
 				pod("grafana-1", "observability", true, 0),
 			},
-			opts:      MetricsOptions{Name: "grafana", Namespace: "observability", Window: 10 * time.Minute},
-			thanosURL: "http://thanos",
+			opts:          MetricsOptions{Name: "grafana", Namespace: "observability", Window: 10 * time.Minute},
+			prometheusURL: "http://prometheus",
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/api/v1/query" {
 					w.WriteHeader(http.StatusNotFound)
@@ -505,9 +505,9 @@ func TestKubernetesServiceMetrics(t *testing.T) {
 			wantQueries: 3,
 		},
 		{
-			name:    "requires thanos url",
+			name:    "requires prometheus url",
 			opts:    MetricsOptions{Name: "grafana"},
-			wantErr: "THANOS_URL is required for service metrics",
+			wantErr: "PROMETHEUS_URL is required for service metrics",
 		},
 	}
 
@@ -518,7 +518,7 @@ func TestKubernetesServiceMetrics(t *testing.T) {
 			if tt.handler != nil {
 				client = newInMemoryHTTPClient(tt.handler)
 			}
-			service.signals = newSignalClient(tt.thanosURL, "http://tempo", client)
+			service.signals = newSignalClient(tt.prometheusURL, "http://tempo", client)
 
 			metrics, err := service.Metrics(context.Background(), tt.opts)
 			if tt.wantErr != "" {
@@ -587,7 +587,7 @@ func TestKubernetesServiceTraces(t *testing.T) {
 			if tt.handler != nil {
 				client = newInMemoryHTTPClient(tt.handler)
 			}
-			service.signals = newSignalClient("http://thanos", tt.tempoURL, client)
+			service.signals = newSignalClient("http://prometheus", tt.tempoURL, client)
 			service.signals.now = func() time.Time {
 				return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 			}

--- a/internal/worker/analytics/analytics.go
+++ b/internal/worker/analytics/analytics.go
@@ -22,22 +22,22 @@ type Sample struct {
 	Payload   map[string]interface{} `json:"payload"`
 }
 
-// ThanosClient handles communication with the Thanos Query API for batch metric retrieval.
-type ThanosClient struct {
+// PrometheusClient handles communication with the Prometheus API for batch metric retrieval.
+type PrometheusClient struct {
 	BaseURL    string
 	HTTPClient *http.Client
 }
 
-// NewThanosClient creates a new client for querying Thanos.
-func NewThanosClient(baseURL string) *ThanosClient {
-	return &ThanosClient{
+// NewPrometheusClient creates a new client for querying Prometheus.
+func NewPrometheusClient(baseURL string) *PrometheusClient {
+	return &PrometheusClient{
 		BaseURL:    baseURL,
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
 // QueryRange fetches a range of metrics for a given PromQL query.
-func (c *ThanosClient) QueryRange(ctx context.Context, query string, start, end time.Time, step string) ([]Sample, error) {
+func (c *PrometheusClient) QueryRange(ctx context.Context, query string, start, end time.Time, step string) ([]Sample, error) {
 	params := url.Values{}
 	params.Add("query", query)
 	params.Add("start", fmt.Sprintf("%d", start.Unix()))
@@ -57,7 +57,7 @@ func (c *ThanosClient) QueryRange(ctx context.Context, query string, start, end 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("thanos api returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("prometheus api returned status %d", resp.StatusCode)
 	}
 
 	var apiResp struct {
@@ -76,7 +76,7 @@ func (c *ThanosClient) QueryRange(ctx context.Context, query string, start, end 
 	}
 
 	if apiResp.Status != "success" {
-		return nil, fmt.Errorf("thanos api reported failure status: %s", apiResp.Status)
+		return nil, fmt.Errorf("prometheus api reported failure status: %s", apiResp.Status)
 	}
 
 	var samples []Sample
@@ -104,12 +104,12 @@ func (c *ThanosClient) QueryRange(ctx context.Context, query string, start, end 
 	return samples, nil
 }
 
-// ThanosResourceProvider implements ResourceProvider using Thanos.
-type ThanosResourceProvider struct {
-	Client *ThanosClient
+// PrometheusResourceProvider implements ResourceProvider using Prometheus.
+type PrometheusResourceProvider struct {
+	Client *PrometheusClient
 }
 
-func NewThanosResourceProvider(client *ThanosClient) *ThanosResourceProvider {
+func NewPrometheusResourceProvider(client *PrometheusClient) *PrometheusResourceProvider {
 	// Log initial factors on startup
 	carbon := os.Getenv("CARBON_INTENSITY_G_KWH")
 	if carbon == "" {
@@ -121,10 +121,10 @@ func NewThanosResourceProvider(client *ThanosClient) *ThanosResourceProvider {
 	}
 	telemetry.Info("analytics_factors_loaded", "carbon_intensity", carbon, "energy_cost", cost)
 
-	return &ThanosResourceProvider{Client: client}
+	return &PrometheusResourceProvider{Client: client}
 }
 
-func (p *ThanosResourceProvider) GetEnergyJoules(ctx context.Context, start, end time.Time) (float64, error) {
+func (p *PrometheusResourceProvider) GetEnergyJoules(ctx context.Context, start, end time.Time) (float64, error) {
 	// Query for node energy increase over the period
 	query := fmt.Sprintf("sum(increase(kepler_node_cpu_joules_total[%s]))", "15m")
 	samples, err := p.Client.QueryRange(ctx, query, start, end, "1m")
@@ -143,7 +143,7 @@ func (p *ThanosResourceProvider) GetEnergyJoules(ctx context.Context, start, end
 	return val, nil
 }
 
-func (p *ThanosResourceProvider) GetContainerEnergy(ctx context.Context, start, end time.Time) (map[string]float64, error) {
+func (p *PrometheusResourceProvider) GetContainerEnergy(ctx context.Context, start, end time.Time) (map[string]float64, error) {
 	// Query energy increase per container
 	query := fmt.Sprintf("sum(increase(kepler_container_cpu_joules_total[%s])) by (container_name)", "15m")
 	samples, err := p.Client.QueryRange(ctx, query, start, end, "1m")
@@ -168,7 +168,7 @@ func (p *ThanosResourceProvider) GetContainerEnergy(ctx context.Context, start, 
 	return features, nil
 }
 
-func (p *ThanosResourceProvider) GetHostServiceCPU(ctx context.Context, start, end time.Time) (map[string]float64, error) {
+func (p *PrometheusResourceProvider) GetHostServiceCPU(ctx context.Context, start, end time.Time) (map[string]float64, error) {
 	// Query CPU usage for target systemd services
 	// Pattern: node_systemd_unit_cpu_usage_seconds_total{name=~"proxy.service|ingestion.service|mcp-.*"}
 	query := fmt.Sprintf("sum(rate(node_systemd_unit_cpu_usage_seconds_total{name=~\"proxy.service|ingestion.service|mcp-.*\"}[%s])) by (name)", "15m")
@@ -190,7 +190,7 @@ func (p *ThanosResourceProvider) GetHostServiceCPU(ctx context.Context, start, e
 	return serviceCPU, nil
 }
 
-func (p *ThanosResourceProvider) GetValueUnits(ctx context.Context, start, end time.Time) (map[string]float64, error) {
+func (p *PrometheusResourceProvider) GetValueUnits(ctx context.Context, start, end time.Time) (map[string]float64, error) {
 	// 1. Define queries for all business value counters
 	// In the future, this could be loaded from a config file.
 	queries := map[string]string{
@@ -213,7 +213,7 @@ func (p *ThanosResourceProvider) GetValueUnits(ctx context.Context, start, end t
 	return units, nil
 }
 
-func (p *ThanosResourceProvider) GetCarbonIntensity(ctx context.Context) (float64, error) {
+func (p *PrometheusResourceProvider) GetCarbonIntensity(ctx context.Context) (float64, error) {
 	// Use environment variable if present, otherwise default to 150.0
 	valStr := os.Getenv("CARBON_INTENSITY_G_KWH")
 	if valStr == "" {
@@ -226,7 +226,7 @@ func (p *ThanosResourceProvider) GetCarbonIntensity(ctx context.Context) (float6
 	return val, nil
 }
 
-func (p *ThanosResourceProvider) GetCostFactor(ctx context.Context) (float64, error) {
+func (p *PrometheusResourceProvider) GetCostFactor(ctx context.Context) (float64, error) {
 	// Use environment variable if present, otherwise default to 0.15 CAD/kWh
 	valStr := os.Getenv("ENERGY_COST_CAD_KWH")
 	pricePerKWh := 0.15

--- a/internal/worker/analytics/analytics_test.go
+++ b/internal/worker/analytics/analytics_test.go
@@ -26,7 +26,7 @@ func newInMemoryHTTPClient(h http.Handler) *http.Client {
 	}
 }
 
-func TestThanosClient_QueryRange(t *testing.T) {
+func TestPrometheusClient_QueryRange(t *testing.T) {
 	tests := []struct {
 		name         string
 		responseJSON string
@@ -55,7 +55,7 @@ func TestThanosClient_QueryRange(t *testing.T) {
 				w.WriteHeader(tt.status)
 				fmt.Fprint(w, tt.responseJSON)
 			})
-			client := NewThanosClient("http://thanos")
+			client := NewPrometheusClient("http://prometheus")
 			client.HTTPClient = newInMemoryHTTPClient(h)
 			samples, err := client.QueryRange(context.Background(), "test", time.Now(), time.Now(), "1m")
 			if (err != nil) != tt.wantErr {
@@ -68,16 +68,16 @@ func TestThanosClient_QueryRange(t *testing.T) {
 	}
 }
 
-func TestThanosResourceProvider(t *testing.T) {
+func TestPrometheusResourceProvider(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("GetEnergyJoules", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{},"values":[[1708531200,"100.5"]]}]}}`)
 		})
-		client := NewThanosClient("http://thanos")
+		client := NewPrometheusClient("http://prometheus")
 		client.HTTPClient = newInMemoryHTTPClient(h)
-		provider := NewThanosResourceProvider(client)
+		provider := NewPrometheusResourceProvider(client)
 
 		val, err := provider.GetEnergyJoules(ctx, time.Now(), time.Now())
 		if err != nil || val != 100.5 {
@@ -89,9 +89,9 @@ func TestThanosResourceProvider(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"container_name":"c1"},"values":[[1708531200,"10"]]}]}}`)
 		})
-		client := NewThanosClient("http://thanos")
+		client := NewPrometheusClient("http://prometheus")
 		client.HTTPClient = newInMemoryHTTPClient(h)
-		provider := NewThanosResourceProvider(client)
+		provider := NewPrometheusResourceProvider(client)
 
 		res, _ := provider.GetContainerEnergy(ctx, time.Now(), time.Now())
 		want := map[string]float64{"c1": 10}
@@ -103,7 +103,7 @@ func TestThanosResourceProvider(t *testing.T) {
 	t.Run("Factors", func(t *testing.T) {
 		t.Setenv("CARBON_INTENSITY_G_KWH", "200.0")
 		t.Setenv("ENERGY_COST_CAD_KWH", "0.20")
-		provider := NewThanosResourceProvider(nil)
+		provider := NewPrometheusResourceProvider(nil)
 		carbon, _ := provider.GetCarbonIntensity(ctx)
 		cost, _ := provider.GetCostFactor(ctx)
 

--- a/internal/worker/dependencies.go
+++ b/internal/worker/dependencies.go
@@ -56,7 +56,7 @@ func (d *Dependencies) Close() {
 	}
 }
 
-// GetThanosURL returns the configured Thanos URL from environment.
-func (d *Dependencies) GetThanosURL() string {
-	return os.Getenv("THANOS_URL")
+// GetPrometheusURL returns the configured Prometheus URL from environment.
+func (d *Dependencies) GetPrometheusURL() string {
+	return os.Getenv("PROMETHEUS_URL")
 }

--- a/k3s/base/worker/analytics-cronjob.yaml
+++ b/k3s/base/worker/analytics-cronjob.yaml
@@ -40,8 +40,8 @@ spec:
                 - ALL
             args: ["--mode", "analytics"]
             env:
-            - name: THANOS_URL
-              value: "http://thanos-query.observability.svc.cluster.local:9090"
+            - name: PROMETHEUS_URL
+              value: "http://prometheus-server.observability.svc.cluster.local:80"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "opentelemetry.observability.svc.cluster.local:4317"
             - name: DB_HOST


### PR DESCRIPTION
### Summary
Move the remaining application metrics callers from Thanos-specific configuration to Prometheus. This removes the runtime `THANOS_URL` dependency from MCP, Worker, and IDP code paths while keeping the PromQL behavior unchanged.

### List of Changes
- Renamed Worker analytics and IDP service metrics clients/providers to Prometheus naming and switched their runtime configuration to `PROMETHEUS_URL`.
- Updated the Worker analytics CronJob to query the in-cluster Prometheus service and removed the remaining `THANOS_URL` fallback from app runtime config.

### Verification
- [x] Formatted edited Go files with `gofmt`
- [x] Parsed the Worker analytics CronJob YAML successfully
- [x] Confirmed runtime app config/code no longer references `THANOS_URL`

