### PR TITLE
refactor(idp): centralize age formatting

### DIFF
--- a/internal/idp/catalog/catalog.go
+++ b/internal/idp/catalog/catalog.go
@@ -218,19 +218,5 @@ func (c *KubernetesCatalog) cronJobEntry(cronJob batchv1.CronJob) Entry {
 }
 
 func (c *KubernetesCatalog) age(created time.Time) string {
-	if created.IsZero() {
-		return "unknown"
-	}
-
-	duration := c.now().Sub(created)
-	switch {
-	case duration < time.Minute:
-		return fmt.Sprintf("%ds", int(duration.Seconds()))
-	case duration < time.Hour:
-		return fmt.Sprintf("%dm", int(duration.Minutes()))
-	case duration < 24*time.Hour:
-		return fmt.Sprintf("%dh", int(duration.Hours()))
-	default:
-		return fmt.Sprintf("%dd", int(duration.Hours()/24))
-	}
+	return kube.Age(c.now(), created)
 }

--- a/internal/idp/cluster/cluster.go
+++ b/internal/idp/cluster/cluster.go
@@ -249,19 +249,5 @@ func (c *KubernetesCluster) cronJobWorkload(cronJob batchv1.CronJob) Workload {
 }
 
 func (c *KubernetesCluster) age(created time.Time) string {
-	if created.IsZero() {
-		return "unknown"
-	}
-
-	duration := c.now().Sub(created)
-	switch {
-	case duration < time.Minute:
-		return fmt.Sprintf("%ds", int(duration.Seconds()))
-	case duration < time.Hour:
-		return fmt.Sprintf("%dm", int(duration.Minutes()))
-	case duration < 24*time.Hour:
-		return fmt.Sprintf("%dh", int(duration.Hours()))
-	default:
-		return fmt.Sprintf("%dd", int(duration.Hours()/24))
-	}
+	return kube.Age(c.now(), created)
 }

--- a/internal/idp/env/env.go
+++ b/internal/idp/env/env.go
@@ -196,19 +196,5 @@ func sortedByteKeys(values map[string][]byte) []string {
 }
 
 func (e *KubernetesEnvironment) age(created time.Time) string {
-	if created.IsZero() {
-		return "unknown"
-	}
-
-	duration := e.now().Sub(created)
-	switch {
-	case duration < time.Minute:
-		return fmt.Sprintf("%ds", int(duration.Seconds()))
-	case duration < time.Hour:
-		return fmt.Sprintf("%dm", int(duration.Minutes()))
-	case duration < 24*time.Hour:
-		return fmt.Sprintf("%dh", int(duration.Hours()))
-	default:
-		return fmt.Sprintf("%dd", int(duration.Hours()/24))
-	}
+	return kube.Age(e.now(), created)
 }

--- a/internal/idp/kube/age.go
+++ b/internal/idp/kube/age.go
@@ -1,0 +1,24 @@
+package kube
+
+import (
+	"fmt"
+	"time"
+)
+
+func Age(now time.Time, created time.Time) string {
+	if created.IsZero() {
+		return "unknown"
+	}
+
+	duration := now.Sub(created)
+	switch {
+	case duration < time.Minute:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	case duration < time.Hour:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	case duration < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(duration.Hours()/24))
+	}
+}

--- a/internal/idp/kube/age_test.go
+++ b/internal/idp/kube/age_test.go
@@ -1,0 +1,50 @@
+package kube
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAge(t *testing.T) {
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		created time.Time
+		want    string
+	}{
+		{
+			name: "zero timestamp",
+			want: "unknown",
+		},
+		{
+			name:    "seconds below one minute",
+			created: now.Add(-30 * time.Second),
+			want:    "30s",
+		},
+		{
+			name:    "minutes below one hour",
+			created: now.Add(-45 * time.Minute),
+			want:    "45m",
+		},
+		{
+			name:    "hours below one day",
+			created: now.Add(-12 * time.Hour),
+			want:    "12h",
+		},
+		{
+			name:    "days after one day",
+			created: now.Add(-72 * time.Hour),
+			want:    "3d",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := Age(now, test.created)
+			if got != test.want {
+				t.Fatalf("Age() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/idp/service/service.go
+++ b/internal/idp/service/service.go
@@ -1242,19 +1242,5 @@ func readyRatioHealthy(ready string) bool {
 }
 
 func (s *KubernetesService) age(created time.Time) string {
-	if created.IsZero() {
-		return "unknown"
-	}
-
-	duration := s.now().Sub(created)
-	switch {
-	case duration < time.Minute:
-		return fmt.Sprintf("%ds", int(duration.Seconds()))
-	case duration < time.Hour:
-		return fmt.Sprintf("%dm", int(duration.Minutes()))
-	case duration < 24*time.Hour:
-		return fmt.Sprintf("%dh", int(duration.Hours()))
-	default:
-		return fmt.Sprintf("%dd", int(duration.Hours()/24))
-	}
+	return kube.Age(s.now(), created)
 }


### PR DESCRIPTION
### Summary
This refactor centralizes IDP age formatting behind a shared helper. It preserves the existing output behavior while removing duplicate formatting logic from the catalog, cluster, environment, and service domains.

### List of Changes
- Added a shared age formatting helper with focused boundary coverage for the existing output rules.
- Made workload and resource display behavior easier to keep consistent across IDP domains.

### Verification
- [x] `go test ./internal/idp/...`

