### PR TITLE
docs(observability): document local retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Observability Hub
 
-Observability Hub is a self-hosted platform engineering lab built with Kubernetes, Argo CD, OpenTofu (Terraform-compatible), OpenTelemetry, Grafana, Loki, Tempo, Prometheus, Cilium/Hubble, OpenBao, and Go services.
+Observability Hub is a self-hosted platform engineering lab built with Kubernetes, GitOps, Terraform, OpenTelemetry, Prometheus, Grafana, Cilium/eBPF, PostgreSQL, and Go services.
 
 It proves an end-to-end platform ownership loop: declarative infrastructure runs host and cluster services, telemetry exposes behavior, operators and agents diagnose issues, bounded remediation applies fixes, and ADRs/RCAs preserve operational memory.
 
@@ -33,9 +33,9 @@ The main system flow starts from declarative source, runs through host and clust
 
 ```mermaid
 flowchart TB
-    Source["Source of Truth<br/>Git, Terraform, Kustomize, systemd"]
+    Source["Source of Truth<br/>Git, Terraform, Kustomize"]
     Runtime["Runtime<br/>Kubernetes, host services, databases"]
-    Signals["Signals<br/>OTel, Prometheus, Loki, Tempo, Hubble"]
+    Signals["Signals<br/>OTel, Prometheus"]
     Decisions["Decisions<br/>Grafana, MCP tools, workflows"]
     Actions["Actions<br/>GitOps sync, pod repair, service restart"]
     Memory["Memory<br/>ADRs, RCAs, notes, workflows"]
@@ -55,13 +55,13 @@ flowchart TB
 
 | Layer | Tools |
 | :--- | :--- |
-| Language | Go |
-| Infrastructure | Kubernetes, Terraform, Helm, Docker, systemd, Argo CD |
-| Data stores | PostgreSQL/CloudNativePG, MinIO, Azure Blob Storage |
-| Observability | OpenTelemetry, Grafana, Loki, Tempo, Prometheus, Cilium/Hubble |
-| Security | OpenBao, Trivy, Tailscale |
+| Language | Go, Rust |
+| Infrastructure | Kubernetes, Terraform, Helm, Docker, Argo CD |
+| Data stores | PostgreSQL, Azure Blob Storage |
+| Observability | OpenTelemetry, Prometheus, Grafana, Cilium |
+| Security | Trivy, Tailscale |
 | Testing | Go `testing` package, table-driven tests |
-| CI/CD | GitHub Actions, Argo CD, GitOps webhook reconciliation |
+| CI/CD | GitHub Actions, Argo CD |
 
 ---
 

--- a/docs/architecture/core-concepts/observability.md
+++ b/docs/architecture/core-concepts/observability.md
@@ -32,7 +32,7 @@ flowchart LR
     Metrics --> Grafana
 ```
 
-The sections below expand this simplified story into the full implementation, including MCP access, eBPF network visibility, storage backends, and long-term retention.
+The sections below expand this simplified story into the full implementation, including MCP access, eBPF network visibility, storage backends, and local retention.
 
 ## 🛠️ The Unified Pipeline
 
@@ -71,12 +71,12 @@ flowchart TB
           Cilium["Cilium / Hubble (eBPF)"]
         end
 
-          LGTM["Loki, Tempo, Prometheus (Thanos)"]
+          LGTM["Loki, Tempo, Prometheus"]
         end
 
         subgraph Storage ["Data Engines"]
             PG[(HA Postgres - CNPG)]
-            S3[(MinIO - S3)]
+            PVC[(Retained Local PVCs)]
             Azure[(Azure Blob Storage)]
         end
     end
@@ -107,9 +107,8 @@ flowchart TB
     OTEL --> LGTM
     
     %% Resilience & Backup
-    LGTM -- "Offload" --> S3
+    LGTM -- "Local Retention" --> PVC
     PG -- "Streaming Backup" --> Azure
-    S3 -- "Replication" --> Azure
 ```
 
 ## 🪵 Logs
@@ -135,7 +134,7 @@ The platform implements a dual-path logging strategy: structured application log
   - **Application Logs**: Services are instrumented with the **OpenTelemetry SDK** to generate logs in OTLP format, sent to the central **OpenTelemetry Collector** via gRPC (NodePort `30317`) or HTTP (NodePort `30318`), which batches and exports them to **Loki**.
   - **System Logs**: Native host services (e.g., `gitops-sync`, `system-metrics`, `tailscale-gate`) are instrumented to emit structured logs directly to the **OpenTelemetry Collector** (running as a DaemonSet) via OTLP, which filters for specific units and pushes them to **Loki**.
 - **Persistence**:
-  - **Loki**: Stores logs with long-term persistence in MinIO S3 buckets (`loki-chunks`, `loki-ruler`, `loki-admin`).
+  - **Loki**: Stores logs on retained local PVC storage with `168h` retention.
 
 ## 📊 Metrics
 
@@ -144,11 +143,10 @@ The platform aggregates infrastructure metrics through Prometheus scraping, appl
 - **Collection Strategy**:
   - **Infrastructure Scrapes**: **Prometheus** actively pulls metrics from the Kubernetes API, nodes (cAdvisor), pods, service endpoints, and internal exporters (`kube-state-metrics`, `node-exporter`).
   - **Telemetry Ingestion**: The **OpenTelemetry Collector** exports OTLP metrics (including derived span-metrics from Tempo) to **Prometheus**, which is configured with the `remote-write-receiver` enabled to ingest these metrics.
-  - **Host Resource Metrics**: Host-level metrics (e.g., CPU, RAM, disk, network) are first collected by **Prometheus**. The **Unified Worker (Analytics Mode)** then retrieves this data from **Prometheus** via **Thanos**, forwards it via the **OpenTelemetry Collector**, and exports it to **PostgreSQL** for long-term resource, capacity, and cost-aware analytical reporting.
+  - **Host Resource Metrics**: Host-level metrics (e.g., CPU, RAM, disk, network) are first collected by **Prometheus**. The **Unified Worker (Analytics Mode)** then retrieves this data directly from **Prometheus**, forwards it via the **OpenTelemetry Collector**, and exports it to **PostgreSQL** for long-term resource, capacity, and cost-aware analytical reporting.
   - **Network Metrics (eBPF)**: Cilium and Hubble export eBPF-level network metrics (e.g., packet drops, connection latency, and L7 protocol stats) directly to Prometheus via dedicated exporters.
 - **Persistence**:
-  - **Local Storage**: Prometheus maintains a high-resolution 24-hour local TSDB on `local-path` persistent volumes.
-  - **Long-term Retention**: The **Thanos** sidecar seamlessly offloads TSDB blocks to MinIO S3 (`prometheus-blocks`) for infinite metrics retention and historical analysis.
+  - **Local Storage**: Prometheus maintains a high-resolution `72h` local TSDB on `local-path-retain` persistent volumes.
 
 ## 🔭 Traces
 
@@ -159,7 +157,7 @@ Distributed tracing is powered by OpenTelemetry for correlation and performance 
   - **Ingestion**: Spans are sent to the **OpenTelemetry Collector** via gRPC (NodePort `30317`) or HTTP (NodePort `30318`), which batches and exports them to **Grafana Tempo**.
   - **Processing**: Tempo analyzes raw spans to generate derived **Service Graphs** and **Span Metrics**, which are pushed to Prometheus via `remote_write` for operational correlation.
 - **Persistence**:
-  - **Tempo**: Stores traces with long-term persistence in MinIO S3 buckets (`tempo-traces`).
+  - **Tempo**: Stores traces on retained local PVC storage with `48h` retention.
 
 ## 📡 Network Observability (eBPF)
 
@@ -173,7 +171,7 @@ The platform leverages **Cilium** and **Hubble** for deep, kernel-level network 
 ## 🗄️ Shared Data Stores
 
 - **PostgreSQL (CloudNativePG)**: Stores analytical metrics and specialized time-series data (TimescaleDB). Orchestrated by CNPG for high availability, with automated failover and streaming backups to Azure Blob Storage.
-- **MinIO S3**: Provides unified object storage for Loki logs, Tempo traces, and Prometheus/Thanos metrics blocks.
-- **Azure Blob Storage**: Serves as the durable off-site backup for PostgreSQL transactional data (WALs/Basebackups) and the global repository for Terraform state.
+- **Retained Local PVCs**: Store Prometheus metrics, Loki logs, and Tempo traces for short local retention windows without object storage.
+- **Azure Blob Storage**: Serves as the durable off-site backup for PostgreSQL transactional data (WALs/Basebackups) and the global repository for OpenTofu state.
 
-Access is secured via internal Kubernetes networking (`minio.observability.svc.cluster.local:9000`) and managed via specialized secrets (`minio-thanos-secret`, `azure-creds`, etc.).
+Access is secured via internal Kubernetes networking and managed through specialized secrets such as `azure-creds` for PostgreSQL backup.

--- a/docs/architecture/infrastructure/deployment.md
+++ b/docs/architecture/infrastructure/deployment.md
@@ -17,14 +17,12 @@ Managed via **OpenTofu (IaC)** and **ArgoCD (GitOps)**.
 | **ArgoCD** | GitOps Orchestrator | Controller for declarative cluster state management and automated self-healing. |
 | **Unified Worker** | Batch Task Engine | CronJobs for collecting host and Kubernetes telemetry for resource analysis, plus synchronizing data sources. |
 | **Cilium & Hubble** | eBPF Networking | CNI with eBPF-native datapath for L7 visibility (MQTT) and network-level observability. |
-| **Grafana** | Visualization | Deployment for unified dashboarding UI. |
-| **Loki** | Log Aggregation | StatefulSet for indexing metadata-tagged logs. |
-| **MinIO** | Object Storage | Deployment for S3-compatible storage, serving as backup for Prometheus, Loki, and Tempo. |
 | **OpenTelemetry Collector** | Telemetry Hub | Deployment for receiving and processing traces, metrics, and logs. |
+| **Prometheus** | Metrics Storage | Deployment for time-series infrastructure and service metrics with local PVC retention. |
+| **Grafana** | Visualization | Deployment for unified dashboarding UI. |
+| **Loki** | Log Aggregation | StatefulSet for indexing metadata-tagged logs with local PVC retention. |
+| **Tempo** | Trace Storage | StatefulSet for distributed tracing with local PVC retention. |
 | **HA PostgreSQL (CNPG)** | Primary Storage | StatefulSet orchestrated by CloudNativePG for High-Availability. Automated failover and streaming backups to Azure Blob Storage. |
-| **Prometheus** | Metrics Storage | Deployment for time-series infrastructure and service metrics. |
-| **Tempo** | Trace Storage | StatefulSet for high-scale distributed tracing persistence via MinIO. |
-| **Thanos** | Long-term Metrics | StatefulSet for querying historical metrics stored in MinIO. |
 
 ### 🚀 Core Services (Native Go)
 

--- a/docs/architecture/ownership.md
+++ b/docs/architecture/ownership.md
@@ -1,52 +1,60 @@
 # Platform Ownership Model
 
-Observability Hub is organized as a closed-loop platform ownership system.
-
-The operating model is:
+Observability Hub is organized around a closed-loop ownership model:
 
 ```text
 Source of Truth -> Runtime -> Signals -> Decisions -> Actions -> Memory
 ```
 
-This page explains how the project connects infrastructure definition, deployment, observability, diagnosis, remediation, resource analysis, and institutional memory into one system.
+The purpose of this page is routing. It should help an operator decide where a responsibility lives, how to diagnose it, and where a durable change should be made.
 
 ## Ownership Loop
 
 | Stage | Purpose | Project Surface |
 | :--- | :--- | :--- |
-| Source of Truth | Defines the intended platform state | `tofu/`, `k3s/`, `systemd/`, `.github/workflows/`, `Makefile` |
-| Runtime | Runs the platform services | K3s workloads, host systemd services, databases, storage |
-| Signals | Captures runtime behavior | OpenTelemetry, Prometheus, Loki, Tempo, Hubble, Grafana dashboards |
-| Decisions | Turns signals into operator judgment | MCP tools, dashboards, runbooks, incident docs |
-| Actions | Applies controlled remediation | GitOps sync, service restart, pod inspection, pod deletion, config patches |
-| Memory | Preserves why and how the system changed | ADRs, RCAs, notes, workflows |
+| Source of Truth | Defines intended state | `tofu/`, `k3s/`, `systemd/`, `.github/workflows/`, `Makefile` |
+| Runtime | Runs the platform | K3s workloads, host services, databases, retained storage |
+| Signals | Captures behavior | OpenTelemetry, Prometheus, Loki, Tempo, Hubble, Grafana |
+| Decisions | Turns signals into judgment | MCP tools, dashboards, runbooks, incidents |
+| Actions | Applies controlled remediation | GitOps sync, Tofu apply, service restart, pod operation, config change |
+| Memory | Preserves why the system changed | ADRs, RCAs, notes, workflows |
 
-## Ownership Domains
+## Control Plane
 
-| Domain | Source of Truth | Runtime | Signals | Diagnostic Path | Remediation Path | Memory |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| Host Tier | `systemd/`, `scripts/`, `makefiles/systemd.mk` | `proxy`, OpenBao, host automation | systemd logs, host metrics | journal logs, systemd runbooks | service restart, unit update, script fix | `docs/notes/`, `docs/incidents/` |
-| Cluster Tier | `k3s/`, `tofu/` | K3s workloads and namespaces | pod status, events, kube metrics | pod MCP tools, kube events | GitOps sync, rollout, pod deletion | `docs/workflows.md`, incident reports |
-| Delivery | `.github/workflows/`, image tags, ArgoCD manifests | GitHub Actions, GHCR, ArgoCD | workflow status, image tags, sync state | workflow logs, proxy logs, ArgoCD state | PR fix, image retag, reconciliation | `docs/workflows.md` |
-| Observability | `k3s/base/infra/`, telemetry config | OpenTelemetry, Loki, Tempo, Prometheus, Grafana | logs, metrics, traces, dashboards | telemetry MCP tools, Grafana queries | config patch, collector restart, datasource fix | observability docs, RCAs |
-| Resource Efficiency | `k3s/`, `tofu/`, worker schedules | K3s workloads, host resources, storage systems | CPU, memory, disk, network, energy, workload metrics | Prometheus/Thanos queries, Grafana dashboards, worker analytics | resource limit patch, workload tuning, capacity plan | notes, RCAs, architecture docs |
-| Data | `tofu/`, database manifests, backup config | Postgres, MinIO, object storage backups | DB health, PVC state, backup status | DB logs, dashboard panels, pod tools | failover, restore, storage fix | `docs/notes/postgres.md`, incidents |
-| Networking | Cilium policies, network docs | Cilium, Hubble, service networking | flows, drops, DNS behavior | network MCP tools, flow baseline | policy patch, DNS/service correction | `docs/notes/network-flow-baseline.md` |
-| Security | `config/openbao/`, secrets manifests | OpenBao, Kubernetes secrets, service accounts | auth failures, service logs, policy errors | host logs, pod logs, security docs | rotate secret, patch policy, tighten RBAC | security docs, ADRs |
-| Agentic Ops | `cmd/mcp-obs-hub`, `internal/mcp/`, `skills/` | MCP tools over telemetry, pods, and network | tool metrics, traces, logs | MCP tool calls and provider logs | bounded tool action, provider fix | MCP architecture docs, ADRs |
-| Documentation | `docs/`, `AGENTS.md` | Versioned project memory | ADRs, RCAs, notes, workflow docs | doc index, linked incidents | update doc, add ADR/RCA | docs tree |
+The control plane owns how changes enter and reconcile through the system.
 
-## Component Standard
+| Area | Owns | Diagnose With | Change Through |
+| :--- | :--- | :--- | :--- |
+| GitOps | ArgoCD apps, sync state, cluster manifest reconciliation | ArgoCD UI, app status, proxy logs | `k3s/`, GitHub PRs |
+| Infrastructure | Tofu-managed Helm releases, namespaces, storage classes, cloud-backed state | `tofu plan`, pod status, service status | `tofu/` |
+| Delivery | GitHub Actions, GHCR images, image tags, deployment references | workflow logs, image tags, ArgoCD sync | `.github/`, `docker/`, `k3s/base/*/kustomization.yaml` |
+| Host Services | Proxy, OpenBao, host automation, local service units | journal logs, service status, host metrics | `systemd/`, `scripts/`, `makefiles/` |
 
-Every platform component should be explainable with the same ownership questions:
+## Data Plane
 
-- What is the component responsible for?
-- Where is its desired state defined?
-- How is it deployed or reconciled?
-- What logs, metrics, traces, or flows prove it is healthy?
-- What resource signals show capacity pressure, waste, or cost risk?
-- Which tool or runbook diagnoses it?
-- What is the safe remediation path?
-- Where are decisions and incidents recorded?
+The data plane owns runtime state, telemetry, and the durable stores the platform depends on.
 
-This standard keeps the project from reading as a collection of tools. Each component has a place in the operating loop.
+| Area | Owns | Diagnose With | Change Through |
+| :--- | :--- | :--- | :--- |
+| Database | CNPG Postgres, database services, Azure-backed backups | pod tools, DB logs, backup status | CNPG manifests, `tofu/` |
+| Telemetry | OpenTelemetry, Prometheus, Loki, Tempo, retained local PVCs | MCP telemetry tools, Grafana, pod logs | `k3s/base/infra/`, `tofu/` |
+| Visualization | Grafana dashboards, datasources, operational views | Grafana UI, datasource checks, pod logs | Grafana values, dashboard files |
+| Resource Analytics | Worker analytics, host and cluster resource metrics, capacity history | Prometheus queries, worker logs, analytics tables | `internal/worker/`, `k3s/base/worker/` |
+
+## Operations Plane
+
+The operations plane owns diagnosis, response, safety boundaries, and institutional memory.
+
+| Area | Owns | Diagnose With | Change Through |
+| :--- | :--- | :--- | :--- |
+| Network | Cilium policies, Hubble flows, service connectivity | Hubble, MCP network tools, flow baseline | `k3s/cilium-policies/`, network docs |
+| Agentic Ops | MCP tools, providers, capability reporting | MCP tool calls, gateway logs, provider health | `cmd/mcp-obs-hub/`, `internal/mcp/` |
+| Security | OpenBao config, service accounts, secrets posture, access controls | host logs, pod logs, security docs | `config/openbao/`, Kubernetes manifests |
+| Memory | ADRs, RCAs, plans, runbooks, workflow docs | docs search, linked incidents, commit history | `docs/`, `AGENTS.md` |
+
+## Operating Rules
+
+- Source-of-truth changes should go through Git, Tofu, or ArgoCD depending on the ownership plane.
+- Runtime fixes should be followed by a source-of-truth update when the fix changes intended state.
+- Incidents that reveal architecture or operating-model gaps should update ADRs, RCAs, or notes.
+- Ownership docs should stay high level; implementation details belong in service, workflow, or incident docs.

--- a/docs/architecture/services/mcp-servers.md
+++ b/docs/architecture/services/mcp-servers.md
@@ -59,6 +59,6 @@ The MCP gateway adheres to a consistent, consolidated architectural standard:
 | Interface | Protocol | Connectivity | Role |
 | :--- | :--- | :--- | :--- |
 | **Agent Inbound** | MCP (Stdio) | Local Process | Unified reasoning interface |
-| **Telemetry Outbound**| HTTP/gRPC | `localhost:<NodePort>` | Data tier access (Thanos/Loki/Tempo) |
+| **Telemetry Outbound**| HTTP/gRPC | `localhost:<NodePort>` | Data tier access (Prometheus/Loki/Tempo) |
 | **Cluster Outbound**| HTTPS | `K3s API` | Infrastructure state access |
 | **Self-Observability** | OTLP (gRPC) | `localhost:30317` | Telemetry pipeline (OTLP) |

--- a/docs/architecture/services/worker.md
+++ b/docs/architecture/services/worker.md
@@ -18,7 +18,7 @@ The worker operates in two primary modes, triggered via the `--mode` CLI flag:
 
 - **Mission**: Correlates infrastructure resource usage with platform outcomes so operators can reason about capacity, efficiency, and cost drivers from real telemetry.
 - **Sources**:
-  - **Thanos**: Retrieves energy (Kepler), Kubernetes, and host utilization metrics.
+  - **Prometheus**: Retrieves energy (Kepler), Kubernetes, and host utilization metrics.
   - **Tailscale**: Inspects Funnel and mesh connectivity status.
 - **Persistence**: Records high-fidelity resource samples into the PostgreSQL `analytics_metrics` table for trend analysis and operational reporting.
 - **Scheduling**: Every 15 minutes via Kubernetes `CronJob`.

--- a/docs/decisions/015-unified-host-telemetry-collectors.md
+++ b/docs/decisions/015-unified-host-telemetry-collectors.md
@@ -1,6 +1,8 @@
 # ADR 015: Unified Host Telemetry Analytics
 
 > **Note:** This service was originally named "Collectors" and was rebranded to **Analytics Engine** (or "Analytics Service") in March 2026 to better reflect its role in resource-to-value correlation and efficiency analysis.
+>
+> **2026-05 update:** The analytics metrics source moved from Thanos Query to direct Prometheus queries after MinIO/Thanos were retired from the active observability stack.
 
 - **Status:** Accepted
 - **Date:** 2026-02-21
@@ -22,7 +24,7 @@ Consolidate all host-level observability responsibilities into a single, re-arch
 
 ### Key Architectural Shifts
 
-- **Thanos-Centric Metrics:** Host metric collection (CPU, RAM, Disk, Network, Temperature) is now retrieved from **Prometheus** (exposed via Thanos Query). This leverages the unified API for both real-time and long-term storage (MinIO).
+- **Prometheus-Centric Metrics:** Host metric collection (CPU, RAM, Disk, Network, Temperature) is retrieved directly from **Prometheus**.
 - **Batch Processing Model:** Move from 1-minute continuous polling to a **15-minute batch interval** (as a starting point). The service wakes up every 15 minutes, performs a range query with `step=1m` to maintain granularity, and batch-inserts results into PostgreSQL.
 - **Unified Tailscale Collection:** Incorporate Tailscale status and log collection (via `exec.Command`) directly into the Go service, exposing them via OpenTelemetry and PostgreSQL.
 - **Resource Optimization:** Configure the new service with tight resource requests (10m CPU / 40Mi RAM), releasing significant guaranteed memory back to the cluster.
@@ -54,7 +56,7 @@ Consolidate all host-level observability responsibilities into a single, re-arch
 ### Negative
 
 - **Increased Development Effort**: Requires custom Go code for Tailscale and PromQL parsing rather than using off-the-shelf Alloy modules.
-- **Dependency on Thanos**: Resource analytics depends on the availability of the Thanos Query service.
+- **Dependency on Prometheus**: Resource analytics depends on the availability of the Prometheus service.
 
 ## Verification
 

--- a/docs/decisions/016-opentofu-k3s-migration.md
+++ b/docs/decisions/016-opentofu-k3s-migration.md
@@ -4,6 +4,8 @@
 - **Date:** 2026-02-25
 - **Author:** Victoria Cheng
 
+> **2026-05 update:** MinIO and Thanos were later retired from the active observability stack. OpenTofu remains the management path for cluster infrastructure, PostgreSQL Azure backup, and retained local storage.
+
 ## Context and Problem Statement
 
 Managing Kubernetes (K3s) Helm releases via `helm template → manifest.yaml → kubectl apply`
@@ -21,9 +23,9 @@ Terraform's HCL syntax and provider ecosystem.
 Adopt OpenTofu to declaratively manage all standard Helm-based Kubernetes services.
 Each service is defined as a `helm_release` resource referencing the existing
 `k3s/<service>/values.yaml`. Existing live releases are migrated via
-`tofu import` for zero-downtime adoption. MinIO serves as the S3-compatible
-state backend. Analytics is explicitly excluded due to its custom local image
-build and sideload workflow.
+`tofu import` for zero-downtime adoption. Azure Blob Storage serves as the
+remote state backend. Analytics is explicitly excluded due to its custom local
+image build and sideload workflow.
 
 ## Consequences
 

--- a/docs/decisions/017-agentic-interface-mcp.md
+++ b/docs/decisions/017-agentic-interface-mcp.md
@@ -4,6 +4,8 @@
 - **Date:** 2026-03-05
 - **Author:** Victoria Cheng
 
+> **2026-05 update:** The telemetry MCP path now queries Prometheus directly for metrics. The NodePort bridge remains, but the active telemetry backends are Prometheus, Loki, and Tempo.
+
 ## Context and Problem Statement
 
 As the Observability Hub matures, the volume of telemetry data (Logs, Metrics, Traces) has outpaced the efficiency of human-centric dashboarding. Resolving complex incidents requires an engineer to manually correlate data across multiple distinct interfaces (Grafana, Tempo, Prometheus).
@@ -25,7 +27,7 @@ Adopt the Model Context Protocol (MCP) to implement a **dedicated telemetry cont
 
 - **MCP-Telemetry (The Health Brain):** A dedicated MCP server acting as the primary professional artifact. It will provide intent-based tools (`query_metrics`, `query_logs`, `query_traces`, `investigate_incident`) that abstract the underlying LGTM stack.
 
-To enable low-latency, direct-to-pod communication for this host-based MCP server, the implementation standardizes on a **NodePort (`localhost`) bridging strategy** for the internal cluster monitoring services (Loki, Thanos, Tempo).
+To enable low-latency, direct-to-pod communication for this host-based MCP server, the implementation standardizes on a **NodePort (`localhost`) bridging strategy** for the internal cluster monitoring services (Prometheus, Loki, Tempo).
 
 ## Consequences
 
@@ -42,7 +44,7 @@ To enable low-latency, direct-to-pod communication for this host-based MCP serve
 
 ## Verification
 
-- [x] **Level 0 (Infrastructure):** Verified Loki, Thanos, and Tempo are accessible via NodePort on `localhost`.
+- [x] **Level 0 (Infrastructure):** Verified Prometheus, Loki, and Tempo are accessible via NodePort on `localhost`.
 - [x] **Level 1 (Metrics Intelligence):** Verified `mcp-telemetry` provides service health analysis and performance baselining tools.
 - [x] **Level 2 (Semantic Logging):** Verified `mcp-telemetry` can correlate unstructured events with system failures via semantic LogQL filtering.
 - [x] **Level 3 (Trace Correlation):** Verified `mcp-telemetry` can reason over distributed request paths and parent/child span relationships.

--- a/docs/notes/cilium-networking.md
+++ b/docs/notes/cilium-networking.md
@@ -55,7 +55,6 @@ The `observability-core` policy protects and enables shared platform traffic for
 - Loki
 - Tempo
 - Prometheus
-- Thanos
 - Kepler
 - kube-state-metrics
 - EMQX
@@ -132,7 +131,7 @@ Before tightening a policy:
 
 1. Document the expected traffic path first.
 2. Verify whether the flow is namespace-local, cross-namespace, or external.
-3. Confirm DNS, Kubernetes API, and storage dependencies.
+3. Confirm DNS, Kubernetes API, and database/retained-PVC dependencies.
 4. Apply the narrowest rule that preserves the known workflow.
 5. Watch Hubble for dropped flows immediately after rollout.
 
@@ -141,7 +140,7 @@ Minimum validation checklist:
 - Grafana can query Prometheus, Loki, and Tempo
 - n8n can reach Postgres and any required external APIs
 - ArgoCD can resolve DNS, reach the Kubernetes API, and sync repositories
-- Tempo, Loki, and Thanos can reach MinIO
+- Prometheus, Loki, and Tempo are healthy on retained local PVC storage
 
 ## What To Document Next
 

--- a/docs/notes/k3s-operations.md
+++ b/docs/notes/k3s-operations.md
@@ -27,11 +27,9 @@ helm repo update
 helm search repo grafana-community/grafana && \
 helm search repo grafana/loki && \
 helm search repo open-telemetry/opentelemetry-collector && \
-helm search repo minio/minio && \
 helm search repo cloudnative-pg/cloudnative-pg && \
 helm search repo prometheus-community/prometheus && \
-helm search repo grafana-community/tempo && \
-helm search repo bitnami/thanos
+helm search repo grafana-community/tempo
 ```
 
 #### Step 2: Update Configuration
@@ -69,7 +67,7 @@ tofu apply
 - **Notes**:
   - DaemonSet runs on every node for network policy enforcement
   - Opt-in policy mode: pods without policies allow all traffic
-  - L7 visibility enabled for: OTel, Loki, Tempo, Prometheus, MinIO, OpenTelemetry
+  - L7 visibility enabled for: OTel, Loki, Tempo, Prometheus, OpenTelemetry
   - Monitor via Hubble UI (`http://localhost:30080`) for traffic flows
 
 ### Grafana (Visualization)
@@ -84,22 +82,14 @@ tofu apply
 - **Tofu Configuration**: `tofu/telemetry.tf`
 - **Values**: `k3s/loki/values.yaml`
 - **Notes**:
-  - S3 credentials are injected from `minio-loki-secret` via environment variables
-  - Loki Helm values use `${MINIO_LOKI_ACCESS_KEY}` and `${MINIO_LOKI_SECRET_KEY}` placeholders
-  - Requires `-config.expand-env=true` flag (configured in `global.extraArgs`)
-  - Secret is injected via `global.extraEnvFrom` in values.yaml
+  - Uses filesystem-backed local PVC storage with `168h` retention.
+  - Persistence uses the `local-path-retain` storage class.
 
 ### OpenTelemetry (Collector)
 
 - **Chart**: `open-telemetry/opentelemetry-collector`
 - **Tofu Configuration**: `tofu/telemetry.tf`
 - **Values**: `k3s/opentelemetry/values.yaml`
-
-### MinIO (S3 Storage Backend)
-
-- **Chart**: `minio/minio`
-- **Tofu Configuration**: `tofu/databases.tf`
-- **Values**: `k3s/minio/values.yaml`
 
 ### HA PostgreSQL (CloudNativePG)
 
@@ -129,24 +119,17 @@ rm postgres-cnpg.tar
 - **Chart**: `prometheus-community/prometheus`
 - **Tofu Configuration**: `tofu/metrics.tf`
 - **Values**: `k3s/prometheus/values.yaml`
+- **Notes**:
+  - Uses local PVC storage with `72h` retention.
+  - MCP and Worker metrics queries use Prometheus directly.
 
 ### Grafana Tempo (Trace Store)
 
 - **Chart**: `grafana-community/tempo`
 - **Tofu Configuration**: `tofu/telemetry.tf`
 - **Values**: `k3s/tempo/values.yaml`
-
-### Thanos Store Gateway (Long-term Metrics Storage)
-
-- **Chart**: `bitnami/thanos`
-- **Tofu Configuration**: `tofu/metrics.tf`
-- **Values**: `k3s/thanos/values.yaml`
 - **Notes**:
-  - Uses official quay.io/thanos/thanos:v0.32.2 image (not bitnami variant)
-  - Requires existing secret: `minio-thanos-secret` (created via kubectl)
-  - Secret contains S3 credentials for MinIO `prometheus-blocks` bucket
-  - Store gateway only mode (querier, ruler, compactor, receive disabled)
-  - Reference: [bitnami/thanos Helm Chart](https://github.com/bitnami/charts/tree/main/bitnami/thanos)
+  - Uses filesystem-backed local PVC storage with `48h` retention.
 
 ## 🔌 Connectivity Bridge (MCP Era)
 
@@ -156,7 +139,7 @@ The platform utilizes **NodePort** to bridge host-based services (MCP agents, pr
 | :--- | :--- | :--- | :--- |
 | **Grafana** | HTTP | 30000 | `http://localhost:30000` |
 | **Loki (Gateway)** | HTTP | 30100 | `http://localhost:30100` |
-| **Thanos (Query)** | HTTP | 30090 | `http://localhost:30090` |
+| **Prometheus** | HTTP | 30091 | `http://localhost:30091` |
 | **Tempo** | HTTP | 30200 | `http://localhost:30200` |
 | **OTel Collector**| gRPC | 30317 | `localhost:30317` |
 | **PostgreSQL** | TCP | 30432 | `localhost:30432` |
@@ -177,14 +160,12 @@ The platform utilizes **NodePort** to bridge host-based services (MCP agents, pr
 | **grafana** | Medium | 50m | 256Mi | 200m | 512Mi | Visualization |
 | **kepler** | None | — | — | — | — | Power/Energy Monitoring (DaemonSet) |
 | **loki** | Standard | 100m | 512Mi | 500m | 1Gi | Log Storage |
-| **minio** | Large | 200m | 512Mi | 1000m | 2Gi | S3 Storage Backend |
 | **n8n** | Standard | 100m | 512Mi | 500m | 1Gi | Workflow Automation |
 | **opentelemetry** | Medium | 50m | 256Mi | 200m | 512Mi | Trace/Metric/Log Collector |
 | **postgres** | Standard | 100m | 512Mi | 500m | 1Gi | Relational Database (HA x3) |
 | **prometheus** | Large | 200m | 512Mi | 1000m | 2Gi | Metrics Storage |
 | **prometheus-node-exporter** | Small | 10m | 64Mi | 50m | 128Mi | Node Metrics Collector (DaemonSet) |
 | **tempo** | Standard | 100m | 512Mi | 500m | 1Gi | Trace Storage |
-| **thanos** | Medium | 100m | 256Mi | 200m | 512Mi | Long-term Metrics Storage |
 
 **Understanding Usage Totals:**
 

--- a/docs/notes/network-flow-baseline.md
+++ b/docs/notes/network-flow-baseline.md
@@ -73,16 +73,12 @@ If a path is required by application configuration but is broader in policy than
 | `hub/grafana` | `observability/tempo` | `3200/TCP` | Trace queries | Explicitly allowed by `hub-security` |
 | `hub/grafana` | `databases/postgres-hub-rw` | `5432/TCP` | PostgreSQL datasource | Explicitly allowed by `hub-security` |
 | `hub/n8n` | `databases/postgres-hub-rw` | `5432/TCP` | Workflow state and application DB | Explicitly allowed by `hub-security` |
-| `hub` workloads | `databases/minio` | `9000/TCP` | S3-style storage access if needed from hub apps | Broadly allowed by `hub-security`; app-level use should be confirmed |
 | `observability/opentelemetry` | `observability/tempo` | `4317/TCP` | OTLP trace export | Allowed by `observability-core` |
 | `observability/opentelemetry` | `observability/loki` | `3100/TCP` | Log export | Allowed by `observability-core` |
 | `observability/opentelemetry` | `observability/prometheus-server` | `80/TCP` service to `/api/v1/write` | Remote write for metrics | Reaches Prometheus service; validate whether port `80` is sufficiently represented in policy intent |
-| `observability/tempo` | `databases/minio` | `9000/TCP` | Trace block storage | Allowed across namespace boundary by `databases-core` |
 | `observability/tempo` | `observability/prometheus-server` | `80/TCP` service to `/api/v1/write` | Metrics generator remote write | Reaches Prometheus service; validate whether port `80` is sufficiently represented in policy intent |
-| `observability/loki` | `databases/minio` | `9000/TCP` | Log chunk and ruler object storage | Allowed across namespace boundary by `databases-core` |
-| `observability/prometheus + thanos-sidecar` | `databases/minio` | object store via Thanos config | Long-term metrics block storage | Allowed across namespace boundary by `databases-core` |
 | `argocd` components | `argocd` components | `80,443,6379,7000,8080,8081/TCP` | Internal control-plane communication | Explicitly allowed by `argocd-security` |
-| `databases` components | `databases` components | `5432,8000,9000,9001/TCP` | Postgres and MinIO internal flows | Explicitly allowed by `databases-core` |
+| `databases` components | `databases` components | `5432,8000/TCP` | Postgres replication and CNPG management flows | Explicitly allowed by `databases-core` |
 
 ## Platform Dependency Flows
 
@@ -115,14 +111,12 @@ These are intentionally exposed today and should be part of every validation pas
 | `hub/ollama` | `11434/TCP` | model endpoint | Allowed from `world` by `hub-security` |
 | `argocd/server` | `80/TCP`, `443/TCP`, `8080/TCP` | GitOps UI and API access | Allowed from `world` by `argocd-security` |
 | `databases/postgres` | `5432/TCP` | Database access | Currently allowed from broad entities by `databases-core`; review whether this should remain externally reachable |
-| `databases/minio` | `9000/TCP`, `9001/TCP` | S3 API and console | Currently allowed from broad entities by `databases-core`; review whether this should remain externally reachable |
 
 ## Gaps To Confirm
 
 These items should be verified against live traffic before any tightening work:
 
 - which exact external domains n8n needs
-- whether any hub workload besides Grafana and n8n needs MinIO access
 - whether any observability service-port dependencies remain documented by container port instead of service port
 - whether `hardware-sim` needs its own namespace policy and baseline entries
 

--- a/docs/notes/opentelemetry.md
+++ b/docs/notes/opentelemetry.md
@@ -86,7 +86,7 @@ To ensure dashboard compatibility across the entire fleet, all signals follow th
 **Traces:**
 
 - `worker.run`: Root Span for every execution.
-- `db.postgres.*`, `github.fetch`, `thanos.query`: Mode-specific child spans.
+- `db.postgres.*`, `github.fetch`, `prometheus.query`: Mode-specific child spans.
 
 **Logs:**
 

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -53,9 +53,9 @@
     <header class="py-12 md:py-16">
         <div class="w-[90%] max-w-4xl mx-auto">
             <nav class="flex flex-col md:flex-row items-center md:justify-between gap-8 md:gap-0 text-center md:text-left mb-12 border-b border-white/10 pb-4" aria-label="Main Navigation">
-                <a href="index.html" class="font-bold text-2xl text-white no-underline transition-colors hover:text-cyan-400">{{ .Landing.Header.ProjectName }}</a>
+                <a href="index.html" class="font-bold text-2xl text-white no-underline transition-colors hover:text-emerald-400">{{ .Landing.Header.ProjectName }}</a>
                 <ul class="flex gap-6">
-                    <li><a href="evolution.html" class="text-slate-300 font-medium no-underline transition-colors hover:text-cyan-400">Evolution</a></li>
+                    <li><a href="evolution.html" class="text-slate-300 font-medium no-underline transition-colors hover:text-emerald-400">Evolution</a></li>
                 </ul>
             </nav>
             {{block "header_extra" .}}{{end}}
@@ -70,10 +70,10 @@
         <div class="w-[90%] max-w-4xl mx-auto border-t border-white/10 pt-6 flex justify-center items-center gap-4 text-slate-300">
             <p>&copy; {{ .Year }} {{ .Landing.Footer.Author }}</p>
             <div class="flex gap-4 items-center">
-                <a href="{{ .Landing.Footer.GithubLink }}" target="_blank" rel="noopener noreferrer" class="text-slate-300 hover:text-cyan-400 transition-colors" aria-label="GitHub">
+                <a href="{{ .Landing.Footer.GithubLink }}" target="_blank" rel="noopener noreferrer" class="text-slate-300 hover:text-emerald-400 transition-colors" aria-label="GitHub">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
                 </a>
-                <a href="{{ .Landing.Footer.LinkedinLink }}" target="_blank" rel="noopener noreferrer" class="text-slate-300 hover:text-cyan-400 transition-colors" aria-label="LinkedIn">
+                <a href="{{ .Landing.Footer.LinkedinLink }}" target="_blank" rel="noopener noreferrer" class="text-slate-300 hover:text-emerald-400 transition-colors" aria-label="LinkedIn">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
                 </a>
             </div>

--- a/internal/web/templates/content/evolution.yaml
+++ b/internal/web/templates/content/evolution.yaml
@@ -162,7 +162,7 @@ chapters:
       - date: "2026-02-13"
         title: "Storage Scalability & Security Hardening"
         description: |
-          - Moved telemetry storage to S3-compatible object storage with MinIO for better durability.
+          - Validated object-storage-backed telemetry retention as a platform learning milestone.
           - Established a safer default baseline across the core platform services.
 
   - title: "Platform Maturity & Reusability"
@@ -188,8 +188,6 @@ chapters:
         artifacts:
           - name: "ADR 015: Unified Host Telemetry Analytics"
             url: "docs/decisions/015-unified-host-telemetry-collectors.md"
-          - name: "RCA 003: Thanos Discovery and Retention Failure"
-            url: "docs/incidents/003-thanos-discovery-and-retention-failure.md"
         description: |
           - Deployed a resource-efficient Analytics service, centralizing host-level data collection and optimizing processing with batch processing.
           - Retired Alloy and cut idle resource usage significantly while freeing reserved CPU and memory.
@@ -207,7 +205,7 @@ chapters:
             url: "docs/incidents/006-loki-gateway-dns-timeout.md"
         description: |
           - Moved OpenTelemetry, Grafana, Prometheus, and the supporting K3s observability stack to OpenTofu.
-          - Brought MinIO, Thanos, Loki, and Tempo into the same declarative infrastructure workflow.
+          - Brought logs, metrics, traces, and supporting storage into the same declarative infrastructure workflow.
           - Improved drift detection, persistent workload recovery, and cross-service telemetry discovery.
 
   - title: "The MCP Era"

--- a/internal/web/templates/evolution.html
+++ b/internal/web/templates/evolution.html
@@ -2,7 +2,7 @@
 
 {{define "header_extra"}}
 <div class="text-center grid gap-6">
-    <h1 class="text-3xl font-bold text-cyan-400">{{ .Evolution.PageTitle }}</h1>
+    <h1 class="text-3xl font-bold text-emerald-400">{{ .Evolution.PageTitle }}</h1>
     <p class="text-lg md:text-xl text-slate-300">{{ .Evolution.IntroText }}</p>
 </div>
 {{end}}
@@ -13,11 +13,11 @@
     {{ range $i, $c := .Evolution.Chapters }}
     {{ $isFirst := eq $i 0 }}
     <details
-        class="group bg-slate-800/40 rounded-xl border border-white/5 transition-all hover:border-cyan-400/30 overflow-hidden"
+        class="group bg-slate-800/40 rounded-xl border border-white/5 transition-all hover:border-emerald-400/30 overflow-hidden"
         {{ if $isFirst }}open{{ end }}>
         <summary class="p-6 cursor-pointer list-none flex flex-col gap-4 group-open:border-b group-open:border-white/5">
             <h2
-                class="text-xl md:text-2xl font-bold text-cyan-400 flex justify-between items-center w-full after:content-['→'] after:transition-transform group-open:after:rotate-90">
+                class="text-xl md:text-2xl font-bold text-emerald-400 flex justify-between items-center w-full after:content-['→'] after:transition-transform group-open:after:rotate-90">
                 Chapter {{ sub $total $i }}: {{ $c.Title }}
             </h2>
             <p class="italic text-slate-300 text-sm">{{ $c.Intro }}</p>
@@ -28,12 +28,12 @@
                 {{ range $c.Events }}
                 <li class="relative pl-12">
                     <time
-                        class="relative block font-bold text-cyan-400 text-sm mb-4 before:absolute before:-left-[39px] before:top-1/2 before:-translate-y-1/2 before:w-3 before:h-3 before:bg-cyan-400 before:rounded-full before:border-2 before:border-slate-900"
+                        class="relative block font-bold text-emerald-400 text-sm mb-4 before:absolute before:-left-[39px] before:top-1/2 before:-translate-y-1/2 before:w-3 before:h-3 before:bg-emerald-400 before:rounded-full before:border-2 before:border-slate-900"
                         datetime="{{ .Date }}">
                         {{ .FormattedDate }}
                     </time>
                     <article class="bg-slate-900/50 p-6 rounded-lg border border-white/5 flex flex-col gap-6">
-                        <h3 class="text-lg font-bold text-cyan-400">{{ .Title }}</h3>
+                        <h3 class="text-lg font-bold text-emerald-400">{{ .Title }}</h3>
                         <ul class="list-disc text-slate-100 grid gap-2 ml-4">
                             {{ range .DescriptionLines }}
                             <li class="pl-2 leading-relaxed">{{ . }}</li>
@@ -43,7 +43,7 @@
                         <div class="flex flex-col gap-3">
                             {{range .Artifacts}}
                             <a href="https://github.com/victoriacheng15/observability-hub/blob/main/{{ .URL }}"
-                                class="inline-flex items-center text-sm font-semibold px-3 py-1.5 bg-transparent text-cyan-400 border border-cyan-400/40 rounded-lg whitespace-nowrap transition-all hover:bg-cyan-400/5 active:scale-95 w-fit"
+                                class="inline-flex items-center text-sm font-semibold px-3 py-1.5 bg-transparent text-emerald-400 border border-emerald-400/40 rounded-lg whitespace-nowrap transition-all hover:bg-emerald-400/5 active:scale-95 w-fit"
                                 target="_blank" rel="noopener noreferrer">
                                 📄 {{ .Name }}
                             </a>

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -2,18 +2,18 @@
 
 {{define "header_extra"}}
 <div class="text-center grid gap-8" aria-label="{{ .Landing.Hero.Headline }}">
-    <h1 class="text-2xl md:text-3xl font-bold text-cyan-400">{{ .Landing.Hero.Headline }}</h1>
+    <h1 class="text-2xl md:text-3xl font-bold text-emerald-400">{{ .Landing.Hero.Headline }}</h1>
     <p class="text-lg md:text-xl text-slate-300">{{ .Landing.Hero.SubHeadline }}</p>
     <p class="text-slate-400 max-w-2xl mx-auto">{{ .Landing.Hero.BriefDescription }}</p>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-2xl mx-auto w-full px-4">
         <a href="{{ .Landing.Hero.CtaLink }}" target="_blank" rel="noopener noreferrer" 
-           class="flex items-center justify-center bg-cyan-400 text-slate-900 px-6 py-3 rounded-lg font-bold transition-all hover:opacity-90 active:scale-95 text-center shadow-lg shadow-cyan-400/10">
+           class="flex items-center justify-center bg-emerald-400 text-slate-900 px-6 py-3 rounded-lg font-bold transition-all hover:opacity-90 active:scale-95 text-center shadow-lg shadow-emerald-400/10">
            {{ .Landing.Hero.CtaText }}
         </a>
         
         {{if .Landing.Hero.SecondaryCtaText}}
         <a href="{{ .Landing.Hero.SecondaryCtaLink }}" 
-           class="flex items-center justify-center bg-slate-800 text-cyan-400 border border-cyan-400/30 px-6 py-3 rounded-lg font-bold transition-all hover:bg-slate-700 active:scale-95 text-center">
+           class="flex items-center justify-center bg-slate-800 text-emerald-400 border border-emerald-400/30 px-6 py-3 rounded-lg font-bold transition-all hover:bg-slate-700 active:scale-95 text-center">
            {{ .Landing.Hero.SecondaryCtaText }}
         </a>
         {{end}}
@@ -38,11 +38,11 @@
 {{define "content"}}
 <div class="grid gap-16">
     <section class="grid gap-6">
-        <h2 class="text-2xl font-bold text-white border-l-4 border-cyan-400 pl-4">{{ .Landing.WhatIs.Title }}</h2>
+        <h2 class="text-2xl font-bold text-white border-l-4 border-emerald-400 pl-4">{{ .Landing.WhatIs.Title }}</h2>
         <ul class="grid gap-4">
             {{range .Landing.WhatIs.Content}}
             <li class="flex gap-3 text-slate-300 leading-relaxed">
-                <span class="text-cyan-400">▹</span>
+                <span class="text-emerald-400">▹</span>
                 <span>{{ . }}</span>
             </li>
             {{end}}
@@ -50,14 +50,14 @@
     </section>
 
     <section class="grid gap-8" aria-label="Key Features">
-        <h2 class="text-2xl font-bold text-white border-l-4 border-cyan-400 pl-4">{{ .Landing.KeyFeatures.Title }}</h2>
+        <h2 class="text-2xl font-bold text-white border-l-4 border-emerald-400 pl-4">{{ .Landing.KeyFeatures.Title }}</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             {{range .Landing.KeyFeatures.Features}}
-            <article class="grid gap-4 bg-slate-800/40 p-8 rounded-xl border border-white/5 transition-all hover:-translate-y-1 hover:border-cyan-400/50">
-                <div class="text-3xl text-cyan-400" aria-hidden="true">
+            <article class="grid gap-4 bg-slate-800/40 p-8 rounded-xl border border-white/5 transition-all hover:-translate-y-1 hover:border-emerald-400/50">
+                <div class="text-3xl text-emerald-400" aria-hidden="true">
                      {{if eq .Icon "rocket"}}🚀{{else if eq .Icon "database"}}💾{{else if eq .Icon "chart-line"}}📈{{else if eq .Icon "layers-half"}}🧱{{else if eq .Icon "shield-check"}}🛡️{{else if eq .Icon "cpu"}}🖥️{{else}}✨{{end}}
                 </div>
-                <h3 class="text-xl font-bold text-cyan-400">{{ .Name }}</h3>
+                <h3 class="text-xl font-bold text-emerald-400">{{ .Name }}</h3>
                 <p class="text-slate-300 leading-relaxed">{{ .Description }}</p>
             </article>
             {{end}}
@@ -65,11 +65,11 @@
     </section>
 
     <section class="grid gap-6">
-        <h2 class="text-2xl font-bold text-white border-l-4 border-cyan-400 pl-4">{{ .Landing.WhyItMatters.Title }}</h2>
+        <h2 class="text-2xl font-bold text-white border-l-4 border-emerald-400 pl-4">{{ .Landing.WhyItMatters.Title }}</h2>
         <ul class="grid gap-4">
             {{range .Landing.WhyItMatters.Points}}
             <li class="flex gap-3 text-slate-300 leading-relaxed">
-                <span class="text-cyan-400">▹</span>
+                <span class="text-emerald-400">▹</span>
                 <span>{{ . }}</span>
             </li>
             {{end}}


### PR DESCRIPTION
### Summary

Update the documentation to match the simplified observability stack after retiring MinIO and Thanos. The active platform docs now describe local PVC retention for Prometheus, Loki, and Tempo, while keeping Azure scoped to PostgreSQL backup and OpenTofu state.

### List of Changes

- Replaced active MinIO/Thanos architecture references with the current Prometheus, Loki, Tempo, retained-PVC model.
- Updated MCP and Worker documentation so metrics paths use Prometheus directly.
- Cleaned network and k3s operations docs so operators are no longer pointed at removed MinIO or Thanos services.
- Simplified the ownership model into Control, Data, and Operations planes for easier routing.

### Verification

- [x] Confirmed active architecture and notes no longer reference MinIO, Thanos, removed ports, or removed MinIO secrets
- [x] Confirmed MCP documentation uses `PROMETHEUS_URL` and Prometheus NodePort `30091`
- [x] Reviewed the simplified ownership model for scanability
- [x] Confirmed `internal/web/templates/content/evolution.yaml` no longer references MinIO or Thanos
- [x] Parsed `internal/web/templates/content/evolution.yaml` as valid YAML
- [x] Confirmed no `cyan` classes remain under `internal/web/templates`

