### PR TITLE
chore(worker): update image tag

### DIFF
--- a/k3s/base/worker/kustomization.yaml
+++ b/k3s/base/worker/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 
 images:
   - name: ghcr.io/victoriacheng15/observability-hub/worker
-    newTag: sha-ed80fc1
+    newTag: sha-5da1c31


### PR DESCRIPTION
### Summary
Update the Worker image tag so the cluster can run the newly published Worker build. This keeps the deployment step isolated from the Worker/IDP Prometheus code migration and makes the rollout easier to review.

### List of Changes
- Updated the Worker Kubernetes image tag to `sha-5da1c31`.
- Kept the PR limited to the Worker kustomization image override.

### Verification
- [x] Confirmed `k3s/base/worker/kustomization.yaml` points Worker at `sha-5da1c31`

