### PR TITLE
refactor(idp): extract workload projection helpers

### DIFF
--- a/internal/idp/catalog/catalog.go
+++ b/internal/idp/catalog/catalog.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"observability-hub/internal/idp/kube"
+	"observability-hub/internal/idp/workload"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -153,67 +154,62 @@ func (c *KubernetesCatalog) serviceEntry(service corev1.Service) Entry {
 }
 
 func (c *KubernetesCatalog) deploymentEntry(deployment appsv1.Deployment) Entry {
-	desired := int32(1)
-	if deployment.Spec.Replicas != nil {
-		desired = *deployment.Spec.Replicas
-	}
+	summary := workload.DeploymentSummary(deployment, c.now())
 
 	return Entry{
-		Name:      deployment.Name,
-		Namespace: deployment.Namespace,
-		Kind:      "Deployment",
-		Status:    fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
-		Age:       c.age(deployment.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Status:    summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCatalog) statefulSetEntry(statefulSet appsv1.StatefulSet) Entry {
-	desired := int32(1)
-	if statefulSet.Spec.Replicas != nil {
-		desired = *statefulSet.Spec.Replicas
-	}
+	summary := workload.StatefulSetSummary(statefulSet, c.now())
 
 	return Entry{
-		Name:      statefulSet.Name,
-		Namespace: statefulSet.Namespace,
-		Kind:      "StatefulSet",
-		Status:    fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
-		Age:       c.age(statefulSet.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Status:    summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCatalog) daemonSetEntry(daemonSet appsv1.DaemonSet) Entry {
+	summary := workload.DaemonSetSummary(daemonSet, c.now())
+
 	return Entry{
-		Name:      daemonSet.Name,
-		Namespace: daemonSet.Namespace,
-		Kind:      "DaemonSet",
-		Status:    fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
-		Age:       c.age(daemonSet.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Status:    summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCatalog) jobEntry(job batchv1.Job) Entry {
-	desired := int32(1)
-	if job.Spec.Completions != nil {
-		desired = *job.Spec.Completions
-	}
+	summary := workload.JobSummary(job, c.now())
 
 	return Entry{
-		Name:      job.Name,
-		Namespace: job.Namespace,
-		Kind:      "Job",
-		Status:    fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
-		Age:       c.age(job.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Status:    summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCatalog) cronJobEntry(cronJob batchv1.CronJob) Entry {
+	summary := workload.CronJobSummary(cronJob, c.now())
+
 	return Entry{
-		Name:      cronJob.Name,
-		Namespace: cronJob.Namespace,
-		Kind:      "CronJob",
-		Status:    fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
-		Age:       c.age(cronJob.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Status:    summary.Ready,
+		Age:       summary.Age,
 	}
 }
 

--- a/internal/idp/cluster/cluster.go
+++ b/internal/idp/cluster/cluster.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"observability-hub/internal/idp/kube"
+	"observability-hub/internal/idp/workload"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -184,67 +185,62 @@ func nodeReady(node corev1.Node) bool {
 }
 
 func (c *KubernetesCluster) deploymentWorkload(deployment appsv1.Deployment) Workload {
-	desired := int32(1)
-	if deployment.Spec.Replicas != nil {
-		desired = *deployment.Spec.Replicas
-	}
+	summary := workload.DeploymentSummary(deployment, c.now())
 
 	return Workload{
-		Name:      deployment.Name,
-		Namespace: deployment.Namespace,
-		Kind:      "Deployment",
-		Ready:     fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
-		Age:       c.age(deployment.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Ready:     summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCluster) statefulSetWorkload(statefulSet appsv1.StatefulSet) Workload {
-	desired := int32(1)
-	if statefulSet.Spec.Replicas != nil {
-		desired = *statefulSet.Spec.Replicas
-	}
+	summary := workload.StatefulSetSummary(statefulSet, c.now())
 
 	return Workload{
-		Name:      statefulSet.Name,
-		Namespace: statefulSet.Namespace,
-		Kind:      "StatefulSet",
-		Ready:     fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
-		Age:       c.age(statefulSet.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Ready:     summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCluster) daemonSetWorkload(daemonSet appsv1.DaemonSet) Workload {
+	summary := workload.DaemonSetSummary(daemonSet, c.now())
+
 	return Workload{
-		Name:      daemonSet.Name,
-		Namespace: daemonSet.Namespace,
-		Kind:      "DaemonSet",
-		Ready:     fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
-		Age:       c.age(daemonSet.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Ready:     summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCluster) jobWorkload(job batchv1.Job) Workload {
-	desired := int32(1)
-	if job.Spec.Completions != nil {
-		desired = *job.Spec.Completions
-	}
+	summary := workload.JobSummary(job, c.now())
 
 	return Workload{
-		Name:      job.Name,
-		Namespace: job.Namespace,
-		Kind:      "Job",
-		Ready:     fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
-		Age:       c.age(job.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Ready:     summary.Ready,
+		Age:       summary.Age,
 	}
 }
 
 func (c *KubernetesCluster) cronJobWorkload(cronJob batchv1.CronJob) Workload {
+	summary := workload.CronJobSummary(cronJob, c.now())
+
 	return Workload{
-		Name:      cronJob.Name,
-		Namespace: cronJob.Namespace,
-		Kind:      "CronJob",
-		Ready:     fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
-		Age:       c.age(cronJob.CreationTimestamp.Time),
+		Name:      summary.Name,
+		Namespace: summary.Namespace,
+		Kind:      summary.Kind,
+		Ready:     summary.Ready,
+		Age:       summary.Age,
 	}
 }
 

--- a/internal/idp/service/workloads.go
+++ b/internal/idp/service/workloads.go
@@ -3,12 +3,12 @@ package service
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
+
+	"observability-hub/internal/idp/workload"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -112,97 +112,38 @@ func (s *KubernetesService) workloads(ctx context.Context, namespace string) ([]
 }
 
 func (s *KubernetesService) deploymentDetails(deployment appsv1.Deployment) Details {
-	desired := int32(1)
-	if deployment.Spec.Replicas != nil {
-		desired = *deployment.Spec.Replicas
-	}
-
-	return Details{
-		Summary: Summary{
-			Name:      deployment.Name,
-			Namespace: deployment.Namespace,
-			Kind:      "Deployment",
-			Ready:     fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
-			Age:       s.age(deployment.CreationTimestamp.Time),
-		},
-		Images:      containerImages(deployment.Spec.Template.Spec),
-		Labels:      copyMap(deployment.Labels),
-		Annotations: copyMap(deployment.Annotations),
-		Selector:    deployment.Spec.Selector.MatchLabels,
-	}
+	return serviceDetails(workload.DeploymentDetails(deployment, s.now()))
 }
 
 func (s *KubernetesService) statefulSetDetails(statefulSet appsv1.StatefulSet) Details {
-	desired := int32(1)
-	if statefulSet.Spec.Replicas != nil {
-		desired = *statefulSet.Spec.Replicas
-	}
-
-	return Details{
-		Summary: Summary{
-			Name:      statefulSet.Name,
-			Namespace: statefulSet.Namespace,
-			Kind:      "StatefulSet",
-			Ready:     fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
-			Age:       s.age(statefulSet.CreationTimestamp.Time),
-		},
-		Images:      containerImages(statefulSet.Spec.Template.Spec),
-		Labels:      copyMap(statefulSet.Labels),
-		Annotations: copyMap(statefulSet.Annotations),
-		Selector:    statefulSet.Spec.Selector.MatchLabels,
-	}
+	return serviceDetails(workload.StatefulSetDetails(statefulSet, s.now()))
 }
 
 func (s *KubernetesService) daemonSetDetails(daemonSet appsv1.DaemonSet) Details {
-	return Details{
-		Summary: Summary{
-			Name:      daemonSet.Name,
-			Namespace: daemonSet.Namespace,
-			Kind:      "DaemonSet",
-			Ready:     fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
-			Age:       s.age(daemonSet.CreationTimestamp.Time),
-		},
-		Images:      containerImages(daemonSet.Spec.Template.Spec),
-		Labels:      copyMap(daemonSet.Labels),
-		Annotations: copyMap(daemonSet.Annotations),
-		Selector:    daemonSet.Spec.Selector.MatchLabels,
-	}
+	return serviceDetails(workload.DaemonSetDetails(daemonSet, s.now()))
 }
 
 func (s *KubernetesService) jobDetails(job batchv1.Job) Details {
-	desired := int32(1)
-	if job.Spec.Completions != nil {
-		desired = *job.Spec.Completions
-	}
-
-	return Details{
-		Summary: Summary{
-			Name:      job.Name,
-			Namespace: job.Namespace,
-			Kind:      "Job",
-			Ready:     fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
-			Age:       s.age(job.CreationTimestamp.Time),
-		},
-		Images:      containerImages(job.Spec.Template.Spec),
-		Labels:      copyMap(job.Labels),
-		Annotations: copyMap(job.Annotations),
-		Selector:    map[string]string{},
-	}
+	return serviceDetails(workload.JobDetails(job, s.now()))
 }
 
 func (s *KubernetesService) cronJobDetails(cronJob batchv1.CronJob) Details {
+	return serviceDetails(workload.CronJobDetails(cronJob, s.now()))
+}
+
+func serviceDetails(detail workload.Details) Details {
 	return Details{
 		Summary: Summary{
-			Name:      cronJob.Name,
-			Namespace: cronJob.Namespace,
-			Kind:      "CronJob",
-			Ready:     fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
-			Age:       s.age(cronJob.CreationTimestamp.Time),
+			Name:      detail.Name,
+			Namespace: detail.Namespace,
+			Kind:      detail.Kind,
+			Ready:     detail.Ready,
+			Age:       detail.Age,
 		},
-		Images:      containerImages(cronJob.Spec.JobTemplate.Spec.Template.Spec),
-		Labels:      copyMap(cronJob.Labels),
-		Annotations: copyMap(cronJob.Annotations),
-		Selector:    map[string]string{},
+		Images:      detail.Images,
+		Labels:      detail.Labels,
+		Annotations: detail.Annotations,
+		Selector:    detail.Selector,
 	}
 }
 
@@ -221,24 +162,4 @@ func serviceMatches(detail Details, name string) bool {
 	}
 
 	return false
-}
-
-func containerImages(spec corev1.PodSpec) []string {
-	images := make([]string, 0, len(spec.InitContainers)+len(spec.Containers))
-	for _, container := range spec.InitContainers {
-		images = append(images, container.Image)
-	}
-	for _, container := range spec.Containers {
-		images = append(images, container.Image)
-	}
-	sort.Strings(images)
-	return images
-}
-
-func copyMap(values map[string]string) map[string]string {
-	copied := make(map[string]string, len(values))
-	for key, value := range values {
-		copied[key] = value
-	}
-	return copied
 }

--- a/internal/idp/workload/workload.go
+++ b/internal/idp/workload/workload.go
@@ -1,0 +1,164 @@
+package workload
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"observability-hub/internal/idp/kube"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Summary struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Ready     string
+	Age       string
+}
+
+type Details struct {
+	Summary
+	Images      []string
+	Labels      map[string]string
+	Annotations map[string]string
+	Selector    map[string]string
+}
+
+func DeploymentSummary(deployment appsv1.Deployment, now time.Time) Summary {
+	desired := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desired = *deployment.Spec.Replicas
+	}
+
+	return Summary{
+		Name:      deployment.Name,
+		Namespace: deployment.Namespace,
+		Kind:      "Deployment",
+		Ready:     fmt.Sprintf("%d/%d", deployment.Status.ReadyReplicas, desired),
+		Age:       kube.Age(now, deployment.CreationTimestamp.Time),
+	}
+}
+
+func StatefulSetSummary(statefulSet appsv1.StatefulSet, now time.Time) Summary {
+	desired := int32(1)
+	if statefulSet.Spec.Replicas != nil {
+		desired = *statefulSet.Spec.Replicas
+	}
+
+	return Summary{
+		Name:      statefulSet.Name,
+		Namespace: statefulSet.Namespace,
+		Kind:      "StatefulSet",
+		Ready:     fmt.Sprintf("%d/%d", statefulSet.Status.ReadyReplicas, desired),
+		Age:       kube.Age(now, statefulSet.CreationTimestamp.Time),
+	}
+}
+
+func DaemonSetSummary(daemonSet appsv1.DaemonSet, now time.Time) Summary {
+	return Summary{
+		Name:      daemonSet.Name,
+		Namespace: daemonSet.Namespace,
+		Kind:      "DaemonSet",
+		Ready:     fmt.Sprintf("%d/%d", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled),
+		Age:       kube.Age(now, daemonSet.CreationTimestamp.Time),
+	}
+}
+
+func JobSummary(job batchv1.Job, now time.Time) Summary {
+	desired := int32(1)
+	if job.Spec.Completions != nil {
+		desired = *job.Spec.Completions
+	}
+
+	return Summary{
+		Name:      job.Name,
+		Namespace: job.Namespace,
+		Kind:      "Job",
+		Ready:     fmt.Sprintf("%d/%d", job.Status.Succeeded, desired),
+		Age:       kube.Age(now, job.CreationTimestamp.Time),
+	}
+}
+
+func CronJobSummary(cronJob batchv1.CronJob, now time.Time) Summary {
+	return Summary{
+		Name:      cronJob.Name,
+		Namespace: cronJob.Namespace,
+		Kind:      "CronJob",
+		Ready:     fmt.Sprintf("active:%d", len(cronJob.Status.Active)),
+		Age:       kube.Age(now, cronJob.CreationTimestamp.Time),
+	}
+}
+
+func DeploymentDetails(deployment appsv1.Deployment, now time.Time) Details {
+	return Details{
+		Summary:     DeploymentSummary(deployment, now),
+		Images:      containerImages(deployment.Spec.Template.Spec),
+		Labels:      copyMap(deployment.Labels),
+		Annotations: copyMap(deployment.Annotations),
+		Selector:    deployment.Spec.Selector.MatchLabels,
+	}
+}
+
+func StatefulSetDetails(statefulSet appsv1.StatefulSet, now time.Time) Details {
+	return Details{
+		Summary:     StatefulSetSummary(statefulSet, now),
+		Images:      containerImages(statefulSet.Spec.Template.Spec),
+		Labels:      copyMap(statefulSet.Labels),
+		Annotations: copyMap(statefulSet.Annotations),
+		Selector:    statefulSet.Spec.Selector.MatchLabels,
+	}
+}
+
+func DaemonSetDetails(daemonSet appsv1.DaemonSet, now time.Time) Details {
+	return Details{
+		Summary:     DaemonSetSummary(daemonSet, now),
+		Images:      containerImages(daemonSet.Spec.Template.Spec),
+		Labels:      copyMap(daemonSet.Labels),
+		Annotations: copyMap(daemonSet.Annotations),
+		Selector:    daemonSet.Spec.Selector.MatchLabels,
+	}
+}
+
+func JobDetails(job batchv1.Job, now time.Time) Details {
+	return Details{
+		Summary:     JobSummary(job, now),
+		Images:      containerImages(job.Spec.Template.Spec),
+		Labels:      copyMap(job.Labels),
+		Annotations: copyMap(job.Annotations),
+		Selector:    map[string]string{},
+	}
+}
+
+func CronJobDetails(cronJob batchv1.CronJob, now time.Time) Details {
+	return Details{
+		Summary:     CronJobSummary(cronJob, now),
+		Images:      containerImages(cronJob.Spec.JobTemplate.Spec.Template.Spec),
+		Labels:      copyMap(cronJob.Labels),
+		Annotations: copyMap(cronJob.Annotations),
+		Selector:    map[string]string{},
+	}
+}
+
+func containerImages(spec corev1.PodSpec) []string {
+	images := make([]string, 0, len(spec.InitContainers)+len(spec.Containers))
+	for _, container := range spec.InitContainers {
+		images = append(images, container.Image)
+	}
+	for _, container := range spec.Containers {
+		images = append(images, container.Image)
+	}
+	sort.Strings(images)
+	return images
+}
+
+func copyMap(values map[string]string) map[string]string {
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
+}


### PR DESCRIPTION
### Summary
This refactor centralizes IDP workload projection in a shared package. It preserves the existing workload status, metadata, image, and selector behavior while removing duplicate projection logic from catalog, cluster, and service code.

### List of Changes
- Added shared workload summary and detail projection helpers for supported Kubernetes workload types.
- Updated catalog, cluster, and service code to use the shared projection helpers without changing public structs or CLI behavior.

### Verification
- [x] `go test ./internal/idp/...`

