### PR TITLE
refactor(idp): centralize Kubernetes client construction

### DIFF
--- a/internal/idp/catalog/catalog.go
+++ b/internal/idp/catalog/catalog.go
@@ -3,18 +3,16 @@ package catalog
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"time"
+
+	"observability-hub/internal/idp/kube"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type KubernetesCatalog struct {
@@ -41,23 +39,9 @@ type ListOptions struct {
 }
 
 func NewKubernetesCatalog() (*KubernetesCatalog, error) {
-	config, err := rest.InClusterConfig()
+	clientset, err := kube.NewClientset()
 	if err != nil {
-		kubeconfig := os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			home, _ := os.UserHomeDir()
-			kubeconfig = filepath.Join(home, ".kube", "config")
-		}
-
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("load kubeconfig: %w", err)
-		}
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("create kubernetes client: %w", err)
+		return nil, err
 	}
 
 	return NewKubernetesCatalogWithClientset(clientset), nil

--- a/internal/idp/cluster/cluster.go
+++ b/internal/idp/cluster/cluster.go
@@ -3,18 +3,16 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"time"
+
+	"observability-hub/internal/idp/kube"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type KubernetesCluster struct {
@@ -48,23 +46,9 @@ type WorkloadOptions struct {
 }
 
 func NewKubernetesCluster() (*KubernetesCluster, error) {
-	config, err := rest.InClusterConfig()
+	clientset, err := kube.NewClientset()
 	if err != nil {
-		kubeconfig := os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			home, _ := os.UserHomeDir()
-			kubeconfig = filepath.Join(home, ".kube", "config")
-		}
-
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("load kubeconfig: %w", err)
-		}
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("create kubernetes client: %w", err)
+		return nil, err
 	}
 
 	return NewKubernetesClusterWithClientset(clientset), nil

--- a/internal/idp/env/env.go
+++ b/internal/idp/env/env.go
@@ -3,17 +3,15 @@ package env
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"observability-hub/internal/idp/kube"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type KubernetesEnvironment struct {
@@ -46,23 +44,9 @@ type DescribeOptions struct {
 }
 
 func NewKubernetesEnvironment() (*KubernetesEnvironment, error) {
-	config, err := rest.InClusterConfig()
+	clientset, err := kube.NewClientset()
 	if err != nil {
-		kubeconfig := os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			home, _ := os.UserHomeDir()
-			kubeconfig = filepath.Join(home, ".kube", "config")
-		}
-
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("load kubeconfig: %w", err)
-		}
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("create kubernetes client: %w", err)
+		return nil, err
 	}
 
 	return NewKubernetesEnvironmentWithClientset(clientset), nil

--- a/internal/idp/kube/client.go
+++ b/internal/idp/kube/client.go
@@ -1,0 +1,34 @@
+package kube
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func NewClientset() (kubernetes.Interface, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := os.Getenv("KUBECONFIG")
+		if kubeconfig == "" {
+			home, _ := os.UserHomeDir()
+			kubeconfig = filepath.Join(home, ".kube", "config")
+		}
+
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("load kubeconfig: %w", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	return clientset, nil
+}

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -22,10 +21,9 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"observability-hub/internal/env"
+	"observability-hub/internal/idp/kube"
 )
 
 type KubernetesService struct {
@@ -162,23 +160,9 @@ type Ownership struct {
 func NewKubernetesService() (*KubernetesService, error) {
 	env.Load()
 
-	config, err := rest.InClusterConfig()
+	clientset, err := kube.NewClientset()
 	if err != nil {
-		kubeconfig := os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			home, _ := os.UserHomeDir()
-			kubeconfig = filepath.Join(home, ".kube", "config")
-		}
-
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("load kubeconfig: %w", err)
-		}
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("create kubernetes client: %w", err)
+		return nil, err
 	}
 
 	return NewKubernetesServiceWithClientset(clientset), nil


### PR DESCRIPTION
### Summary
This refactor centralizes Kubernetes client construction for the IDP packages. It keeps the existing in-cluster and kubeconfig fallback behavior intact while removing duplicated setup logic from the catalog, cluster, environment, and service domains.

### List of Changes
- Added a shared IDP Kubernetes client helper so authentication and kubeconfig fallback behavior live in one place.

### Verification
- [x] `go test ./internal/idp/...`

